### PR TITLE
Fix Issue #78 - Error in Redirect::route() Method

### DIFF
--- a/src/Rector/ClassMethod/AddArgumentDefaultValueRector.php
+++ b/src/Rector/ClassMethod/AddArgumentDefaultValueRector.php
@@ -6,6 +6,7 @@ namespace RectorLaravel\Rector\ClassMethod;
 
 use PhpParser\BuilderHelpers;
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
@@ -93,7 +94,7 @@ CODE_SAMPLE
             $position = $addedArgument->getPosition();
             $param = $node->params[$position];
 
-            if ($param->default !== null) {
+            if ($param->default instanceof Expr) {
                 continue;
             }
 

--- a/src/Rector/Empty_/EmptyToBlankAndFilledFuncRector.php
+++ b/src/Rector/Empty_/EmptyToBlankAndFilledFuncRector.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RectorLaravel\Rector\Empty_;
 
 use PhpParser\Node;
@@ -14,22 +16,25 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 class EmptyToBlankAndFilledFuncRector extends AbstractRector
 {
-
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Replace use of the unsafe empty() function with Laravel\'s safer blank() & filled() functions.', [
-            new CodeSample(
-                <<<'CODE_SAMPLE'
+        return new RuleDefinition(
+            'Replace use of the unsafe empty() function with Laravel\'s safer blank() & filled() functions.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 empty([]);
 !empty([]);
 CODE_SAMPLE
-                ,
-                <<<'CODE_SAMPLE'
+                    ,
+                    <<<'CODE_SAMPLE'
 blank([]);
 filled([]);
 CODE_SAMPLE
-            ),
-        ]);
+                ),
+
+            ]
+        );
     }
 
     public function getNodeTypes(): array
@@ -45,7 +50,7 @@ CODE_SAMPLE
             }
             $method = 'filled';
             $args = [$node->expr->expr];
-        } else if ($node instanceof Empty_) {
+        } elseif ($node instanceof Empty_) {
             $method = 'blank';
             $args = [$node->expr];
         } else {

--- a/src/Rector/MethodCall/AssertStatusToAssertMethodRector.php
+++ b/src/Rector/MethodCall/AssertStatusToAssertMethodRector.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace RectorLaravel\Rector\MethodCall;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\LNumber;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -189,18 +192,18 @@ CODE_SAMPLE
             return null;
         }
 
-        if (count($methodCall->getArgs()) <> 1) {
+        if (count($methodCall->getArgs()) !== 1) {
             return null;
         }
 
         $arg = $methodCall->getArgs()[0];
         $argValue = $arg->value;
 
-        if (! $argValue instanceof Node\Scalar\LNumber && ! $argValue instanceof Node\Expr\ClassConstFetch) {
+        if (! $argValue instanceof LNumber && ! $argValue instanceof ClassConstFetch) {
             return null;
         }
 
-        if ($argValue instanceof Node\Scalar\LNumber) {
+        if ($argValue instanceof LNumber) {
             $replacementMethod = match ($argValue->value) {
                 200 => 'assertOk',
                 204 => 'assertNoContent',
@@ -216,9 +219,9 @@ CODE_SAMPLE
         } else {
             if (! in_array($this->getName($argValue->class), [
                 'Illuminate\Http\Response',
-                'Symfony\Component\HttpFoundation\Response'
+                'Symfony\Component\HttpFoundation\Response',
             ], true)) {
-               return null;
+                return null;
             }
 
             $replacementMethod = match ($this->getName($argValue->name)) {
@@ -239,7 +242,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $methodCall->name = new Node\Identifier($replacementMethod);
+        $methodCall->name = new Identifier($replacementMethod);
         $methodCall->args = [];
 
         return $methodCall;

--- a/src/Rector/MethodCall/RedirectBackToBackHelperRector.php
+++ b/src/Rector/MethodCall/RedirectBackToBackHelperRector.php
@@ -122,10 +122,7 @@ CODE_SAMPLE
             $parentNode->var->name = new Name('back');
             $parentNode->var->args = $methodCall->getArgs();
         } else {
-            return new Node\Expr\FuncCall(
-                new Node\Name('back'),
-                $methodCall->getArgs()
-            );
+            return new FuncCall(new Name('back'), $methodCall->getArgs());
         }
 
         return $parentNode;

--- a/src/Rector/MethodCall/RedirectBackToBackHelperRector.php
+++ b/src/Rector/MethodCall/RedirectBackToBackHelperRector.php
@@ -90,7 +90,7 @@ CODE_SAMPLE
         return $this->updateRedirectStaticCall($node);
     }
 
-    private function updateRedirectHelperCall(MethodCall $methodCall): ?MethodCall
+    private function updateRedirectHelperCall(MethodCall $methodCall): MethodCall|FuncCall|null
     {
         if (! $this->isName($methodCall->name, 'back')) {
             return null;
@@ -115,9 +115,18 @@ CODE_SAMPLE
             return null;
         }
 
-        $this->removeNode($methodCall);
+        $childElement = $methodCall->getAttribute('parent');
 
-        $parentNode->var->name = new Name('back');
+        if ($childElement instanceof MethodCall) {
+            $this->removeNode($methodCall);
+            $parentNode->var->name = new Name('back');
+            $parentNode->var->args = $methodCall->getArgs();
+        } else {
+            return new Node\Expr\FuncCall(
+                new Node\Name('back'),
+                $methodCall->getArgs()
+            );
+        }
 
         return $parentNode;
     }

--- a/src/Rector/MethodCall/RedirectRouteToToRouteHelperRector.php
+++ b/src/Rector/MethodCall/RedirectRouteToToRouteHelperRector.php
@@ -122,10 +122,7 @@ CODE_SAMPLE
             $parentNode->var->name = new Name('to_route');
             $parentNode->var->args = $methodCall->getArgs();
         } else {
-            return new Node\Expr\FuncCall(
-                new Node\Name('to_route'),
-                $methodCall->getArgs()
-            );
+            return new FuncCall(new Name('to_route'), $methodCall->getArgs());
         }
 
         return $parentNode;

--- a/src/Rector/MethodCall/RedirectRouteToToRouteHelperRector.php
+++ b/src/Rector/MethodCall/RedirectRouteToToRouteHelperRector.php
@@ -90,7 +90,7 @@ CODE_SAMPLE
         return $this->updateRedirectStaticCall($node);
     }
 
-    private function updateRedirectHelperCall(MethodCall $methodCall): ?MethodCall
+    private function updateRedirectHelperCall(MethodCall $methodCall): MethodCall|FuncCall|null
     {
         if (! $this->isName($methodCall->name, 'route')) {
             return null;
@@ -115,10 +115,18 @@ CODE_SAMPLE
             return null;
         }
 
-        $this->removeNode($methodCall);
+        $childElement = $methodCall->getAttribute('parent');
 
-        $parentNode->var->name = new Name('to_route');
-        $parentNode->var->args = $methodCall->getArgs();
+        if ($childElement instanceof MethodCall) {
+            $this->removeNode($methodCall);
+            $parentNode->var->name = new Name('to_route');
+            $parentNode->var->args = $methodCall->getArgs();
+        } else {
+            return new Node\Expr\FuncCall(
+                new Node\Name('to_route'),
+                $methodCall->getArgs()
+            );
+        }
 
         return $parentNode;
     }

--- a/src/Rector/StaticCall/RouteActionCallableRector.php
+++ b/src/Rector/StaticCall/RouteActionCallableRector.php
@@ -7,6 +7,8 @@ namespace RectorLaravel\Rector\StaticCall;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
@@ -140,16 +142,12 @@ CODE_SAMPLE
             if (is_string($argValue['middleware'])) {
                 $argument = new String_($argValue['middleware']);
             } else {
-                $argument = new Node\Expr\Array_(array_map(
-                    static fn ($value) => new Node\Expr\ArrayItem(new String_($value)),
+                $argument = new Array_(array_map(
+                    static fn ($value) => new ArrayItem(new String_($value)),
                     $argValue['middleware']
                 ));
             }
-            $node = new MethodCall(
-                $node,
-                'middleware',
-                [new Arg($argument)]
-            );
+            $node = new MethodCall($node, 'middleware', [new Arg($argument)]);
         }
 
         return $node;
@@ -172,8 +170,6 @@ CODE_SAMPLE
     }
 
     /**
-     * @param mixed $action
-     *
      * @return array{string, string}|null
      */
     private function resolveControllerFromAction(mixed $action): ?array

--- a/tests/Rector/MethodCall/AssertStatusToAssertMethodRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/AssertStatusToAssertMethodRector/config/configured_rule.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 
-use RectorLaravel\Rector\MethodCall\RedirectBackToBackHelperRector;
+use RectorLaravel\Rector\MethodCall\AssertStatusToAssertMethodRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
 
-    $rectorConfig->rule(\RectorLaravel\Rector\MethodCall\AssertStatusToAssertMethodRector::class);
+    $rectorConfig->rule(AssertStatusToAssertMethodRector::class);
 };

--- a/tests/Rector/MethodCall/RedirectBackToBackHelperRector/Fixture/fixture_with_argument.php.inc
+++ b/tests/Rector/MethodCall/RedirectBackToBackHelperRector/Fixture/fixture_with_argument.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RedirectBackToBackHelperRector\Fixture;
+
+use Illuminate\Support\Facades\Redirect;
+
+class Fixture
+{
+    public function store()
+    {
+        return redirect()->back(302);
+    }
+
+    public function update()
+    {
+        return Redirect::back(302);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RedirectBackToBackHelperRector\Fixture;
+
+use Illuminate\Support\Facades\Redirect;
+
+class Fixture
+{
+    public function store()
+    {
+        return back(302);
+    }
+
+    public function update()
+    {
+        return back(302);
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/RedirectBackToBackHelperRector/Fixture/fixture_with_argument.php.inc
+++ b/tests/Rector/MethodCall/RedirectBackToBackHelperRector/Fixture/fixture_with_argument.php.inc
@@ -4,7 +4,7 @@ namespace RectorLaravel\Tests\Rector\MethodCall\RedirectBackToBackHelperRector\F
 
 use Illuminate\Support\Facades\Redirect;
 
-class Fixture
+class FixtureWithArgument
 {
     public function store()
     {
@@ -25,7 +25,7 @@ namespace RectorLaravel\Tests\Rector\MethodCall\RedirectBackToBackHelperRector\F
 
 use Illuminate\Support\Facades\Redirect;
 
-class Fixture
+class FixtureWithArgument
 {
     public function store()
     {

--- a/tests/Rector/MethodCall/RedirectBackToBackHelperRector/Fixture/fixture_without_with.php.inc
+++ b/tests/Rector/MethodCall/RedirectBackToBackHelperRector/Fixture/fixture_without_with.php.inc
@@ -4,7 +4,7 @@ namespace RectorLaravel\Tests\Rector\MethodCall\RedirectBackToBackHelperRector\F
 
 use Illuminate\Support\Facades\Redirect;
 
-class Fixture
+class FixtureWithoutWith
 {
     public function store()
     {
@@ -25,7 +25,7 @@ namespace RectorLaravel\Tests\Rector\MethodCall\RedirectBackToBackHelperRector\F
 
 use Illuminate\Support\Facades\Redirect;
 
-class Fixture
+class FixtureWithoutWith
 {
     public function store()
     {

--- a/tests/Rector/MethodCall/RedirectBackToBackHelperRector/Fixture/fixture_without_with.php.inc
+++ b/tests/Rector/MethodCall/RedirectBackToBackHelperRector/Fixture/fixture_without_with.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RedirectBackToBackHelperRector\Fixture;
+
+use Illuminate\Support\Facades\Redirect;
+
+class Fixture
+{
+    public function store()
+    {
+        return redirect()->back();
+    }
+
+    public function update()
+    {
+        return Redirect::back();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RedirectBackToBackHelperRector\Fixture;
+
+use Illuminate\Support\Facades\Redirect;
+
+class Fixture
+{
+    public function store()
+    {
+        return back();
+    }
+
+    public function update()
+    {
+        return back();
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/RedirectRouteToToRouteHelperRector/Fixture/fixture_without_with.php.inc
+++ b/tests/Rector/MethodCall/RedirectRouteToToRouteHelperRector/Fixture/fixture_without_with.php.inc
@@ -4,7 +4,7 @@ namespace RectorLaravel\Tests\Rector\MethodCall\RedirectRouteToToRouteHelperRect
 
 use Illuminate\Support\Facades\Redirect;
 
-class WithoutWithFixture
+class FixtureWithoutWith
 {
     public function store()
     {
@@ -25,7 +25,7 @@ namespace RectorLaravel\Tests\Rector\MethodCall\RedirectRouteToToRouteHelperRect
 
 use Illuminate\Support\Facades\Redirect;
 
-class WithoutWithFixture
+class FixtureWithoutWith
 {
     public function store()
     {

--- a/tests/Rector/MethodCall/RedirectRouteToToRouteHelperRector/Fixture/without_with_fixture.php.inc
+++ b/tests/Rector/MethodCall/RedirectRouteToToRouteHelperRector/Fixture/without_with_fixture.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RedirectRouteToToRouteHelperRector\Fixture;
+
+use Illuminate\Support\Facades\Redirect;
+
+class WithoutWithFixture
+{
+    public function store()
+    {
+        return redirect()->route('home');
+    }
+
+    public function update()
+    {
+        return Redirect::route('home');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RedirectRouteToToRouteHelperRector\Fixture;
+
+use Illuminate\Support\Facades\Redirect;
+
+class WithoutWithFixture
+{
+    public function store()
+    {
+        return to_route('home');
+    }
+
+    public function update()
+    {
+        return to_route('home');
+    }
+}
+
+?>


### PR DESCRIPTION
This pull request resolves issue #78. The issue was related to an error occurring when using the `redirect()->route()` method. The bug has been identified and fixed.

**Changes:**

- Analyzed the root cause of the error and determined that it was due to incorrect parameter handling in the `redirect()->back()` method.
- Refactored Some old files code


**Testing:**

Added new unit tests specifically targeting the scenario described in issue #78 to verify the fix.
Ran the full test suite locally to ensure that all existing tests pass successfully.
Manually tested the affected functionality, verifying that the error no longer occurs. 



