### PR TITLE
Route callable improvement

### DIFF
--- a/src/Rector/StaticCall/RouteActionCallableRector.php
+++ b/src/Rector/StaticCall/RouteActionCallableRector.php
@@ -223,7 +223,7 @@ CODE_SAMPLE
             $keys = array_keys($action);
             sort($keys);
 
-            return in_array('uses', $keys, true) && empty(array_diff($keys, ['as', 'middleware', 'uses']));
+            return in_array('uses', $keys, true) && array_diff($keys, ['as', 'middleware', 'uses']) === [];
         }
 
         return str_contains($action, '@');

--- a/tests/Rector/StaticCall/RouteActionCallableRector/Fixture/named_route_with_middleware.php.inc
+++ b/tests/Rector/StaticCall/RouteActionCallableRector/Fixture/named_route_with_middleware.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Fixture;
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/users', ['as' => 'users.index', 'middleware' => 'auth', 'uses' => 'SomeController@index']);
+Route::get('/users', ['as' => 'users.index', 'uses' => 'SomeController@index', 'middleware' => 'auth']);
+Route::get('/users', ['uses' => 'SomeController@index', 'middleware' => 'auth', 'as' => 'users.index']);
+Route::get('/users', ['uses' => 'SomeController@index', 'as' => 'users.index', 'middleware' => 'auth']);
+Route::get('/users', ['middleware' => 'auth', 'as' => 'users.index', 'uses' => 'SomeController@index']);
+Route::get('/users', ['middleware' => 'auth', 'uses' => 'SomeController@index', 'as' => 'users.index']);
+Route::get('/users', ['as' => 'users.index', 'middleware' => ['auth', 'throttle:20,1'], 'uses' => 'SomeController@index']);
+Route::get('/users', ['as' => 'users.index', 'uses' => 'SomeController@index', 'middleware' => ['auth', 'throttle:20,1']]);
+Route::get('/users', ['uses' => 'SomeController@index', 'as' => 'users.index', 'middleware' => ['auth', 'throttle:20,1']]);
+Route::get('/users', ['uses' => 'SomeController@index', 'middleware' => ['auth', 'throttle:20,1'], 'as' => 'users.index']);
+Route::get('/users', ['middleware' => ['auth', 'throttle:20,1'], 'uses' => 'SomeController@index', 'as' => 'users.index']);
+Route::get('/users', ['middleware' => ['auth', 'throttle:20,1'], 'as' => 'users.index', 'uses' => 'SomeController@index']);
+
+?>
+    -----
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Fixture;
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/users', [\RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index'])->name('users.index')->middleware('auth');
+Route::get('/users', [\RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index'])->name('users.index')->middleware('auth');
+Route::get('/users', [\RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index'])->name('users.index')->middleware('auth');
+Route::get('/users', [\RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index'])->name('users.index')->middleware('auth');
+Route::get('/users', [\RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index'])->name('users.index')->middleware('auth');
+Route::get('/users', [\RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index'])->name('users.index')->middleware('auth');
+Route::get('/users', [\RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index'])->name('users.index')->middleware(['auth', 'throttle:20,1']);
+Route::get('/users', [\RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index'])->name('users.index')->middleware(['auth', 'throttle:20,1']);
+Route::get('/users', [\RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index'])->name('users.index')->middleware(['auth', 'throttle:20,1']);
+Route::get('/users', [\RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index'])->name('users.index')->middleware(['auth', 'throttle:20,1']);
+Route::get('/users', [\RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index'])->name('users.index')->middleware(['auth', 'throttle:20,1']);
+Route::get('/users', [\RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index'])->name('users.index')->middleware(['auth', 'throttle:20,1']);
+
+?>

--- a/tests/Rector/StaticCall/RouteActionCallableRector/Fixture/named_route_with_middleware.php.inc
+++ b/tests/Rector/StaticCall/RouteActionCallableRector/Fixture/named_route_with_middleware.php.inc
@@ -18,7 +18,7 @@ Route::get('/users', ['middleware' => ['auth', 'throttle:20,1'], 'uses' => 'Some
 Route::get('/users', ['middleware' => ['auth', 'throttle:20,1'], 'as' => 'users.index', 'uses' => 'SomeController@index']);
 
 ?>
-    -----
+-----
 <?php
 
 namespace RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Fixture;

--- a/tests/Rector/StaticCall/RouteActionCallableRector/Fixture/only_array_route.php.inc
+++ b/tests/Rector/StaticCall/RouteActionCallableRector/Fixture/only_array_route.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Fixture;
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/users', ['uses' => 'SomeController@index']);
+Route::get('/users', ['uses' => 'SomeController@index']);
+
+?>
+    -----
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Fixture;
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/users', [\RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index']);
+Route::get('/users', [\RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index']);
+
+?>

--- a/tests/Rector/StaticCall/RouteActionCallableRector/Fixture/only_array_route.php.inc
+++ b/tests/Rector/StaticCall/RouteActionCallableRector/Fixture/only_array_route.php.inc
@@ -8,7 +8,7 @@ Route::get('/users', ['uses' => 'SomeController@index']);
 Route::get('/users', ['uses' => 'SomeController@index']);
 
 ?>
-    -----
+-----
 <?php
 
 namespace RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Fixture;

--- a/tests/Rector/StaticCall/RouteActionCallableRector/Fixture/route_with_middleware.php.inc
+++ b/tests/Rector/StaticCall/RouteActionCallableRector/Fixture/route_with_middleware.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Fixture;
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/users', ['middleware' => 'auth', 'uses' => 'SomeController@index']);
+Route::get('/users', ['uses' => 'SomeController@index', 'middleware' => 'auth']);
+Route::get('/users', ['middleware' => ['auth', 'throttle:20,1'], 'uses' => 'SomeController@index']);
+Route::get('/users', ['uses' => 'SomeController@index', 'middleware' => ['auth', 'throttle:20,1']]);
+
+?>
+    -----
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Fixture;
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/users', [\RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index'])->middleware('auth');
+Route::get('/users', [\RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index'])->middleware('auth');
+Route::get('/users', [\RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index'])->middleware(['auth', 'throttle:20,1']);
+Route::get('/users', [\RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index'])->middleware(['auth', 'throttle:20,1']);
+
+?>

--- a/tests/Rector/StaticCall/RouteActionCallableRector/Fixture/route_with_middleware.php.inc
+++ b/tests/Rector/StaticCall/RouteActionCallableRector/Fixture/route_with_middleware.php.inc
@@ -10,7 +10,7 @@ Route::get('/users', ['middleware' => ['auth', 'throttle:20,1'], 'uses' => 'Some
 Route::get('/users', ['uses' => 'SomeController@index', 'middleware' => ['auth', 'throttle:20,1']]);
 
 ?>
-    -----
+-----
 <?php
 
 namespace RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Fixture;


### PR DESCRIPTION
Allows refactoring of routes using the array with `uses` as a single key and arrays that outside of the `name` key are using `middleware` one. 