### PR TITLE
Adds Gone, InternalServerError & ServiceUnavailable statuses to AssertStatusToAssertMethodRector

### DIFF
--- a/src/Rector/MethodCall/AssertStatusToAssertMethodRector.php
+++ b/src/Rector/MethodCall/AssertStatusToAssertMethodRector.php
@@ -165,7 +165,10 @@ CODE_SAMPLE
                 401 => 'assertUnauthorized',
                 403 => 'assertForbidden',
                 404 => 'assertNotFound',
+                410 => 'assertGone',
                 422 => 'assertUnprocessable',
+                500 => 'assertInternalServerError',
+                503 => 'assertServiceUnavailable',
                 default => null
             };
         } else {
@@ -182,7 +185,10 @@ CODE_SAMPLE
                 'HTTP_UNAUTHORIZED' => 'assertUnauthorized',
                 'HTTP_FORBIDDEN' => 'assertForbidden',
                 'HTTP_NOT_FOUND' => 'assertNotFound',
+                'HTTP_GONE' => 'assertGone',
                 'HTTP_UNPROCESSABLE_ENTITY' => 'assertUnprocessable',
+                'HTTP_INTERNAL_SERVER_ERROR' => 'assertInternalServerError',
+                'HTTP_SERVICE_UNAVAILABLE' => 'assertServiceUnavailable',
                 default => null
             };
         }

--- a/src/Rector/MethodCall/AssertStatusToAssertMethodRector.php
+++ b/src/Rector/MethodCall/AssertStatusToAssertMethodRector.php
@@ -67,6 +67,27 @@ class ExampleTest extends \Illuminate\Foundation\Testing\TestCase
         $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY);
     }
+
+    public function testGone()
+    {
+        $this->get('/')->assertStatus(410);
+        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_GONE);
+        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_GONE);
+    }
+
+    public function testInternalServerError()
+    {
+        $this->get('/')->assertStatus(500);
+        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_INTERNAL_SERVER_ERROR);
+        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_INTERNAL_SERVER_ERROR);
+    }
+
+    public function testServiceUnavailable()
+    {
+        $this->get('/')->assertStatus(503);
+        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_SERVICE_UNAVAILABLE);
+        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_SERVICE_UNAVAILABLE);
+    }
 }
 CODE_SAMPLE
                     ,
@@ -113,6 +134,27 @@ class ExampleTest extends \Illuminate\Foundation\Testing\TestCase
         $this->get('/')->assertUnprocessable();
         $this->get('/')->assertUnprocessable();
         $this->get('/')->assertUnprocessable();
+    }
+
+    public function testGone()
+    {
+        $this->get('/')->assertGone();
+        $this->get('/')->assertGone();
+        $this->get('/')->assertGone();
+    }
+
+    public function testInternalServerError()
+    {
+        $this->get('/')->assertInternalServerError();
+        $this->get('/')->assertInternalServerError();
+        $this->get('/')->assertInternalServerError();
+    }
+
+    public function testServiceUnavailable()
+    {
+        $this->get('/')->asserServiceUnavailable();
+        $this->get('/')->asserServiceUnavailable();
+        $this->get('/')->asserServiceUnavailable();
     }
 }
 CODE_SAMPLE

--- a/tests/Rector/MethodCall/AssertStatusToAssertMethodRector/AssertStatusToAssertMethodTest.php
+++ b/tests/Rector/MethodCall/AssertStatusToAssertMethodRector/AssertStatusToAssertMethodTest.php
@@ -17,7 +17,7 @@ final class AssertStatusToAssertMethodTest extends AbstractRectorTestCase
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
         return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }

--- a/tests/Rector/MethodCall/AssertStatusToAssertMethodRector/Fixture/fixture_with_illuminate_response_constants.php.inc
+++ b/tests/Rector/MethodCall/AssertStatusToAssertMethodRector/Fixture/fixture_with_illuminate_response_constants.php.inc
@@ -33,6 +33,21 @@ class FixtureWithIlluminateTest
     {
         $response->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY);
     }
+
+    public function testGone(\Illuminate\Testing\TestResponse $response)
+    {
+        $response->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_GONE);
+    }
+
+    public function testInternalServerError(\Illuminate\Testing\TestResponse $response)
+    {
+        $response->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_INTERNAL_SERVER_ERROR);
+    }
+
+    public function testServiceUnavailable(\Illuminate\Testing\TestResponse $response)
+    {
+        $response->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_SERVICE_UNAVAILABLE);
+    }
 }
 
 ?>
@@ -71,6 +86,21 @@ class FixtureWithIlluminateTest
     public function testUnprocessableEntity(\Illuminate\Testing\TestResponse $response)
     {
         $response->assertUnprocessable();
+    }
+
+    public function testGone(\Illuminate\Testing\TestResponse $response)
+    {
+        $response->assertGone();
+    }
+
+    public function testInternalServerError(\Illuminate\Testing\TestResponse $response)
+    {
+        $response->assertInternalServerError();
+    }
+
+    public function testServiceUnavailable(\Illuminate\Testing\TestResponse $response)
+    {
+        $response->assertServiceUnavailable();
     }
 }
 

--- a/tests/Rector/MethodCall/AssertStatusToAssertMethodRector/Fixture/fixture_with_magic_numbers.php.inc
+++ b/tests/Rector/MethodCall/AssertStatusToAssertMethodRector/Fixture/fixture_with_magic_numbers.php.inc
@@ -33,6 +33,21 @@ class FixtureTest
     {
         $response->assertStatus(422);
     }
+
+    public function testGone(\Illuminate\Testing\TestResponse $response)
+    {
+        $response->assertStatus(410);
+    }
+
+    public function testInternalServerError(\Illuminate\Testing\TestResponse $response)
+    {
+        $response->assertStatus(500);
+    }
+
+    public function testServiceUnavailable(\Illuminate\Testing\TestResponse $response)
+    {
+        $response->assertStatus(503);
+    }
 }
 
 ?>
@@ -71,6 +86,21 @@ class FixtureTest
     public function testUnprocessableEntity(\Illuminate\Testing\TestResponse $response)
     {
         $response->assertUnprocessable();
+    }
+
+    public function testGone(\Illuminate\Testing\TestResponse $response)
+    {
+        $response->assertGone();
+    }
+
+    public function testInternalServerError(\Illuminate\Testing\TestResponse $response)
+    {
+        $response->assertInternalServerError();
+    }
+
+    public function testServiceUnavailable(\Illuminate\Testing\TestResponse $response)
+    {
+        $response->assertServiceUnavailable();
     }
 }
 


### PR DESCRIPTION
# Changes

* Adapted the `AssertStatusToAssertMethodRector` to handle 410, 500 and 503 status codes.
* Updates the test to reflect the changes.
* Updates the test to use a static data provider method.

# Why
Updates the `AssertStatusToAssertMethodRector` with the [new HTTP assertion methods introduced in 10.9](https://laravel-news.com/laravel-10-9-0).

There might be some issues here with a requirement to configure which version of Laravel you're using otherwise you might end up with broken method calls because the method doesn't exist. I'm not sure of the best way to apply this. A configuration to specify which HTTP statuses to refactor.

There's also a minor fix to make the test for this use a static data provider.