### PR TITLE
Don't run Rector job inside forks

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -12,7 +12,7 @@ jobs:
 
     rector:
         # run only on PR's from branches on main repository (from core contributors), not on the forks or PR's from forks.
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.repository == 'driftingly/rector-laravel'
 
         # see https://github.com/rectorphp/reusable-workflows
         uses: rectorphp/reusable-workflows/.github/workflows/rector.yaml@main


### PR DESCRIPTION
With my previous change it ran inside my fork itself, thus in PR's from rene-bos/some-branch to rene-bos/main. We also don't want that offcourse 😉.