### PR TITLE
Adds AppEnvironmentComparisonToParameterRector rule

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -194,7 +194,7 @@ Convert migrations to anonymous classes.
 
 ## AppEnvironmentComparisonToParameterRector
 
-Replace `$app->environment() === 'local'` with `$app->environment('local'])`
+Replace `$app->environment() === 'local'` with `$app->environment('local')`
 
 - class: [`RectorLaravel\Rector\Expr\AppEnvironmentComparisonToParameterRector`](../src/Rector/Expr/AppEnvironmentComparisonToParameterRector.php)
 

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 39 Rules Overview
+# 40 Rules Overview
 
 ## AddArgumentDefaultValueRector
 
@@ -188,6 +188,19 @@ Convert migrations to anonymous classes.
      // ...
 -}
 +};
+```
+
+<br>
+
+## AppEnvironmentComparisonToParameterRector
+
+Replace `$app->environment() === 'local'` with `$app->environment('local'])`
+
+- class: [`RectorLaravel\Rector\Expr\AppEnvironmentComparisonToParameterRector`](../src/Rector/Expr/AppEnvironmentComparisonToParameterRector.php)
+
+```diff
+-$app->environment() === 'production';
++$app->environment('production');
 ```
 
 <br>

--- a/src/Rector/Expr/AppEnvironmentComparisonToParameterRector.php
+++ b/src/Rector/Expr/AppEnvironmentComparisonToParameterRector.php
@@ -21,7 +21,7 @@ class AppEnvironmentComparisonToParameterRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Replace `$app->environment() === \'local\'` with `$app->environment(\'local\'])`',
+            'Replace `$app->environment() === \'local\'` with `$app->environment(\'local\')`',
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'

--- a/src/Rector/Expr/AppEnvironmentComparisonToParameterRector.php
+++ b/src/Rector/Expr/AppEnvironmentComparisonToParameterRector.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\Expr;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\BinaryOp\Equal;
+use PhpParser\Node\Expr\BinaryOp\Identical;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\Expr\AppEnvironmentComparisonToParameterRector\AppEnvironmentComparisonToParameterRectorTest
+ */
+class AppEnvironmentComparisonToParameterRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace `$app->environment() === \'local\'` with `$app->environment(\'local\'])`',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+$app->environment() === 'production';
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+$app->environment('production');
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Expr::class];
+    }
+
+    public function refactor(Node $node): Expr\MethodCall|Expr\StaticCall|null
+    {
+        if (! $node instanceof Identical && ! $node instanceof Equal) {
+            return null;
+        }
+
+        /** @var Node\Expr\MethodCall|Node\Expr\StaticCall|null $methodCall */
+        $methodCall = array_values(
+            array_filter(
+                [$node->left, $node->right],
+                fn ($node) => ($node instanceof Node\Expr\MethodCall || $node instanceof Node\Expr\StaticCall) && $this->isName(
+                    $node->name,
+                    'environment'
+                )
+            )
+        )[0] ?? null;
+
+        if ($methodCall === null || ! $this->validMethodCall($methodCall)) {
+            return null;
+        }
+
+        /** @var Expr $otherNode */
+        $otherNode = array_values(
+            array_filter([$node->left, $node->right], static fn ($node) => $node !== $methodCall)
+        )[0] ?? null;
+
+        if (! $otherNode instanceof Node\Scalar\String_) {
+            return null;
+        }
+
+        // make sure the method call has no arguments
+        if ($methodCall->getArgs() !== []) {
+            return null;
+        }
+
+        $methodCall->args[] = new Node\Arg($otherNode);
+
+        return $methodCall;
+    }
+
+    private function validMethodCall(Expr\MethodCall|Expr\StaticCall $methodCall): bool
+    {
+        return match (true) {
+            $methodCall instanceof Node\Expr\MethodCall && $this->isObjectType(
+                $methodCall->var,
+                new ObjectType('Illuminate\Contracts\Foundation\Application')
+            ) => true,
+            $methodCall instanceof Node\Expr\StaticCall && $this->isObjectType(
+                $methodCall->class,
+                new ObjectType('Illuminate\Support\Facades\App')
+            ) => true,
+            $methodCall instanceof Node\Expr\StaticCall && $this->isObjectType(
+                $methodCall->class,
+                new ObjectType('App')
+            ) => true,
+            default => false,
+        };
+    }
+}

--- a/tests/Rector/Expr/AppEnvironmentComparisonToParameterRector/AppEnvironmentComparisonToParameterRectorTest.php
+++ b/tests/Rector/Expr/AppEnvironmentComparisonToParameterRector/AppEnvironmentComparisonToParameterRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\Expr\AppEnvironmentComparisonToParameterRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AppEnvironmentComparisonToParameterRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Expr/AppEnvironmentComparisonToParameterRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Expr/AppEnvironmentComparisonToParameterRector/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Expr\AppEnvironmentComparisonToParameterRector\Fixture;
+
+/** @var \Illuminate\Contracts\Foundation\Application $app */
+$app->environment() === 'production';
+'staging' == $app->environment();
+
+if ($app->environment() === 'production') {
+}
+
+\Illuminate\Support\Facades\App::environment() === 'production';
+\App::environment() === 'production';
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Expr\AppEnvironmentComparisonToParameterRector\Fixture;
+
+/** @var \Illuminate\Contracts\Foundation\Application $app */
+$app->environment('production');
+$app->environment('staging');
+
+if ($app->environment('production')) {
+}
+
+\Illuminate\Support\Facades\App::environment('production');
+\App::environment('production');
+
+?>

--- a/tests/Rector/Expr/AppEnvironmentComparisonToParameterRector/Fixture/skip_if_already_using_parameter.php.inc
+++ b/tests/Rector/Expr/AppEnvironmentComparisonToParameterRector/Fixture/skip_if_already_using_parameter.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Expr\AppEnvironmentComparisonToParameterRector\Fixture;
+
+/** @var \Illuminate\Contracts\Foundation\Application $app */
+$app->environment('production') === true;
+
+?>

--- a/tests/Rector/Expr/AppEnvironmentComparisonToParameterRector/Fixture/skip_if_not_application_object.php.inc
+++ b/tests/Rector/Expr/AppEnvironmentComparisonToParameterRector/Fixture/skip_if_not_application_object.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Expr\AppEnvironmentComparisonToParameterRector\Fixture;
+
+$app->environment() === 'production';
+
+?>

--- a/tests/Rector/Expr/AppEnvironmentComparisonToParameterRector/Fixture/skip_if_not_comparing_to_string.php.inc
+++ b/tests/Rector/Expr/AppEnvironmentComparisonToParameterRector/Fixture/skip_if_not_comparing_to_string.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Expr\AppEnvironmentComparisonToParameterRector\Fixture;
+
+$app->environment() === true;
+
+?>

--- a/tests/Rector/Expr/AppEnvironmentComparisonToParameterRector/Fixture/skip_if_not_using_facade.php.inc
+++ b/tests/Rector/Expr/AppEnvironmentComparisonToParameterRector/Fixture/skip_if_not_using_facade.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Expr\AppEnvironmentComparisonToParameterRector\Fixture;
+
+Illuminate\Contracts\Foundation\Application::environment() === 'production';
+
+?>

--- a/tests/Rector/Expr/AppEnvironmentComparisonToParameterRector/config/configured_rule.php
+++ b/tests/Rector/Expr/AppEnvironmentComparisonToParameterRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+use RectorLaravel\Rector\Expr\AppEnvironmentComparisonToParameterRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(AppEnvironmentComparisonToParameterRector::class);
+};


### PR DESCRIPTION
Creates the following rule:

## AppEnvironmentComparisonToParameterRector

Replace `$app->environment() === 'local'` with `$app->environment('local'])`

- class: [`RectorLaravel\Rector\Expr\AppEnvironmentComparisonToParameterRector`](../src/Rector/Expr/AppEnvironmentComparisonToParameterRector.php)

```diff
-$app->environment() === 'production';
+$app->environment('production');
```

This rule will handle scenarios such as if the Facade is used or the Application contract.