### PR TITLE
Remove MethodCallRename rule from Laravel80 ruleset

### DIFF
--- a/config/sets/laravel80.php
+++ b/config/sets/laravel80.php
@@ -60,7 +60,5 @@ return static function (RectorConfig $rectorConfig): void {
             new MethodCallRename('Illuminate\Contracts\Queue\ShouldQueue', 'timeoutAt', 'retryUntil'),
             # https://github.com/laravel/framework/commit/f9374fa5fb0450721fb2f90e96adef9d409b112c
             new MethodCallRename('Illuminate\Testing\TestResponse', 'decodeResponseJson', 'json'),
-            # https://github.com/laravel/framework/commit/fd662d4699776a94e7ead2a42e82c340363fc5a6
-            new MethodCallRename('Illuminate\Testing\TestResponse', 'assertExactJson', 'assertSimilarJson'),
         ]);
 };


### PR DESCRIPTION
It references the commit where the function was "renamed", but the next commit in the laravel/framework repository is re-adding the function.

https://github.com/laravel/framework/commit/8e0914e847e8b161a1968a68f9f80003e23136db

As `assertExactJson()` and `assertSimilarJson()` have very different expectations, I think this could change could inadvertently alter tests to be less accurate.