### PR TITLE
Fix `check-active-classes` and re-enable code_analysis workflow

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -1,0 +1,15 @@
+name: Code Analysis
+
+on:
+    pull_request: null
+    push:
+        branches:
+            - main
+
+env:
+    # see https://github.com/composer/composer/issues/9368#issuecomment-718112361
+    COMPOSER_ROOT_VERSION: "dev-main"
+
+jobs:
+    code_analysis:
+        uses: rectorphp/reusable-workflows/.github/workflows/code_analysis.yaml@main

--- a/easy-ci.php
+++ b/easy-ci.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Symplify\EasyCI\Config\EasyCIConfig;
+
+return static function (EasyCIConfig $easyCIConfig): void {
+    $easyCIConfig->paths([__DIR__ . '/config', __DIR__ . '/src']);
+
+    $easyCIConfig->typesToSkip([
+        \Rector\Core\Contract\Rector\RectorInterface::class,
+    ]);
+};


### PR DESCRIPTION
As I find the code_analysis very important I researched the problem and found it. The problem lies in [this commit](https://github.com/rectorphp/reusable-workflows/commit/f2da03392acc3c7df6387862c384e7651b98bf3e) in the reusable-workflows repository. The fetching of a default easy-ci.php is removed. Thats why I grabbed the one from rector-doctrine. Did not have to change anything to our needings at all.