### PR TITLE
Remove reverted Laravel 10 rule (getBaseQuery -> toBase)

### DIFF
--- a/config/sets/laravel100.php
+++ b/config/sets/laravel100.php
@@ -31,8 +31,6 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig
         ->ruleWithConfiguration(RenameMethodRector::class, [
-            // https://github.com/laravel/framework/pull/41136/files
-            new MethodCallRename('Illuminate\Database\Eloquent\Relations\Relation', 'getBaseQuery', 'toBase'),
             // https://github.com/laravel/framework/pull/42591/files
             new MethodCallRename('Illuminate\Support\Facades\Bus', 'dispatchNow', 'dispatchSync'),
         ]);


### PR DESCRIPTION
The deprecated `getBaseQuery` was initially removed, but then it was [added back](https://github.com/laravel/framework/pull/41923) because it caused a regression.

Closes #129