### PR TITLE
Update composer to Rector `0.14.7`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=8.1"
     },
     "require-dev": {
-        "rector/rector": "dev-main",
+        "rector/rector": "^0.14.7",
         "phpunit/phpunit": "^9.5",
         "phpstan/phpstan": "^1.8.2",
         "symplify/phpstan-rules": "^11.0",


### PR DESCRIPTION
This PR updates Rector to the latest `0.14.7` release.