### PR TITLE
Add ability to auto downgrade tag release

### DIFF
--- a/.github/workflows/downgraded_release.yaml
+++ b/.github/workflows/downgraded_release.yaml
@@ -1,0 +1,52 @@
+name: Downgraded Release
+
+# https://tomasvotruba.com/blog/how-to-release-php-81-and-72-package-in-the-same-repository/
+# https://github.com/TomasVotruba/cognitive-complexity/blob/main/.github/workflows/downgraded_release.yaml
+# https://github.com/symplify/config-transformer/blob/main/.github/workflows/downgraded_release.yaml
+
+on:
+    push:
+        tags:
+            - '*'
+
+jobs:
+    downgrade_release:
+        runs-on: ubuntu-latest
+
+        steps:
+            -
+                uses: "actions/checkout@v3"
+
+            -
+                uses: "shivammathur/setup-php@v2"
+                with:
+                    php-version: 8.1
+                    coverage: none
+
+            -   uses: "ramsey/composer-install@v2"
+
+            # downgrade /src to PHP 7.2
+            -   run: vendor/bin/rector process src --config build/rector-downgrade-php-72.php --ansi
+            -   run: vendor/bin/ecs check src --fix --ansi
+
+            # copy PHP 7.2 composer
+            -   run: cp build/composer-php-72.json composer.json
+
+            # clear the dev files
+            -   run: rm -rf build .github tests stubs easy-ci.php ecs.php phpstan.neon phpunit.xml
+
+            # setup git user
+            -
+                run: |
+                    git config user.email "action@github.com"
+                    git config user.name "GitHub Action"
+
+            # publish to the same repository with a new tag
+            -
+                name: "Tag Downgraded Code"
+                run: |
+                    git commit -a -m "release PHP 7.2 downgraded ${GITHUB_REF#refs/tags/}"
+
+                    # force push tag, so there is only 1 version
+                    git tag "${GITHUB_REF#refs/tags/}" --force
+                    git push origin "${GITHUB_REF#refs/tags/}" --force

--- a/build/composer-php-72.json
+++ b/build/composer-php-72.json
@@ -1,0 +1,29 @@
+{
+    "name": "driftingly/rector-laravel",
+    "type": "rector-extension",
+    "license": "MIT",
+    "description": "Rector upgrades rules for Laravel Framework",
+    "require": {
+        "php": "^7.2 || 8.0.*"
+    },
+    "autoload": {
+        "psr-4": {
+            "RectorLaravel\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "RectorLaravel\\Tests\\": "tests"
+        },
+        "classmap": ["stubs"]
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "cweagans/composer-patches": true,
+            "rector/extension-installer": true,
+            "phpstan/extension-installer": true
+        }
+    }
+}

--- a/build/composer-php-72.json
+++ b/build/composer-php-72.json
@@ -15,12 +15,5 @@
         "classmap": ["stubs"]
     },
     "minimum-stability": "dev",
-    "prefer-stable": true,
-    "config": {
-        "allow-plugins": {
-            "cweagans/composer-patches": true,
-            "rector/extension-installer": true,
-            "phpstan/extension-installer": true
-        }
-    }
+    "prefer-stable": true
 }

--- a/build/composer-php-72.json
+++ b/build/composer-php-72.json
@@ -12,9 +12,6 @@
         }
     },
     "autoload-dev": {
-        "psr-4": {
-            "RectorLaravel\\Tests\\": "tests"
-        },
         "classmap": ["stubs"]
     },
     "minimum-stability": "dev",

--- a/build/composer-php-72.json
+++ b/build/composer-php-72.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "description": "Rector upgrades rules for Laravel Framework",
     "require": {
-        "php": "^7.2 || 8.0.*"
+        "php": "^7.2 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/build/rector-downgrade-php-72.php
+++ b/build/rector-downgrade-php-72.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\DowngradeLevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([DowngradeLevelSetList::DOWN_TO_PHP_72]);
+};

--- a/src/Rector/StaticCall/RequestStaticValidateToInjectRector.php
+++ b/src/Rector/StaticCall/RequestStaticValidateToInjectRector.php
@@ -10,6 +10,8 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Type\ObjectType;
@@ -88,7 +90,7 @@ CODE_SAMPLE
 
         $requestParam = $this->addRequestParameterIfMissing($node, new ObjectType('Illuminate\Http\Request'));
 
-        if ($requestParam === null) {
+        if (! $requestParam instanceof Param) {
             return null;
         }
 
@@ -132,7 +134,7 @@ CODE_SAMPLE
         return ! $this->isName($node, 'request');
     }
 
-    private function addRequestParameterIfMissing(Node $node, ObjectType $objectType): ?Node\Param
+    private function addRequestParameterIfMissing(Node $node, ObjectType $objectType): ?Param
     {
         $classMethod = $this->betterNodeFinder->findParentType($node, ClassMethod::class);
 
@@ -148,9 +150,9 @@ CODE_SAMPLE
             return $paramNode;
         }
 
-        $classMethod->params[] = $paramNode = new Node\Param(new Variable(
+        $classMethod->params[] = $paramNode = new Param(new Variable(
             'request'
-        ), null, new Node\Name\FullyQualified($objectType->getClassName()));
+        ), null, new FullyQualified($objectType->getClassName()));
 
         return $paramNode;
     }


### PR DESCRIPTION
This PR adds the ability to downgrade the PHP version and tag a new release.

See: 

- https://tomasvotruba.com/blog/how-to-release-php-81-and-72-package-in-the-same-repository/
- https://github.com/TomasVotruba/cognitive-complexity/blob/main/.github/workflows/downgraded_release.yaml
- https://github.com/symplify/config-transformer/blob/main/.github/workflows/downgraded_release.yaml