### PR TITLE
Support for rector 0.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ composer.lock
 .idea/
 
 .phpunit.result.cache
+.phpunit.cache
 
 # often customized locally - example on Github is just fine
 rector-recipe.php

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
     "description": "Rector upgrades rules for Laravel Framework",
     "require": {
         "php": ">=8.1",
-        "rector/rector": ">= 0.15.0 < 0.15.12"
+        "rector/rector": "^0.15.12"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^10.0",
         "phpstan/phpstan": "^1.8.2",
         "symplify/phpstan-rules": "^11.0",
         "symplify/phpstan-extensions": "^11.0",

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
     "license": "MIT",
     "description": "Rector upgrades rules for Laravel Framework",
     "require": {
-        "php": ">=8.1"
+        "php": ">=8.1",
+        "rector/rector": ">= 0.15.0 < 0.15.12"
     },
     "require-dev": {
-        "rector/rector": "^0.14.7",
         "phpunit/phpunit": "^9.5",
         "phpstan/phpstan": "^1.8.2",
         "symplify/phpstan-rules": "^11.0",

--- a/config/sets/laravel60.php
+++ b/config/sets/laravel60.php
@@ -12,7 +12,6 @@ use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\Rector\StaticCall\RenameStaticMethodRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\Renaming\ValueObject\RenameStaticMethod;
-use Rector\TypeDeclaration\Rector\FunctionLike\ParamTypeDeclarationRector;
 use Rector\Visibility\Rector\ClassMethod\ChangeMethodVisibilityRector;
 use Rector\Visibility\ValueObject\ChangeMethodVisibility;
 
@@ -22,16 +21,14 @@ use Rector\Visibility\ValueObject\ChangeMethodVisibility;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../config.php');
 
-    # https://github.com/laravel/framework/commit/67a38ba0fa2acfbd1f4af4bf7d462bb4419cc091
-    $rectorConfig->rule(ParamTypeDeclarationRector::class);
-
     $rectorConfig
-        ->ruleWithConfiguration(RenameMethodRector::class, [new MethodCallRename(
-            'Illuminate\Auth\Access\Gate',
-            # https://github.com/laravel/framework/commit/69de466ddc25966a0f6551f48acab1afa7bb9424
-            'access',
-            'inspect'
-        ),
+        ->ruleWithConfiguration(RenameMethodRector::class, [
+            new MethodCallRename(
+                'Illuminate\Auth\Access\Gate',
+                # https://github.com/laravel/framework/commit/69de466ddc25966a0f6551f48acab1afa7bb9424
+                'access',
+                'inspect'
+            ),
             new MethodCallRename(
                 'Illuminate\Support\Facades\Lang',
                 # https://github.com/laravel/framework/commit/efbe23c4116f86846ad6edc0d95cd56f4175a446
@@ -64,11 +61,12 @@ return static function (RectorConfig $rectorConfig): void {
         ]);
 
     $rectorConfig
-        ->ruleWithConfiguration(ChangeMethodVisibilityRector::class, [new ChangeMethodVisibility(
-            'Illuminate\Foundation\Http\FormRequest',
-            'validationData',
-            Visibility::PUBLIC
-        ),
+        ->ruleWithConfiguration(ChangeMethodVisibilityRector::class, [
+            new ChangeMethodVisibility(
+                'Illuminate\Foundation\Http\FormRequest',
+                'validationData',
+                Visibility::PUBLIC
+            ),
         ]);
 
     $rectorConfig

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
     bootstrap="vendor/autoload.php"
     colors="true"
+    executionOrder="defects"
+    cacheDirectory=".phpunit.cache"
 >
     <testsuites>
         <testsuite name="main">

--- a/src/Rector/ClassMethod/MigrateToSimplifiedAttributeRector.php
+++ b/src/Rector/ClassMethod/MigrateToSimplifiedAttributeRector.php
@@ -59,10 +59,7 @@ final class MigrateToSimplifiedAttributeRector extends AbstractRector
         }
 
         /** @var ClassLike $parentClass */
-        $parentClass = $this->betterNodeFinder->findParentType(
-            $node,
-            ClassLike::class
-        );
+        $parentClass = $this->betterNodeFinder->findParentType($node, ClassLike::class);
 
         // Skip if the new attribute name is already used
         foreach ($parentClass->getMethods() as $classMethod) {
@@ -83,9 +80,7 @@ final class MigrateToSimplifiedAttributeRector extends AbstractRector
         // So we generate the new method where the accessor
         // is placed on the model and remove the mutator,
         // so we don't run the refactoring twice
-        if ($accessor instanceof ClassMethod && $mutator instanceof ClassMethod && $this->isMutator(
-            $nodeName
-        )) {
+        if ($accessor instanceof ClassMethod && $mutator instanceof ClassMethod && $this->isMutator($nodeName)) {
             $this->removeNode($mutator);
             return null;
         }
@@ -327,9 +322,7 @@ CODE_SAMPLE
         );
 
         // Append the updated attributes assignment statements
-        $statements[] = new Return_(new Array_(
-            $attributesAssignmentStatements
-        ));
+        $statements[] = new Return_(new Array_($attributesAssignmentStatements));
 
         return $statements;
     }

--- a/tests/Rector/Assign/CallOnAppArrayAccessToStandaloneAssignRector/CallOnAppArrayAccessToStandaloneAssignRectorTest.php
+++ b/tests/Rector/Assign/CallOnAppArrayAccessToStandaloneAssignRector/CallOnAppArrayAccessToStandaloneAssignRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\Assign\CallOnAppArrayAccessToStandaloneAssignRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class CallOnAppArrayAccessToStandaloneAssignRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/ClassMethod/AddArgumentDefaultValueRector/AddArgumentDefaultValueRectorTest.php
+++ b/tests/Rector/ClassMethod/AddArgumentDefaultValueRector/AddArgumentDefaultValueRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\ClassMethod\AddArgumentDefaultValueRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class AddArgumentDefaultValueRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/ClassMethod/AddArgumentDefaultValueRector/config/configured_rule.php
+++ b/tests/Rector/ClassMethod/AddArgumentDefaultValueRector/config/configured_rule.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-
 use RectorLaravel\Rector\ClassMethod\AddArgumentDefaultValueRector;
 use RectorLaravel\ValueObject\AddArgumentDefaultValue;
 

--- a/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/AddGenericReturnTypeToRelationsRectorTest.php
+++ b/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/AddGenericReturnTypeToRelationsRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class AddGenericReturnTypeToRelationsRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/ClassMethod/AddParentBootToModelClassMethodRector/AddParentBootToModelClassMethodRectorTest.php
+++ b/tests/Rector/ClassMethod/AddParentBootToModelClassMethodRector/AddParentBootToModelClassMethodRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\ClassMethod\AddParentBootToModelClassMethodRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class AddParentBootToModelClassMethodRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/ClassMethod/AddParentRegisterToEventServiceProviderRector/AddParentRegisterToEventServiceProviderRectorTest.php
+++ b/tests/Rector/ClassMethod/AddParentRegisterToEventServiceProviderRector/AddParentRegisterToEventServiceProviderRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\ClassMethod\AddParentRegisterToEventServiceProviderRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class AddParentRegisterToEventServiceProviderRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/ClassMethod/MigrateToSimplifiedAttributeRector/MigrateToSimplifiedAttributeRectorTest.php
+++ b/tests/Rector/ClassMethod/MigrateToSimplifiedAttributeRector/MigrateToSimplifiedAttributeRectorTest.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\ClassMethod\MigrateToSimplifiedAttributeRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 class MigrateToSimplifiedAttributeRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
@@ -20,9 +19,9 @@ class MigrateToSimplifiedAttributeRectorTest extends AbstractRectorTestCase
     /**
      * @return Iterator<string>
      */
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/Class_/AddMockConsoleOutputFalseToConsoleTestsRector/AddMockConsoleOutputFalseToConsoleTestsRectorTest.php
+++ b/tests/Rector/Class_/AddMockConsoleOutputFalseToConsoleTestsRector/AddMockConsoleOutputFalseToConsoleTestsRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\Class_\AddMockConsoleOutputFalseToConsoleTestsRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class AddMockConsoleOutputFalseToConsoleTestsRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/Class_/AnonymousMigrationsRector/AnonymousMigrationsRectorTest.php
+++ b/tests/Rector/Class_/AnonymousMigrationsRector/AnonymousMigrationsRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\Class_\AnonymousMigrationsRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class AnonymousMigrationsRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/Class_/AnonymousMigrationsRector/Fixture/skip_abstract_migration.php.inc
+++ b/tests/Rector/Class_/AnonymousMigrationsRector/Fixture/skip_abstract_migration.php.inc
@@ -7,4 +7,4 @@ use Illuminate\Database\Migrations\Migration;
 abstract class AbstractMigration extends Migration
 {
     // ...
-};
+}

--- a/tests/Rector/Class_/PropertyDeferToDeferrableProviderToRector/PropertyDeferToDeferrableProviderToRectorTest.php
+++ b/tests/Rector/Class_/PropertyDeferToDeferrableProviderToRector/PropertyDeferToDeferrableProviderToRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\Class_\PropertyDeferToDeferrableProviderToRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class PropertyDeferToDeferrableProviderToRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/Class_/UnifyModelDatesWithCastsRector/UnifyModelDatesWithCastsRectorTest.php
+++ b/tests/Rector/Class_/UnifyModelDatesWithCastsRector/UnifyModelDatesWithCastsRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\Class_\UnifyModelDatesWithCastsRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class UnifyModelDatesWithCastsRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/FuncCall/FactoryFuncCallToStaticCallRector/FactoryFuncCallToStaticCallRectorTest.php
+++ b/tests/Rector/FuncCall/FactoryFuncCallToStaticCallRector/FactoryFuncCallToStaticCallRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\FuncCall\FactoryFuncCallToStaticCallRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class FactoryFuncCallToStaticCallRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/FuncCall/HelperFuncCallToFacadeClassRector/HelperFuncCallToFacadeClassRectorTest.php
+++ b/tests/Rector/FuncCall/HelperFuncCallToFacadeClassRector/HelperFuncCallToFacadeClassRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\FuncCall\HelperFuncCallToFacadeClassRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class HelperFuncCallToFacadeClassRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/FuncCall/RemoveDumpDataDeadCodeRector/RemoveDumpDataDeadCodeRectorTest.php
+++ b/tests/Rector/FuncCall/RemoveDumpDataDeadCodeRector/RemoveDumpDataDeadCodeRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\FuncCall\RemoveDumpDataDeadCodeRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class RemoveDumpDataDeadCodeRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/MethodCall/ChangeQueryWhereDateValueWithCarbonRector/ChangeQueryWhereDateValueWithCarbonRectorTest.php
+++ b/tests/Rector/MethodCall/ChangeQueryWhereDateValueWithCarbonRector/ChangeQueryWhereDateValueWithCarbonRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\MethodCall\ChangeQueryWhereDateValueWithCarbonRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class ChangeQueryWhereDateValueWithCarbonRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/MethodCall/FactoryApplyingStatesRector/FactoryApplyingStatesRectorTest.php
+++ b/tests/Rector/MethodCall/FactoryApplyingStatesRector/FactoryApplyingStatesRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\MethodCall\FactoryApplyingStatesRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class FactoryApplyingStatesRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/MethodCall/LumenRoutesStringActionToUsesArrayRector/LumenRoutesStringActionToUsesArrayRectorTest.php
+++ b/tests/Rector/MethodCall/LumenRoutesStringActionToUsesArrayRector/LumenRoutesStringActionToUsesArrayRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\MethodCall\LumenRoutesStringActionToUsesArrayRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class LumenRoutesStringActionToUsesArrayRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/MethodCall/LumenRoutesStringMiddlewareToArrayRector/LumenRoutesStringMiddlewareToArrayRectorTest.php
+++ b/tests/Rector/MethodCall/LumenRoutesStringMiddlewareToArrayRector/LumenRoutesStringMiddlewareToArrayRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\MethodCall\LumenRoutesStringMiddlewareToArrayRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class LumenRoutesStringMiddlewareToArrayRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/MethodCall/RedirectBackToBackHelperRector/RedirectBackToBackHelperRectorTest.php
+++ b/tests/Rector/MethodCall/RedirectBackToBackHelperRector/RedirectBackToBackHelperRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\MethodCall\RedirectBackToBackHelperRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class RedirectBackToBackHelperRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/MethodCall/RedirectRouteToToRouteHelperRector/RedirectRouteToToRouteHelperRectorTest.php
+++ b/tests/Rector/MethodCall/RedirectRouteToToRouteHelperRector/RedirectRouteToToRouteHelperRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\MethodCall\RedirectRouteToToRouteHelperRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class RedirectRouteToToRouteHelperRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/Namespace_/FactoryDefinitionRector/FactoryDefinitionRectorTest.php
+++ b/tests/Rector/Namespace_/FactoryDefinitionRector/FactoryDefinitionRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\Namespace_\FactoryDefinitionRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class FactoryDefinitionRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/New_/AddGuardToLoginEventRector/AddGuardToLoginEventRectorTest.php
+++ b/tests/Rector/New_/AddGuardToLoginEventRector/AddGuardToLoginEventRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\New_\AddGuardToLoginEventRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class AddGuardToLoginEventRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/PropertyFetch/OptionalToNullsafeOperatorRector/OptionalToNullsafeOperatorRectorTest.php
+++ b/tests/Rector/PropertyFetch/OptionalToNullsafeOperatorRector/OptionalToNullsafeOperatorRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\PropertyFetch\OptionalToNullsafeOperatorRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class OptionalToNullsafeOperatorRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/StaticCall/MinutesToSecondsInCacheRector/MinutesToSecondsInCacheRectorTest.php
+++ b/tests/Rector/StaticCall/MinutesToSecondsInCacheRector/MinutesToSecondsInCacheRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\StaticCall\MinutesToSecondsInCacheRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class MinutesToSecondsInCacheRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/StaticCall/Redirect301ToPermanentRedirectRector/Redirect301ToPermanentRedirectRectorTest.php
+++ b/tests/Rector/StaticCall/Redirect301ToPermanentRedirectRector/Redirect301ToPermanentRedirectRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\StaticCall\Redirect301ToPermanentRedirectRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class Redirect301ToPermanentRedirectRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/StaticCall/RequestStaticValidateToInjectRector/RequestStaticValidateToInjectRectorTest.php
+++ b/tests/Rector/StaticCall/RequestStaticValidateToInjectRector/RequestStaticValidateToInjectRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\StaticCall\RequestStaticValidateToInjectRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class RequestStaticValidateToInjectRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/StaticCall/RouteActionCallableRector/RouteActionCallableRectorTest.php
+++ b/tests/Rector/StaticCall/RouteActionCallableRector/RouteActionCallableRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class RouteActionCallableRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string


### PR DESCRIPTION
- Removed `ParamTypeDeclarationRector` from `laravel60` set
- Fixed `RequestStaticValidateToInjectRector` replacing calls to `ClassMethodManipulator@addMethodParameterIfMissing` which has been removed
- Upgraded to phpunit 10 to sync with rector 0.15.12 release (also set minimum required version of rector to 0.15.12 in `composer.json`)