### PR TITLE
Empty() to Blank() or Filled() refactor rule

### DIFF
--- a/src/Rector/Empty_/EmptyToBlankAndFilledFuncRector.php
+++ b/src/Rector/Empty_/EmptyToBlankAndFilledFuncRector.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace RectorLaravel\Rector\Empty_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\Empty_;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class EmptyToBlankAndFilledFuncRector extends AbstractRector
+{
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Replace use of the unsafe empty() function with Laravel\'s safer blank() & filled() functions.', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+empty([]);
+!empty([]);
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+blank([]);
+filled([]);
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Empty_::class, BooleanNot::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if ($node instanceof BooleanNot) {
+            if (! $node->expr instanceof Empty_) {
+                return null;
+            }
+            $method = 'filled';
+            $args = [$node->expr->expr];
+        } else {
+            $method = 'blank';
+            $args = [$node->expr];
+        }
+
+        return $this->nodeFactory->createFuncCall($method, $args);
+    }
+}

--- a/src/Rector/Empty_/EmptyToBlankAndFilledFuncRector.php
+++ b/src/Rector/Empty_/EmptyToBlankAndFilledFuncRector.php
@@ -9,6 +9,9 @@ use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
+/**
+ * @see \RectorLaravel\Tests\Rector\Empty_\EmptyToBlankAndFilledFuncRector\EmptyToBlankAndFilledFuncRectorTest
+ */
 class EmptyToBlankAndFilledFuncRector extends AbstractRector
 {
 
@@ -42,9 +45,11 @@ CODE_SAMPLE
             }
             $method = 'filled';
             $args = [$node->expr->expr];
-        } else {
+        } else if ($node instanceof Empty_) {
             $method = 'blank';
             $args = [$node->expr];
+        } else {
+            return null;
         }
 
         return $this->nodeFactory->createFuncCall($method, $args);

--- a/tests/Rector/Empty_/EmptyToBlankAndFilledFuncRector/EmptyToBlankAndFilledFuncRectorTest.php
+++ b/tests/Rector/Empty_/EmptyToBlankAndFilledFuncRector/EmptyToBlankAndFilledFuncRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\Empty_\EmptyToBlankAndFilledFuncRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class EmptyToBlankAndFilledFuncRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Empty_/EmptyToBlankAndFilledFuncRector/Fixture/fixture_with_empty.php.inc
+++ b/tests/Rector/Empty_/EmptyToBlankAndFilledFuncRector/Fixture/fixture_with_empty.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Empty_\EmptyToBlankAndFilledFuncRector\Fixture;
+
+empty('');
+empty('   ');
+empty(null);
+empty(true);
+empty([]);
+empty(0);
+empty(true);
+empty(false);
+empty(collect());
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Empty_\EmptyToBlankAndFilledFuncRector\Fixture;
+
+blank('');
+blank('   ');
+blank(null);
+blank(true);
+blank([]);
+blank(0);
+blank(true);
+blank(false);
+blank(collect());
+
+?>

--- a/tests/Rector/Empty_/EmptyToBlankAndFilledFuncRector/Fixture/fixture_with_not_empty.php.inc
+++ b/tests/Rector/Empty_/EmptyToBlankAndFilledFuncRector/Fixture/fixture_with_not_empty.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Empty_\EmptyToBlankAndFilledFuncRector\Fixture;
+
+!empty('');
+!empty('   ');
+!empty(null);
+!empty(true);
+!empty([]);
+!empty(0);
+!empty(true);
+!empty(false);
+!empty(collect());
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Empty_\EmptyToBlankAndFilledFuncRector\Fixture;
+
+filled('');
+filled('   ');
+filled(null);
+filled(true);
+filled([]);
+filled(0);
+filled(true);
+filled(false);
+filled(collect());
+
+?>

--- a/tests/Rector/Empty_/EmptyToBlankAndFilledFuncRector/config/configured_rule.php
+++ b/tests/Rector/Empty_/EmptyToBlankAndFilledFuncRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Empty_\EmptyToBlankAndFilledFuncRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(EmptyToBlankAndFilledFuncRector::class);
+};


### PR DESCRIPTION
# Changes

* Adds the `RectorLaravel\Rector\Empty_\EmptyToBlankAndFilledFuncRector` rule
* Adds a test for the rule.

# Why
In the Laravel framework, there are two helpers, [blank()](https://laravel.com/docs/10.x/helpers#method-blank) and [filled()](https://laravel.com/docs/10.x/helpers#method-filled), which are better replacements for PHP's built-in `empty()` construct, as it has some odd behaviours.
