### PR TITLE
Fix AddGenericReturnTypeToRelationsRector on Rector 0.15.2

### DIFF
--- a/src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php
+++ b/src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php
@@ -16,7 +16,6 @@ use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\ObjectType;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\ValueObject\Type\FullyQualifiedIdentifierTypeNode;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -101,10 +100,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
-        if (! $phpDocInfo instanceof PhpDocInfo) {
-            return null;
-        }
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
         // Return, if already has return type
         if ($node->getDocComment() !== null && $phpDocInfo->hasByName('return')) {


### PR DESCRIPTION
On Rector 0.15.2 the test failed to run for no-phpdoc.php.inc. This fix supports both 0.14.x and 0.15.x

It failed because of [this change](https://github.com/rectorphp/rector-src/commit/96c457badfd0c198a57a758c552ec82aee0049de#diff-d12d9867614cdc1cab5c7942a80cafabd78d8e027d227f9ba1bc8ffeb6643f61L70).