### PR TITLE
Fix PHPStan ignored errors

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -24,6 +24,6 @@ parameters:
             message: '#Parameter \#1 \$array of function array_keys expects array, mixed given#'
 
         # rector co-variant
-        - '#Parameter \#1 \$node \(PhpParser\\Node\\(.*?) of method RectorLaravel\\(.*?)\(\) should be contravariant with parameter \$node \(PhpParser\\Node\) of method Rector\\Core\\Contract\\Rector\\PhpRectorInterface\:\:refactor\(\)#'
+        - '#Parameter \#1 \$node (.*?) of method RectorLaravel\\(.*?)\:\:(refactor|refactorWithScope)\(\) should be contravariant with parameter \$node \(PhpParser\\Node\) of method Rector\\Core\\Contract\\Rector\\RectorInterface\:\:refactor\(\)#'
 
         - '#Parameter \#1 \$className of method Rector\\Core\\Reflection\\ReflectionResolver\:\:resolveMethodReflection\(\) expects class\-string, string given#'

--- a/src/Rector/StaticCall/RouteActionCallableRector.php
+++ b/src/Rector/StaticCall/RouteActionCallableRector.php
@@ -88,7 +88,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param Node\Expr\MethodCall|StaticCall $node
+     * @param MethodCall|StaticCall $node
      */
     public function refactor(Node $node): ?Node
     {


### PR DESCRIPTION
Fixes https://github.com/driftingly/rector-laravel/issues/133

We simply ignored this type of PHPStan error in the core Rector as well, we just needed to update the error pattern.