### PR TITLE
substring to Str::startsWith or Str::endsWith

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -702,6 +702,19 @@ return static function (RectorConfig $rectorConfig): void {
 
 <br>
 
+## SubStrToStartsWithOrEndsWithStaticMethodCallRector
+
+Change `substr()` to `startsWith()` or `endsWith()` static method call where applicable.
+
+- class: [`RectorLaravel\Rector\FuncCall\SubStrToStartsWithOrEndsWithStaticMethodCallRector`](../src/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/SubStrToStartsWithOrEndsWithStaticMethodCallRector.php)
+
+```diff
+-$string = substr($string, 0, 5) === 'foo';
++$string = Str::startsWith($string, 'foo');
+```
+
+<br>
+
 ## UnifyModelDatesWithCastsRector
 
 Unify Model `$dates` property with `$casts`

--- a/src/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/SubStrToStartsWithOrEndsWithStaticMethodCallRector.php
+++ b/src/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/SubStrToStartsWithOrEndsWithStaticMethodCallRector.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace RectorLaravel\Rector\Expr\SubStrToStartsWithOrEndsWithStaticMethodCallRector;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\StaticCall;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\Expr\SubStrToStartsWithOrEndsWithStaticMethodCallRector\SubStrToStartsWithOrEndsWithStaticMethodCallRectorTest
+ */
+class SubStrToStartsWithOrEndsWithStaticMethodCallRector extends AbstractRector
+{
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Use Str::startsWith() or Str::endsWith() instead of substr() === $str', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+if (substr($str, 0, 3) === 'foo') {
+    // do something
+}
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+if (Str::startsWith($str, 'foo')) {
+    // do something
+}
+CODE_SAMPLE,
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Expr::class];
+    }
+
+    /**
+     * @param Expr $node
+     */
+    public function refactor(Node $node): ?StaticCall
+    {
+        if (!$node instanceof Expr\BinaryOp\Identical && !$node instanceof Expr\BinaryOp\Equal) {
+            return null;
+        }
+
+        $functionCall = array_filter([$node->left, $node->right], function ($node) {
+            return $node instanceof Expr\FuncCall && $this->isName($node, 'substr');
+        });
+
+        if ($functionCall === []) {
+            return null;
+        }
+
+        $functionCall = reset($functionCall);
+
+        $otherNode = array_filter([$node->left, $node->right], static function ($node) use ($functionCall) {
+            return $node !== $functionCall;
+        });
+
+        $otherNode = reset($otherNode);
+
+        // get the function call second argument value
+        if (count($functionCall->args) < 2) {
+            return null;
+        }
+
+        $secondArgument = $this->valueResolver->getValue($functionCall->args[1]->value);
+
+        if (!is_int($secondArgument)) {
+            return null;
+        }
+
+        if ($secondArgument < 0 && isset($functionCall->args[2])) {
+            return null;
+        }
+
+        if (!$methodName = $this->getStaticMethodName($secondArgument)) {
+            return null;
+        }
+
+        return $this->nodeFactory->createStaticCall('Illuminate\Support\Str', $methodName, [
+            $functionCall->args[0]->value,
+            $otherNode,
+        ]);
+    }
+
+    protected function getStaticMethodName(int $secondArgument): ?string
+    {
+        if ($secondArgument === 0) {
+            return 'startsWith';
+        }
+
+        if ($secondArgument < 0) {
+            return 'endsWith';
+        }
+
+        return null;
+    }
+}

--- a/tests/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/Fixture/fixture.php.inc
@@ -1,0 +1,51 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Expr\SubStrToStartsWithOrEndsWithStaticMethodCallRector\Fixture;
+
+if (substr($value, 0, 1) === 'a') {
+    return true;
+}
+
+if (substr($value, -1) === 'a') {
+    return true;
+}
+
+if ('a' === substr($value, 0, 1)) {
+    return true;
+}
+
+if ($prefix === substr($value, 0, 1)) {
+    return true;
+}
+
+if (substr($value, 0, 1) == 'a') {
+    return true;
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Expr\SubStrToStartsWithOrEndsWithStaticMethodCallRector\Fixture;
+
+if (\Illuminate\Support\Str::startsWith($value, 'a')) {
+    return true;
+}
+
+if (\Illuminate\Support\Str::endsWith($value, 'a')) {
+    return true;
+}
+
+if (\Illuminate\Support\Str::startsWith($value, 'a')) {
+    return true;
+}
+
+if (\Illuminate\Support\Str::startsWith($value, $prefix)) {
+    return true;
+}
+
+if (\Illuminate\Support\Str::startsWith($value, 'a')) {
+    return true;
+}
+
+?>

--- a/tests/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/Fixture/skips_non_ends_with.php.inc
+++ b/tests/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/Fixture/skips_non_ends_with.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Expr\SubStrToStartsWithOrEndsWithStaticMethodCallRector\Fixture;
+
+if (substr($value, -1, 1) === 'a') {
+    return true;
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Expr\SubStrToStartsWithOrEndsWithStaticMethodCallRector\Fixture;
+
+if (substr($value, -1, 1) === 'a') {
+    return true;
+}
+
+?>

--- a/tests/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/Fixture/skips_non_starts_with.php.inc
+++ b/tests/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/Fixture/skips_non_starts_with.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Expr\SubStrToStartsWithOrEndsWithStaticMethodCallRector\Fixture;
+
+if (substr($value, 1) === 'a') {
+    return true;
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Expr\SubStrToStartsWithOrEndsWithStaticMethodCallRector\Fixture;
+
+if (substr($value, 1) === 'a') {
+    return true;
+}
+
+?>

--- a/tests/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/SubStrToStartsWithOrEndsWithStaticMethodCallRectorTest.php
+++ b/tests/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/SubStrToStartsWithOrEndsWithStaticMethodCallRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\Expr\SubStrToStartsWithOrEndsWithStaticMethodCallRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class SubStrToStartsWithOrEndsWithStaticMethodCallRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/config/configured_rule.php
+++ b/tests/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Expr\SubStrToStartsWithOrEndsWithStaticMethodCallRector\SubStrToStartsWithOrEndsWithStaticMethodCallRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(SubStrToStartsWithOrEndsWithStaticMethodCallRector::class);
+};


### PR DESCRIPTION
# Changes

* Adds the new rule for processing `substr()` using Laravel's Str helper for `startsWith()` or `endsWith()` where appropriate.
* Adds tests
* Adds documentation

# Why

Often older projects will use the substring method, allowing the end user to switch these out quickly.