### PR TITLE
Fix code-style using `fix-cs` command

### DIFF
--- a/config/sets/laravel90.php
+++ b/config/sets/laravel90.php
@@ -65,7 +65,7 @@ return static function (RectorConfig $rectorConfig): void {
             0,
             'key',
         ),
-            new ArgumentAdder('Illuminate\Foundation\Http\FormRequest', 'validated', 1, 'default',),
+            new ArgumentAdder('Illuminate\Foundation\Http\FormRequest', 'validated', 1, 'default'),
         ]);
 
     // https://github.com/laravel/framework/commit/84c78b9f5f3dad58f92161069e6482f7267ffdb6


### PR DESCRIPTION
This way contributors don't get errors when using `composer run check-cs` locally.