### PR TITLE
Updated config to use the new Laravel DI Container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Rector upgrades rules for Laravel Framework",
     "require": {
         "php": ">=8.1",
-        "rector/rector": "^0.17.1"
+        "rector/rector": "^0.18.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",

--- a/config/config.php
+++ b/config/config.php
@@ -4,18 +4,5 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 
-use Rector\Core\NonPhpFile\Rector\RenameClassNonPhpRector;
-
 return static function (RectorConfig $rectorConfig): void {
-    $services = $rectorConfig->services();
-
-    $services->defaults()
-        ->public()
-        ->autowire()
-        ->autoconfigure();
-
-    $services->load('RectorLaravel\\', __DIR__ . '/../src')
-        ->exclude([__DIR__ . '/../src/{Rector,ValueObject}']);
-
-    $services->set(RenameClassNonPhpRector::class);
 };

--- a/src/Rector/FuncCall/SleepFuncToSleepStaticCallRector.php
+++ b/src/Rector/FuncCall/SleepFuncToSleepStaticCallRector.php
@@ -23,11 +23,11 @@ class SleepFuncToSleepStaticCallRector extends AbstractRector
                     <<<'CODE_SAMPLE'
 sleep(5);
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 \Illuminate\Support\Sleep::sleep(5);
 CODE_SAMPLE
-,
+                    ,
                 ),
             ]
         );


### PR DESCRIPTION
The base `config.php` file is now practically empty, but I did not delete it.

I tried deleting it and all the places where it was imported, and all tests still passed. They did not delete it in the core because they still had to keep some configuration there, and we might want to do the same in the future.

This PR would fix https://github.com/driftingly/rector-laravel/issues/125.