### PR TITLE
Extract rule for Facade aliases in their own set

### DIFF
--- a/config/sets/laravel-code-quality.php
+++ b/config/sets/laravel-code-quality.php
@@ -4,47 +4,9 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 
-use Rector\Renaming\Rector\Name\RenameClassRector;
 use RectorLaravel\Rector\Assign\CallOnAppArrayAccessToStandaloneAssignRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../config.php');
     $rectorConfig->rule(CallOnAppArrayAccessToStandaloneAssignRector::class);
-    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
-        'App' => 'Illuminate\Support\Facades\App',
-        'Arr' => 'Illuminate\Support\Arr',
-        'Artisan' => 'Illuminate\Support\Facades\Artisan',
-        'Auth' => 'Illuminate\Support\Facades\Auth',
-        'Blade' => 'Illuminate\Support\Facades\Blade',
-        'Broadcast' => 'Illuminate\Support\Facades\Broadcast',
-        'Bus' => 'Illuminate\Support\Facades\Bus',
-        'Cache' => 'Illuminate\Support\Facades\Cache',
-        'Config' => 'Illuminate\Support\Facades\Config',
-        'Cookie' => 'Illuminate\Support\Facades\Cookie',
-        'Crypt' => 'Illuminate\Support\Facades\Crypt',
-        'DB' => 'Illuminate\Support\Facades\DB',
-        'Model' => 'Illuminate\Database\Eloquent\Model',
-        'Event' => 'Illuminate\Support\Facades\Event',
-        'File' => 'Illuminate\Support\Facades\File',
-        'Gate' => 'Illuminate\Support\Facades\Gate',
-        'Hash' => 'Illuminate\Support\Facades\Hash',
-        'Lang' => 'Illuminate\Support\Facades\Lang',
-        'Log' => 'Illuminate\Support\Facades\Log',
-        'Mail' => 'Illuminate\Support\Facades\Mail',
-        'Notification' => 'Illuminate\Support\Facades\Notification',
-        'Password' => 'Illuminate\Support\Facades\Password',
-        'Queue' => 'Illuminate\Support\Facades\Queue',
-        'Redirect' => 'Illuminate\Support\Facades\Redirect',
-        'Redis' => 'Illuminate\Support\Facades\Redis',
-        'Request' => 'Illuminate\Support\Facades\Request',
-        'Response' => 'Illuminate\Support\Facades\Response',
-        'Route' => 'Illuminate\Support\Facades\Route',
-        'Schema' => 'Illuminate\Support\Facades\Schema',
-        'Session' => 'Illuminate\Support\Facades\Session',
-        'Storage' => 'Illuminate\Support\Facades\Storage',
-        'Str' => 'Illuminate\Support\Str',
-        'URL' => 'Illuminate\Support\Facades\URL',
-        'Validator' => 'Illuminate\Support\Facades\Validator',
-        'View' => 'Illuminate\Support\Facades\View',
-    ]);
 };

--- a/config/sets/laravel-facade-aliases-to-full-names.php
+++ b/config/sets/laravel-facade-aliases-to-full-names.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+use Rector\Renaming\Rector\Name\RenameClassRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../config.php');
+
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'App' => 'Illuminate\Support\Facades\App',
+        'Arr' => 'Illuminate\Support\Arr',
+        'Artisan' => 'Illuminate\Support\Facades\Artisan',
+        'Auth' => 'Illuminate\Support\Facades\Auth',
+        'Blade' => 'Illuminate\Support\Facades\Blade',
+        'Broadcast' => 'Illuminate\Support\Facades\Broadcast',
+        'Bus' => 'Illuminate\Support\Facades\Bus',
+        'Cache' => 'Illuminate\Support\Facades\Cache',
+        'Config' => 'Illuminate\Support\Facades\Config',
+        'Cookie' => 'Illuminate\Support\Facades\Cookie',
+        'Crypt' => 'Illuminate\Support\Facades\Crypt',
+        'DB' => 'Illuminate\Support\Facades\DB',
+        'Model' => 'Illuminate\Database\Eloquent\Model',
+        'Event' => 'Illuminate\Support\Facades\Event',
+        'File' => 'Illuminate\Support\Facades\File',
+        'Gate' => 'Illuminate\Support\Facades\Gate',
+        'Hash' => 'Illuminate\Support\Facades\Hash',
+        'Lang' => 'Illuminate\Support\Facades\Lang',
+        'Log' => 'Illuminate\Support\Facades\Log',
+        'Mail' => 'Illuminate\Support\Facades\Mail',
+        'Notification' => 'Illuminate\Support\Facades\Notification',
+        'Password' => 'Illuminate\Support\Facades\Password',
+        'Queue' => 'Illuminate\Support\Facades\Queue',
+        'Redirect' => 'Illuminate\Support\Facades\Redirect',
+        'Redis' => 'Illuminate\Support\Facades\Redis',
+        'Request' => 'Illuminate\Support\Facades\Request',
+        'Response' => 'Illuminate\Support\Facades\Response',
+        'Route' => 'Illuminate\Support\Facades\Route',
+        'Schema' => 'Illuminate\Support\Facades\Schema',
+        'Session' => 'Illuminate\Support\Facades\Session',
+        'Storage' => 'Illuminate\Support\Facades\Storage',
+        'Str' => 'Illuminate\Support\Str',
+        'URL' => 'Illuminate\Support\Facades\URL',
+        'Validator' => 'Illuminate\Support\Facades\Validator',
+        'View' => 'Illuminate\Support\Facades\View',
+    ]);
+};

--- a/src/Set/LaravelSetList.php
+++ b/src/Set/LaravelSetList.php
@@ -102,4 +102,9 @@ final class LaravelSetList implements SetListInterface
      * @var string
      */
     final public const LARAVEL_LEGACY_FACTORIES_TO_CLASSES = __DIR__ . '/../../config/sets/laravel-legacy-factories-to-classes.php';
+
+    /**
+     * @var string
+     */
+    final public const LARAVEL_FACADE_ALIASES_TO_FULL_NAMES = __DIR__ . '/../../config/sets/laravel-facade-aliases-to-full-names.php';
 }


### PR DESCRIPTION
For cases when you want to skip this refactoring (Change Facade aliases into full facade names), like in this issue https://github.com/driftingly/rector-laravel/issues/95, you have to opt out of the Code Style set entirely.

This PR extracts that refactoring into a set of its own, so we can use it only if we need it.