### PR TITLE
New `now()->startOfDay()` to `today()` rule

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -403,6 +403,25 @@ Change minutes argument to seconds in `Illuminate\Contracts\Cache\Store` and Ill
 
 <br>
 
+## NowFuncWithStartOfDayMethodCallToTodayFuncRector
+
+Changes the user of `now()->startOfDay()` to be replaced with `today()`.
+
+- class: [`RectorLaravel\Rector\FuncCall\NowFuncWithStartOfDayMethodCallToTodayFuncRector`](../src/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector.php)
+
+```diff
+class SomeClass
+{
+    public function run()
+    {
+-       now()->startOfDay();
++       today();
+    }
+}
+```
+
+<br>
+
 ## OptionalToNullsafeOperatorRector
 
 Convert simple calls to optional helper to use the nullsafe operator

--- a/src/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector.php
+++ b/src/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector.php
@@ -35,7 +35,7 @@ CODE_SAMPLE
     /**
      * @param MethodCall $node
      */
-    public function refactor(Node $node): ?Node
+    public function refactor(Node $node): ?Node\Expr\FuncCall
     {
         if (! $this->isName($node->name, 'startOfDay')) {
             return null;

--- a/src/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector.php
+++ b/src/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace RectorLaravel\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\FuncCall\NowFuncWithStartOfDayMethodCallToTodayFuncRector\NowFuncWithStartOfDayMethodCallToTodayFuncRectorTest
+ */
+class NowFuncWithStartOfDayMethodCallToTodayFuncRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Use today() instead of now()->startOfDay()', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+$now = now()->startOfDay();
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+$now = today();
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isName($node->name, 'startOfDay')) {
+            return null;
+        }
+
+        if (! $this->isName($node->var, 'now')) {
+            return null;
+        }
+
+        return $this->nodeFactory->createFuncCall('today');
+    }
+}

--- a/tests/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector/Fixture/fixture.php.inc
+++ b/tests/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector/Fixture/fixture.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\HelperFuncCallToFacadeClassRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        $today = now()->startOfDay();
+        $tomorrow = now()->startOfDay()->addDay();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\HelperFuncCallToFacadeClassRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        $today = today();
+        $tomorrow = today()->addDay();
+    }
+}
+
+?>

--- a/tests/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector/Fixture/skip_now_with_other_calls.php.inc
+++ b/tests/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector/Fixture/skip_now_with_other_calls.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\HelperFuncCallToFacadeClassRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        $today = now()->addDay()->startOfDay();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\HelperFuncCallToFacadeClassRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        $today = now()->addDay()->startOfDay();
+    }
+}
+
+?>

--- a/tests/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector/NowFuncWithStartOfDayMethodCallToTodayFuncRectorTest.php
+++ b/tests/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector/NowFuncWithStartOfDayMethodCallToTodayFuncRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\FuncCall\NowFuncWithStartOfDayMethodCallToTodayFuncRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class NowFuncWithStartOfDayMethodCallToTodayFuncRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector/config/configured_rule.php
+++ b/tests/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+use RectorLaravel\Rector\FuncCall\HelperFuncCallToFacadeClassRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(\RectorLaravel\Rector\FuncCall\NowFuncWithStartOfDayMethodCallToTodayFuncRector::class);
+};


### PR DESCRIPTION
# Changes

* Adds the new rule
* Adds tests for the rule
* Adds documentation for said rule

# Why

The `today()` helper exists in Laravel, providing the date today but set at the start of the day. It makes sense, where possible, to remove the use of `now()` for `today()` when this is the case.