### PR TITLE
Upgrade service type setting in config.php

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -7,7 +7,7 @@ use Rector\Config\RectorConfig;
 use Rector\Core\NonPhpFile\Rector\RenameClassNonPhpRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $services = $rectorConfig->services();
+    $services = $rectorConfig->singleton(ServiceType::class);
 
     $services->defaults()
         ->public()


### PR DESCRIPTION
Service type may be one of these
https://github.com/rectorphp/rector-src/blob/5363a676265cbe868f4ecc6bde8c6a99b213d028/src/DependencyInjection/LazyContainerFactory.php#L328-L335

`RenameClassNonPhpRector` [does not exist](https://github.com/rectorphp/rector-src/commit/1659ca292848fc1722b4b084d9fd1625b21e69c9) anymore.

Fixes #125
