### PR TITLE
Support updating an existing return type with generics

### DIFF
--- a/src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php
+++ b/src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php
@@ -28,8 +28,7 @@ class AddGenericReturnTypeToRelationsRector extends AbstractRector
 {
     public function __construct(
         private readonly TypeComparator $typeComparator
-    )
-    {
+    ) {
     }
 
     public function getRuleDefinition(): RuleDefinition
@@ -117,7 +116,12 @@ CODE_SAMPLE
         // E.g. we only add generics to an existing return type, but don't change the type itself.
         if (
             $phpDocInfo->getReturnTagValue() !== null &&
-            !$this->typeComparator->arePhpParserAndPhpStanPhpDocTypesEqual($methodReturnType, $phpDocInfo->getReturnTagValue()->type, $node)
+            ! $this->typeComparator->arePhpParserAndPhpStanPhpDocTypesEqual(
+                $methodReturnType,
+                $phpDocInfo->getReturnTagValue()
+                    ->type,
+                $node
+            )
         ) {
             return null;
         }
@@ -150,12 +154,10 @@ CODE_SAMPLE
 
         // Update or add return tag
         if ($phpDocInfo->getReturnTagValue() !== null) {
-            $phpDocInfo->getReturnTagValue()->type = $genericTypeNode;
+            $phpDocInfo->getReturnTagValue()
+                ->type = $genericTypeNode;
         } else {
-            $phpDocInfo->addTagValueNode(new ReturnTagValueNode(
-                $genericTypeNode,
-                ''
-            ));
+            $phpDocInfo->addTagValueNode(new ReturnTagValueNode($genericTypeNode, ''));
         }
 
         return $node;

--- a/src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php
+++ b/src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php
@@ -116,8 +116,7 @@ CODE_SAMPLE
         // Don't update an existing return type if it differs from the native return type (thus the one without generics).
         // E.g. we only add generics to an existing return type, but don't change the type itself.
         if (
-            $node->getDocComment() !== null &&
-            $phpDocInfo->hasByName('return') &&
+            $phpDocInfo->getReturnTagValue() !== null &&
             !$this->typeComparator->arePhpParserAndPhpStanPhpDocTypesEqual($methodReturnType, $phpDocInfo->getReturnTagValue()->type, $node)
         ) {
             return null;
@@ -150,7 +149,7 @@ CODE_SAMPLE
         );
 
         // Update or add return tag
-        if ($phpDocInfo->hasByName('return')) {
+        if ($phpDocInfo->getReturnTagValue() !== null) {
             $phpDocInfo->getReturnTagValue()->type = $genericTypeNode;
         } else {
             $phpDocInfo->addTagValueNode(new ReturnTagValueNode(

--- a/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Fixture/phpdoc-with-supported-return.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Fixture/phpdoc-with-supported-return.php.inc
@@ -10,7 +10,7 @@ class Account extends Model {}
 class User extends Model
 {
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * @return HasMany
      */
     public function accounts(): HasMany
     {

--- a/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Fixture/phpdoc-with-supported-return.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Fixture/phpdoc-with-supported-return.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Account extends Model {}
+
+class User extends Model
+{
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function accounts(): HasMany
+    {
+        return $this->hasMany(Account::class);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Account extends Model {}
+
+class User extends Model
+{
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Fixture\Account>
+     */
+    public function accounts(): HasMany
+    {
+        return $this->hasMany(Account::class);
+    }
+}
+
+?>


### PR DESCRIPTION
Only supported if the existing PHPDoc return type is the same as the native return type. This way we ensure that we don't change types. 

Not updating of another type was already covered with a test. I added a test for the case when we can update the PHPDoc with only the generics.