### PR TITLE
Move `ArgumentFuncCallToMethodCallRector` to package

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ return static function (RectorConfig $rectorConfig): void {
 
 Rector is a tool that [we develop](https://getrector.org/) and share for free, so anyone can save hundreds of hours on refactoring. But not everyone has time to understand Rector and AST complexity. You have 2 ways to speed this process up:
 
-* read a book - <a href="https://leanpub.com/rector-the-power-of-automated-refactoring">The Power of Automated Refactoring</a>
-* hire our experienced team to <a href="https://getrector.org/contact">improve your codebase</a>
+* Read the book - <a href="https://leanpub.com/rector-the-power-of-automated-refactoring">The Power of Automated Refactoring</a>
+* Hire our experienced team to <a href="https://getrector.org/contact">improve your codebase</a>
 
 Both ways support us to and improve Rector in sustainable way by learning from practical projects.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ return static function (RectorConfig $rectorConfig): void {
 
 ## Learn Rector Faster
 
-Rector is a tool that [we develop](https://getrector.org/) and share for free, so anyone can save hundreds of hours on refactoring. But not everyone has time to understand Rector and AST complexity. You have 2 ways to speed this process up:
+Rector is a tool that [we develop](https://getrector.org/) and share for free, so anyone can save hundreds of hours on refactoring.
+But not everyone has time to understand Rector and AST complexity. You have 2 ways to speed this process up:
 
 * Read the book - <a href="https://leanpub.com/rector-the-power-of-automated-refactoring">The Power of Automated Refactoring</a>
 * Hire our experienced team to <a href="https://getrector.org/contact">improve your codebase</a>

--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,7 @@
         "check-cs": "vendor/bin/ecs check --ansi",
         "fix-cs": "vendor/bin/ecs check --fix --ansi",
         "docs": [
-            "vendor/bin/rule-doc-generator generate src --output-file docs/rector_rules_overview.md --ansi",
-            "vendor/bin/ecs check-markdown docs/rector_rules_overview.md --ansi --fix"
+            "vendor/bin/rule-doc-generator generate src --output-file docs/rector_rules_overview.md --ansi"
         ]
     },
     "minimum-stability": "dev",

--- a/config/sets/laravel-static-to-injection.php
+++ b/config/sets/laravel-static-to-injection.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 
 use Rector\Renaming\Rector\Name\RenameClassRector;
-use Rector\Transform\Rector\FuncCall\ArgumentFuncCallToMethodCallRector;
 use Rector\Transform\Rector\FuncCall\FuncCallToNewRector;
 use Rector\Transform\Rector\StaticCall\StaticCallToMethodCallRector;
 use Rector\Transform\ValueObject\ArgumentFuncCallToMethodCall;
 use Rector\Transform\ValueObject\ArrayFuncCallToMethodCall;
 use Rector\Transform\ValueObject\StaticCallToMethodCall;
+use RectorLaravel\Rector\FuncCall\ArgumentFuncCallToMethodCallRector;
 use RectorLaravel\Rector\FuncCall\HelperFuncCallToFacadeClassRector;
 use RectorLaravel\Rector\StaticCall\RequestStaticValidateToInjectRector;
 

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 27 Rules Overview
+# 34 Rules Overview
 
 ## AddArgumentDefaultValueRector
 
@@ -9,9 +9,13 @@ Adds default value for arguments in defined methods.
 - class: [`RectorLaravel\Rector\ClassMethod\AddArgumentDefaultValueRector`](../src/Rector/ClassMethod/AddArgumentDefaultValueRector.php)
 
 ```php
-use Rector\Config\RectorConfig;
+<?php
+
+declare(strict_types=1);
+
 use RectorLaravel\Rector\ClassMethod\AddArgumentDefaultValueRector;
 use RectorLaravel\ValueObject\AddArgumentDefaultValue;
+use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(AddArgumentDefaultValueRector::class, [
@@ -168,21 +172,164 @@ Convert migrations to anonymous classes.
 
 <br>
 
+## ArgumentFuncCallToMethodCallRector
+
+Move help facade-like function calls to constructor injection
+
+:wrench: **configure it!**
+
+- class: [`RectorLaravel\Rector\FuncCall\ArgumentFuncCallToMethodCallRector`](../src/Rector/FuncCall/ArgumentFuncCallToMethodCallRector.php)
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use RectorLaravel\Rector\FuncCall\ArgumentFuncCallToMethodCallRector;
+use RectorLaravel\ValueObject\ArgumentFuncCallToMethodCall;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(ArgumentFuncCallToMethodCallRector::class, [
+        new ArgumentFuncCallToMethodCall('view', 'Illuminate\Contracts\View\Factory', 'make'),
+    ]);
+};
+```
+
+↓
+
+```diff
+ class SomeController
+ {
++    /**
++     * @var \Illuminate\Contracts\View\Factory
++     */
++    private $viewFactory;
++
++    public function __construct(\Illuminate\Contracts\View\Factory $viewFactory)
++    {
++        $this->viewFactory = $viewFactory;
++    }
++
+     public function action()
+     {
+-        $template = view('template.blade');
+-        $viewFactory = view();
++        $template = $this->viewFactory->make('template.blade');
++        $viewFactory = $this->viewFactory;
+     }
+ }
+```
+
+<br>
+
 ## AssertStatusToAssertMethodRector
 
-Change `assertStatus($statusCode)` to the equivalent method `assertOk()` for example.
+Replace `(new \Illuminate\Testing\TestResponse)->assertStatus(200)` with `(new \Illuminate\Testing\TestResponse)->assertOk()`
 
 - class: [`RectorLaravel\Rector\MethodCall\AssertStatusToAssertMethodRector`](../src/Rector/MethodCall/AssertStatusToAssertMethodRector.php)
 
 ```diff
- use Illuminate\Foundation\Testing\TestCase;
-
- final class SomeTest extends TestCase
+ class ExampleTest extends \Illuminate\Foundation\Testing\TestCase
  {
-     public function test(): void
+     public function testOk()
      {
 -        $this->get('/')->assertStatus(200);
+-        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_OK);
+-        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_OK);
 +        $this->get('/')->assertOk();
++        $this->get('/')->assertOk();
++        $this->get('/')->assertOk();
+     }
+
+     public function testNoContent()
+     {
+-        $this->get('/')->assertStatus(204);
+-        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_NO_CONTENT);
+-        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_NO_CONTENT);
++        $this->get('/')->assertNoContent();
++        $this->get('/')->assertNoContent();
++        $this->get('/')->assertNoContent();
+     }
+
+     public function testUnauthorized()
+     {
+-        $this->get('/')->assertStatus(401);
+-        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_UNAUTHORIZED);
+-        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_UNAUTHORIZED);
++        $this->get('/')->assertUnauthorized();
++        $this->get('/')->assertUnauthorized();
++        $this->get('/')->assertUnauthorized();
+     }
+
+     public function testForbidden()
+     {
+-        $this->get('/')->assertStatus(403);
+-        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_FORBIDDEN);
+-        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_FORBIDDEN);
++        $this->get('/')->assertForbidden();
++        $this->get('/')->assertForbidden();
++        $this->get('/')->assertForbidden();
+     }
+
+     public function testNotFound()
+     {
+-        $this->get('/')->assertStatus(404);
+-        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_NOT_FOUND);
+-        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND);
++        $this->get('/')->assertNotFound();
++        $this->get('/')->assertNotFound();
++        $this->get('/')->assertNotFound();
+     }
+
+     public function testMethodNotAllowed()
+     {
+-        $this->get('/')->assertStatus(405);
+-        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_METHOD_NOT_ALLOWED);
+-        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_METHOD_NOT_ALLOWED);
++        $this->get('/')->assertMethodNotAllowed();
++        $this->get('/')->assertMethodNotAllowed();
++        $this->get('/')->assertMethodNotAllowed();
+     }
+
+     public function testUnprocessableEntity()
+     {
+-        $this->get('/')->assertStatus(422);
+-        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_UNPROCESSABLE_ENTITY);
+-        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY);
++        $this->get('/')->assertUnprocessable();
++        $this->get('/')->assertUnprocessable();
++        $this->get('/')->assertUnprocessable();
+     }
+
+     public function testGone()
+     {
+-        $this->get('/')->assertStatus(410);
+-        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_GONE);
+-        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_GONE);
++        $this->get('/')->assertGone();
++        $this->get('/')->assertGone();
++        $this->get('/')->assertGone();
+     }
+
+     public function testInternalServerError()
+     {
+-        $this->get('/')->assertStatus(500);
+-        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_INTERNAL_SERVER_ERROR);
+-        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_INTERNAL_SERVER_ERROR);
++        $this->get('/')->assertInternalServerError();
++        $this->get('/')->assertInternalServerError();
++        $this->get('/')->assertInternalServerError();
+     }
+
+     public function testServiceUnavailable()
+     {
+-        $this->get('/')->assertStatus(503);
+-        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_SERVICE_UNAVAILABLE);
+-        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_SERVICE_UNAVAILABLE);
++        $this->get('/')->asserServiceUnavailable();
++        $this->get('/')->asserServiceUnavailable();
++        $this->get('/')->asserServiceUnavailable();
      }
  }
 ```
@@ -270,15 +417,15 @@ Convert DB Expression `__toString()` calls to `getValue()` method calls.
 
 ## EmptyToBlankAndFilledFuncRector
 
-Convert `empty()` calls to `blank()` and `!empty()` calls to `filled()`.
+Replace use of the unsafe `empty()` function with Laravel's safer `blank()` & `filled()` functions.
 
-- class: [`RectorLaravel\Rector\FuncCall\EmptyToBlankAndFilledFuncRector`](../src/Rector/FuncCall/EmptyToBlankAndFilledFuncRector.php)
+- class: [`RectorLaravel\Rector\Empty_\EmptyToBlankAndFilledFuncRector`](../src/Rector/Empty_/EmptyToBlankAndFilledFuncRector.php)
 
 ```diff
--$empty = empty($value);
-+$empty = blank($value);
--$notEmpty = !empty($value);
-+$notEmpty = filled($value);
+-empty([]);
+-!empty([]);
++blank([]);
++filled([]);
 ```
 
 <br>
@@ -441,38 +588,28 @@ Change minutes argument to seconds in `Illuminate\Contracts\Cache\Store` and Ill
 
 ## NotFilledBlankFuncCallToBlankFilledFuncCallRector
 
-Change `!blank()` func calls to `filled()` func calls and vice versa.
+Swap the use of NotBooleans used with `filled()` and `blank()` to the correct helper.
 
 - class: [`RectorLaravel\Rector\FuncCall\NotFilledBlankFuncCallToBlankFilledFuncCallRector`](../src/Rector/FuncCall/NotFilledBlankFuncCallToBlankFilledFuncCallRector.php)
 
 ```diff
- class SomeClass
- {
-     public function run()
-     {
--        return !blank($value);
-+        return filled($value);
-     }
- }
+-!filled([]);
+-!blank([]);
++blank([]);
++filled([]);
 ```
 
 <br>
 
 ## NowFuncWithStartOfDayMethodCallToTodayFuncRector
 
-Changes the user of `now()->startOfDay()` to be replaced with `today()`.
+Use `today()` instead of `now()->startOfDay()`
 
 - class: [`RectorLaravel\Rector\FuncCall\NowFuncWithStartOfDayMethodCallToTodayFuncRector`](../src/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector.php)
 
 ```diff
-class SomeClass
-{
-    public function run()
-    {
--       now()->startOfDay();
-+       today();
-    }
-}
+-$now = now()->startOfDay();
++$now = today();
 ```
 
 <br>
@@ -486,12 +623,18 @@ Convert simple calls to optional helper to use the nullsafe operator
 - class: [`RectorLaravel\Rector\PropertyFetch\OptionalToNullsafeOperatorRector`](../src/Rector/PropertyFetch/OptionalToNullsafeOperatorRector.php)
 
 ```php
-use Rector\Config\RectorConfig;
+<?php
+
+declare(strict_types=1);
+
 use RectorLaravel\Rector\PropertyFetch\OptionalToNullsafeOperatorRector;
+use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(OptionalToNullsafeOperatorRector::class, [
-        OptionalToNullsafeOperatorRector::EXCLUDE_METHODS => ['present'],
+        OptionalToNullsafeOperatorRector::EXCLUDE_METHODS => [
+            'present',
+        ],
     ]);
 };
 ```
@@ -683,8 +826,12 @@ Use PHP callable syntax instead of string syntax for controller route declaratio
 - class: [`RectorLaravel\Rector\StaticCall\RouteActionCallableRector`](../src/Rector/StaticCall/RouteActionCallableRector.php)
 
 ```php
-use Rector\Config\RectorConfig;
+<?php
+
+declare(strict_types=1);
+
 use RectorLaravel\Rector\StaticCall\RouteActionCallableRector;
+use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(RouteActionCallableRector::class, [

--- a/src/Contract/ValueObject/ArgumentFuncCallToMethodCallInterface.php
+++ b/src/Contract/ValueObject/ArgumentFuncCallToMethodCallInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Contract\ValueObject;
+
+interface ArgumentFuncCallToMethodCallInterface
+{
+    public function getFunction(): string;
+}

--- a/src/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/SubStrToStartsWithOrEndsWithStaticMethodCallRector.php
+++ b/src/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/SubStrToStartsWithOrEndsWithStaticMethodCallRector.php
@@ -1,9 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RectorLaravel\Rector\Expr\SubStrToStartsWithOrEndsWithStaticMethodCallRector;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\BinaryOp\Equal;
+use PhpParser\Node\Expr\BinaryOp\Identical;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\StaticCall;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -14,7 +19,6 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 class SubStrToStartsWithOrEndsWithStaticMethodCallRector extends AbstractRector
 {
-
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Use Str::startsWith() or Str::endsWith() instead of substr() === $str', [
@@ -23,12 +27,14 @@ class SubStrToStartsWithOrEndsWithStaticMethodCallRector extends AbstractRector
 if (substr($str, 0, 3) === 'foo') {
     // do something
 }
-CODE_SAMPLE,
+CODE_SAMPLE
+,
                 <<<'CODE_SAMPLE'
 if (Str::startsWith($str, 'foo')) {
     // do something
 }
-CODE_SAMPLE,
+CODE_SAMPLE
+,
             ),
         ]);
     }
@@ -43,23 +49,26 @@ CODE_SAMPLE,
      */
     public function refactor(Node $node): ?StaticCall
     {
-        if (!$node instanceof Expr\BinaryOp\Identical && !$node instanceof Expr\BinaryOp\Equal) {
+        if (! $node instanceof Identical && ! $node instanceof Equal) {
             return null;
         }
 
         /** @var Expr\FuncCall|null $functionCall */
-        $functionCall = array_values(array_filter([$node->left, $node->right], function ($node) {
-            return $node instanceof Expr\FuncCall && $this->isName($node, 'substr');
-        }))[0] ?? null;
+        $functionCall = array_values(
+            array_filter([$node->left, $node->right], fn ($node) => $node instanceof FuncCall && $this->isName(
+                $node,
+                'substr'
+            ))
+        )[0] ?? null;
 
-        if ($functionCall === null) {
+        if (! $functionCall instanceof FuncCall) {
             return null;
         }
 
         /** @var Expr $otherNode */
-        $otherNode = array_values(array_filter([$node->left, $node->right], static function ($node) use ($functionCall) {
-            return $node !== $functionCall;
-        }))[0] ?? null;
+        $otherNode = array_values(
+            array_filter([$node->left, $node->right], static fn ($node) => $node !== $functionCall)
+        )[0] ?? null;
 
         // get the function call second argument value
         if (count($functionCall->getArgs()) < 2) {
@@ -68,7 +77,7 @@ CODE_SAMPLE,
 
         $secondArgument = $this->valueResolver->getValue($functionCall->getArgs()[1]->value);
 
-        if (!is_int($secondArgument)) {
+        if (! is_int($secondArgument)) {
             return null;
         }
 
@@ -83,7 +92,8 @@ CODE_SAMPLE,
         }
 
         return $this->nodeFactory->createStaticCall('Illuminate\Support\Str', $methodName, [
-            $functionCall->getArgs()[0]->value,
+            $functionCall->getArgs()[0]
+->value,
             $otherNode,
         ]);
     }

--- a/src/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/SubStrToStartsWithOrEndsWithStaticMethodCallRector.php
+++ b/src/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/SubStrToStartsWithOrEndsWithStaticMethodCallRector.php
@@ -28,13 +28,13 @@ if (substr($str, 0, 3) === 'foo') {
     // do something
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 if (Str::startsWith($str, 'foo')) {
     // do something
 }
 CODE_SAMPLE
-,
+                ,
             ),
         ]);
     }

--- a/src/Rector/FuncCall/ArgumentFuncCallToMethodCallRector.php
+++ b/src/Rector/FuncCall/ArgumentFuncCallToMethodCallRector.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Exception\ShouldNotHappenException;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Naming\Naming\PropertyNaming;
+use Rector\Naming\ValueObject\ExpectedName;
+use Rector\NodeTypeResolver\TypeAnalyzer\ArrayTypeAnalyzer;
+use Rector\PostRector\Collector\PropertyToAddCollector;
+use Rector\PostRector\ValueObject\PropertyMetadata;
+use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
+use RectorLaravel\Contract\ValueObject\ArgumentFuncCallToMethodCallInterface;
+use RectorLaravel\ValueObject\ArgumentFuncCallToMethodCall;
+use RectorLaravel\ValueObject\ArrayFuncCallToMethodCall;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\FuncCall\ArgumentFuncCallToMethodCallRector\ArgumentFuncCallToMethodCallRectorTest
+ */
+final class ArgumentFuncCallToMethodCallRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var ArgumentFuncCallToMethodCallInterface[]
+     */
+    private array $argumentFuncCallToMethodCalls = [];
+
+    public function __construct(
+        private readonly ArrayTypeAnalyzer $arrayTypeAnalyzer,
+        private readonly PropertyNaming $propertyNaming,
+        private readonly PropertyToAddCollector $propertyToAddCollector
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Move help facade-like function calls to constructor injection', [
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+class SomeController
+{
+    public function action()
+    {
+        $template = view('template.blade');
+        $viewFactory = view();
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeController
+{
+    /**
+     * @var \Illuminate\Contracts\View\Factory
+     */
+    private $viewFactory;
+
+    public function __construct(\Illuminate\Contracts\View\Factory $viewFactory)
+    {
+        $this->viewFactory = $viewFactory;
+    }
+
+    public function action()
+    {
+        $template = $this->viewFactory->make('template.blade');
+        $viewFactory = $this->viewFactory;
+    }
+}
+CODE_SAMPLE
+                ,
+                [new ArgumentFuncCallToMethodCall('view', 'Illuminate\Contracts\View\Factory', 'make')]
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($this->shouldSkipFuncCall($node)) {
+            return null;
+        }
+
+        /** @var Class_ $classLike */
+        $classLike = $this->betterNodeFinder->findParentType($node, Class_::class);
+
+        foreach ($this->argumentFuncCallToMethodCalls as $argumentFuncCallToMethodCall) {
+            if (! $this->isName($node, $argumentFuncCallToMethodCall->getFunction())) {
+                continue;
+            }
+
+            if ($argumentFuncCallToMethodCall instanceof ArgumentFuncCallToMethodCall) {
+                return $this->refactorFuncCallToMethodCall($argumentFuncCallToMethodCall, $classLike, $node);
+            }
+
+            if ($argumentFuncCallToMethodCall instanceof ArrayFuncCallToMethodCall) {
+                return $this->refactorArrayFunctionToMethodCall($argumentFuncCallToMethodCall, $node, $classLike);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        Assert::allIsInstanceOf($configuration, ArgumentFuncCallToMethodCallInterface::class);
+
+        $this->argumentFuncCallToMethodCalls = $configuration;
+    }
+
+    private function shouldSkipFuncCall(FuncCall $funcCall): bool
+    {
+        // we can inject only in injectable class method  context
+        /** @var ClassMethod|null $classMethod */
+        $classMethod = $this->betterNodeFinder->findParentType($funcCall, ClassMethod::class);
+        if (! $classMethod instanceof ClassMethod) {
+            return true;
+        }
+
+        return $classMethod->isStatic();
+    }
+
+    /**
+     * @return MethodCall|PropertyFetch|null
+     */
+    private function refactorFuncCallToMethodCall(
+        ArgumentFuncCallToMethodCall $argumentFuncCallToMethodCall,
+        Class_ $class,
+        FuncCall $funcCall
+    ): ?Node {
+        $fullyQualifiedObjectType = new FullyQualifiedObjectType($argumentFuncCallToMethodCall->getClass());
+        $expectedName = $this->propertyNaming->getExpectedNameFromType($fullyQualifiedObjectType);
+
+        if (! $expectedName instanceof ExpectedName) {
+            throw new ShouldNotHappenException();
+        }
+
+        $propertyMetadata = new PropertyMetadata(
+            $expectedName->getName(),
+            $fullyQualifiedObjectType,
+            Class_::MODIFIER_PRIVATE
+        );
+        $this->propertyToAddCollector->addPropertyToClass($class, $propertyMetadata);
+
+        $propertyFetchNode = $this->nodeFactory->createPropertyFetch('this', $expectedName->getName());
+
+        if ($funcCall->args === []) {
+            return $this->refactorEmptyFuncCallArgs($argumentFuncCallToMethodCall, $propertyFetchNode);
+        }
+
+        if ($this->isFunctionToMethodCallWithArgs($funcCall, $argumentFuncCallToMethodCall)) {
+            $methodName = $argumentFuncCallToMethodCall->getMethodIfArgs();
+            if (! is_string($methodName)) {
+                throw new ShouldNotHappenException();
+            }
+
+            return new MethodCall($propertyFetchNode, $methodName, $funcCall->args);
+        }
+
+        return null;
+    }
+
+    /**
+     * @return PropertyFetch|MethodCall|null
+     */
+    private function refactorArrayFunctionToMethodCall(
+        ArrayFuncCallToMethodCall $arrayFuncCallToMethodCall,
+        FuncCall $funcCall,
+        Class_ $class
+    ): ?Node {
+        $propertyName = $this->propertyNaming->fqnToVariableName($arrayFuncCallToMethodCall->getClass());
+        $propertyFetch = $this->nodeFactory->createPropertyFetch('this', $propertyName);
+
+        $fullyQualifiedObjectType = new FullyQualifiedObjectType($arrayFuncCallToMethodCall->getClass());
+
+        $propertyMetadata = new PropertyMetadata($propertyName, $fullyQualifiedObjectType, Class_::MODIFIER_PRIVATE);
+        $this->propertyToAddCollector->addPropertyToClass($class, $propertyMetadata);
+
+        return $this->createMethodCallArrayFunctionToMethodCall(
+            $funcCall,
+            $arrayFuncCallToMethodCall,
+            $propertyFetch
+        );
+    }
+
+    private function refactorEmptyFuncCallArgs(
+        ArgumentFuncCallToMethodCall $argumentFuncCallToMethodCall,
+        PropertyFetch $propertyFetch
+    ): MethodCall | PropertyFetch {
+        if ($argumentFuncCallToMethodCall->getMethodIfNoArgs() !== null) {
+            $methodName = $argumentFuncCallToMethodCall->getMethodIfNoArgs();
+            return new MethodCall($propertyFetch, $methodName);
+        }
+
+        return $propertyFetch;
+    }
+
+    private function isFunctionToMethodCallWithArgs(
+        FuncCall $funcCall,
+        ArgumentFuncCallToMethodCall $argumentFuncCallToMethodCall
+    ): bool {
+        if ($argumentFuncCallToMethodCall->getMethodIfArgs() === null) {
+            return false;
+        }
+
+        return count($funcCall->args) >= 1;
+    }
+
+    /**
+     * @return PropertyFetch|MethodCall|null
+     */
+    private function createMethodCallArrayFunctionToMethodCall(
+        FuncCall $funcCall,
+        ArrayFuncCallToMethodCall $arrayFuncCallToMethodCall,
+        PropertyFetch $propertyFetch
+    ): ?Node {
+        if ($funcCall->getArgs() === []) {
+            return $propertyFetch;
+        }
+
+        if ($this->arrayTypeAnalyzer->isArrayType($funcCall->getArgs()[0]->value)) {
+            return new MethodCall($propertyFetch, $arrayFuncCallToMethodCall->getArrayMethod(), $funcCall->getArgs());
+        }
+
+        if ($arrayFuncCallToMethodCall->getNonArrayMethod() === '') {
+            return null;
+        }
+
+        return new MethodCall($propertyFetch, $arrayFuncCallToMethodCall->getNonArrayMethod(), $funcCall->getArgs());
+    }
+}

--- a/src/Rector/FuncCall/NotFilledBlankFuncCallToBlankFilledFuncCallRector.php
+++ b/src/Rector/FuncCall/NotFilledBlankFuncCallToBlankFilledFuncCallRector.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RectorLaravel\Rector\FuncCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\FuncCall;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -13,7 +16,6 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 class NotFilledBlankFuncCallToBlankFilledFuncCallRector extends AbstractRector
 {
-
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -43,9 +45,9 @@ CODE_SAMPLE
     /**
      * @param BooleanNot $node
      */
-    public function refactor(Node $node): ?Node\Expr\FuncCall
+    public function refactor(Node $node): ?FuncCall
     {
-        if (! $node->expr instanceof Node\Expr\FuncCall) {
+        if (! $node->expr instanceof FuncCall) {
             return null;
         }
 

--- a/src/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector.php
+++ b/src/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector.php
@@ -23,7 +23,7 @@ class NowFuncWithStartOfDayMethodCallToTodayFuncRector extends AbstractRector
                 <<<'CODE_SAMPLE'
 $now = now()->startOfDay();
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 $now = today();
 CODE_SAMPLE

--- a/src/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector.php
+++ b/src/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RectorLaravel\Rector\FuncCall;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -19,7 +22,8 @@ class NowFuncWithStartOfDayMethodCallToTodayFuncRector extends AbstractRector
             new CodeSample(
                 <<<'CODE_SAMPLE'
 $now = now()->startOfDay();
-CODE_SAMPLE,
+CODE_SAMPLE
+,
                 <<<'CODE_SAMPLE'
 $now = today();
 CODE_SAMPLE
@@ -35,7 +39,7 @@ CODE_SAMPLE
     /**
      * @param MethodCall $node
      */
-    public function refactor(Node $node): ?Node\Expr\FuncCall
+    public function refactor(Node $node): ?FuncCall
     {
         if (! $this->isName($node->name, 'startOfDay')) {
             return null;

--- a/src/ValueObject/ArgumentFuncCallToMethodCall.php
+++ b/src/ValueObject/ArgumentFuncCallToMethodCall.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\ValueObject;
+
+use Rector\Core\Validation\RectorAssert;
+use RectorLaravel\Contract\ValueObject\ArgumentFuncCallToMethodCallInterface;
+
+final class ArgumentFuncCallToMethodCall implements ArgumentFuncCallToMethodCallInterface
+{
+    public function __construct(
+        private readonly string $function,
+        private readonly string $class,
+        private readonly ?string $methodIfArgs = null,
+        private readonly ?string $methodIfNoArgs = null
+    ) {
+        RectorAssert::className($class);
+        RectorAssert::functionName($function);
+    }
+
+    public function getFunction(): string
+    {
+        return $this->function;
+    }
+
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    public function getMethodIfNoArgs(): ?string
+    {
+        return $this->methodIfNoArgs;
+    }
+
+    public function getMethodIfArgs(): ?string
+    {
+        return $this->methodIfArgs;
+    }
+}

--- a/src/ValueObject/ArrayFuncCallToMethodCall.php
+++ b/src/ValueObject/ArrayFuncCallToMethodCall.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\ValueObject;
+
+use Rector\Core\Validation\RectorAssert;
+use RectorLaravel\Contract\ValueObject\ArgumentFuncCallToMethodCallInterface;
+
+final class ArrayFuncCallToMethodCall implements ArgumentFuncCallToMethodCallInterface
+{
+    /**
+     * @param non-empty-string $function
+     * @param non-empty-string $class
+     * @param non-empty-string $arrayMethod
+     * @param non-empty-string $nonArrayMethod
+     */
+    public function __construct(
+        private readonly string $function,
+        private readonly string $class,
+        private readonly string $arrayMethod,
+        private readonly string $nonArrayMethod
+    ) {
+        RectorAssert::className($class);
+        RectorAssert::functionName($function);
+        RectorAssert::methodName($arrayMethod);
+        RectorAssert::methodName($nonArrayMethod);
+    }
+
+    public function getFunction(): string
+    {
+        return $this->function;
+    }
+
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    public function getArrayMethod(): string
+    {
+        return $this->arrayMethod;
+    }
+
+    public function getNonArrayMethod(): string
+    {
+        return $this->nonArrayMethod;
+    }
+}

--- a/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/ArgumentFuncCallToMethodCallRectorTest.php
+++ b/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/ArgumentFuncCallToMethodCallRectorTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace RectorLaravel\Tests\Rector\MethodCall\AssertStatusToAssertMethodRector;
+namespace RectorLaravel\Tests\Rector\FuncCall\ArgumentFuncCallToMethodCallRector;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
-final class AssertStatusToAssertMethodTest extends AbstractRectorTestCase
+final class ArgumentFuncCallToMethodCallRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]
     public function test(string $filePath): void

--- a/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/back.php.inc
+++ b/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/back.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\ArgumentFuncCallToMethodCallRector\Fixture;
+
+class Back
+{
+    public function action()
+    {
+        return back();
+    }
+
+    public function actionWithParams()
+    {
+        return back(200);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\ArgumentFuncCallToMethodCallRector\Fixture;
+
+class Back
+{
+    public function __construct(private \Illuminate\Routing\Redirector $redirector)
+    {
+    }
+    public function action()
+    {
+        return $this->redirector->back();
+    }
+
+    public function actionWithParams()
+    {
+        return $this->redirector->back(200);
+    }
+}
+
+?>

--- a/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/broadcast.php.inc
+++ b/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/broadcast.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\ArgumentFuncCallToMethodCallRector\Fixture;
+
+class Broadcast
+{
+    public function action()
+    {
+        return broadcast('template.blade');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\ArgumentFuncCallToMethodCallRector\Fixture;
+
+class Broadcast
+{
+    public function __construct(private \Illuminate\Contracts\Broadcasting\Factory $broadcastingFactory)
+    {
+    }
+    public function action()
+    {
+        return $this->broadcastingFactory->event('template.blade');
+    }
+}
+
+?>

--- a/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/config.php.inc
+++ b/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/config.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\ArgumentFuncCallToMethodCallRector\Fixture;
+
+class Config
+{
+    public function actionGet()
+    {
+        $value = config('value');
+    }
+
+    public function actionSet($value)
+    {
+        config(['value' => $value]);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\ArgumentFuncCallToMethodCallRector\Fixture;
+
+class Config
+{
+    public function __construct(private \Illuminate\Contracts\Config\Repository $configRepository)
+    {
+    }
+    public function actionGet()
+    {
+        $value = $this->configRepository->get('value');
+    }
+
+    public function actionSet($value)
+    {
+        $this->configRepository->set(['value' => $value]);
+    }
+}
+
+?>

--- a/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/route.php.inc
+++ b/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/route.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\ArgumentFuncCallToMethodCallRector\Fixture;
+
+class Route
+{
+    public function action()
+    {
+        return route('template.blade');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\ArgumentFuncCallToMethodCallRector\Fixture;
+
+class Route
+{
+    public function __construct(private \Illuminate\Routing\UrlGenerator $urlGenerator)
+    {
+    }
+    public function action()
+    {
+        return $this->urlGenerator->route('template.blade');
+    }
+}
+
+?>

--- a/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/session.php.inc
+++ b/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/session.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\FactoryFuncCallToStaticCallRector\Fixture;
+
+class Session
+{
+    public function action()
+    {
+        $session = session();
+        session(['key']);
+        session('key', 'value');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\FactoryFuncCallToStaticCallRector\Fixture;
+
+class Session
+{
+    public function __construct(private \Illuminate\Session\SessionManager $sessionManager)
+    {
+    }
+    public function action()
+    {
+        $session = $this->sessionManager;
+        $this->sessionManager->put(['key']);
+        $this->sessionManager->get('key', 'value');
+    }
+}
+
+?>

--- a/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/skip_static_method.php.inc
+++ b/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/skip_static_method.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\ArgumentFuncCallToMethodCallRector\Fixture;
+
+class SkipStaticMethod
+{
+    public static function go()
+    {
+        $value = config('value');
+    }
+}

--- a/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/view.php.inc
+++ b/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/view.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\ArgumentFuncCallToMethodCallRector\Fixture;
+
+class View
+{
+    public function action()
+    {
+        $template = view('template.blade');
+        $viewFactory = view();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\ArgumentFuncCallToMethodCallRector\Fixture;
+
+class View
+{
+    public function __construct(private \Illuminate\Contracts\View\Factory $viewFactory)
+    {
+    }
+    public function action()
+    {
+        $template = $this->viewFactory->make('template.blade');
+        $viewFactory = $this->viewFactory;
+    }
+}
+
+?>

--- a/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/config/configured_rule.php
+++ b/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/config/configured_rule.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\FuncCall\ArgumentFuncCallToMethodCallRector;
+use RectorLaravel\ValueObject\ArgumentFuncCallToMethodCall;
+use RectorLaravel\ValueObject\ArrayFuncCallToMethodCall;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig
+        ->ruleWithConfiguration(ArgumentFuncCallToMethodCallRector::class, [
+            new ArgumentFuncCallToMethodCall('view', 'Illuminate\Contracts\View\Factory', 'make'),
+            new ArgumentFuncCallToMethodCall('route', 'Illuminate\Routing\UrlGenerator', 'route'),
+            new ArgumentFuncCallToMethodCall('back', 'Illuminate\Routing\Redirector', 'back', 'back'),
+            new ArgumentFuncCallToMethodCall('broadcast', 'Illuminate\Contracts\Broadcasting\Factory', 'event'),
+
+            new ArrayFuncCallToMethodCall('config', 'Illuminate\Contracts\Config\Repository', 'set', 'get'),
+            new ArrayFuncCallToMethodCall('session', 'Illuminate\Session\SessionManager', 'put', 'get'),
+        ]);
+};

--- a/tests/Rector/FuncCall/NotFilledBlankFuncCallToBlankFilledFuncCallRector/config/configured_rule.php
+++ b/tests/Rector/FuncCall/NotFilledBlankFuncCallToBlankFilledFuncCallRector/config/configured_rule.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 
+use RectorLaravel\Rector\FuncCall\NotFilledBlankFuncCallToBlankFilledFuncCallRector;
+
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
 
-    $rectorConfig->rule(\RectorLaravel\Rector\FuncCall\NotFilledBlankFuncCallToBlankFilledFuncCallRector::class);
+    $rectorConfig->rule(NotFilledBlankFuncCallToBlankFilledFuncCallRector::class);
 };

--- a/tests/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector/config/configured_rule.php
+++ b/tests/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector/config/configured_rule.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 
-use RectorLaravel\Rector\FuncCall\HelperFuncCallToFacadeClassRector;
+use RectorLaravel\Rector\FuncCall\NowFuncWithStartOfDayMethodCallToTodayFuncRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
 
-    $rectorConfig->rule(\RectorLaravel\Rector\FuncCall\NowFuncWithStartOfDayMethodCallToTodayFuncRector::class);
+    $rectorConfig->rule(NowFuncWithStartOfDayMethodCallToTodayFuncRector::class);
 };


### PR DESCRIPTION
This PR moves the `ArgumentFuncCallToMethodCallRector` class from Rector to Rector Laravel. 

See https://github.com/rectorphp/rector-src/pull/3774#issuecomment-1539905216