### PR TITLE
Adds UseComponentPropertyWithinCommandsRector rule

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 40 Rules Overview
+# 41 Rules Overview
 
 ## AddArgumentDefaultValueRector
 
@@ -969,6 +969,33 @@ Unify Model `$dates` property with `$casts`
      ];
 -
 -    protected $dates = ['birthday'];
+ }
+```
+
+<br>
+
+## UseComponentPropertyWithinCommandsRector
+
+Use `$this->components` property within commands
+
+- class: [`RectorLaravel\Rector\MethodCall\UseComponentPropertyWithinCommandsRector`](../src/Rector/MethodCall/UseComponentPropertyWithinCommandsRector.php)
+
+```diff
+ use Illuminate\Console\Command;
+
+ class CommandWithComponents extends Command
+ {
+     public function handle()
+     {
+-        $this->ask('What is your name?');
+-        $this->line('A line!');
+-        $this->info('Info!');
+-        $this->error('Error!');
++        $this->components->ask('What is your name?');
++        $this->components->line('A line!');
++        $this->components->info('Info!');
++        $this->components->error('Error!');
+     }
  }
 ```
 

--- a/tests/Rector/MethodCall/UseComponentPropertyWithinCommandsRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/UseComponentPropertyWithinCommandsRector/Fixture/fixture.php.inc
@@ -1,0 +1,57 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\UseComponentPropertyWithinCommandsRector\Fixture;
+
+use Illuminate\Console\Command;
+
+class CommandWithComponents extends Command
+{
+    public function handle()
+    {
+        $this->ask('What is your name?');
+        $this->line('Thank you!');
+        $this->info('Thank you!');
+        $this->error('Thank you!');
+        $this->warn('Thank you!');
+        $this->confirm('Thank you!');
+        $this->askWithCompletion('Thank you!');
+        $this->choice('Thank you!');
+        $this->alert('Thank you!');
+    }
+
+    public function test()
+    {
+        $this->ask('What is your name?');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\UseComponentPropertyWithinCommandsRector\Fixture;
+
+use Illuminate\Console\Command;
+
+class CommandWithComponents extends Command
+{
+    public function handle()
+    {
+        $this->components->ask('What is your name?');
+        $this->components->line('Thank you!');
+        $this->components->info('Thank you!');
+        $this->components->error('Thank you!');
+        $this->components->warn('Thank you!');
+        $this->components->confirm('Thank you!');
+        $this->components->askWithCompletion('Thank you!');
+        $this->components->choice('Thank you!');
+        $this->components->alert('Thank you!');
+    }
+
+    public function test()
+    {
+        $this->components->ask('What is your name?');
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/UseComponentPropertyWithinCommandsRector/Fixture/skip_non_command_extending_classes.php.inc
+++ b/tests/Rector/MethodCall/UseComponentPropertyWithinCommandsRector/Fixture/skip_non_command_extending_classes.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\UseComponentPropertyWithinCommandsRector\Fixture;
+
+class CommandWithComponents extends Command
+{
+    public function handle()
+    {
+        $this->ask('What is your name?');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\UseComponentPropertyWithinCommandsRector\Fixture;
+
+class CommandWithComponents extends Command
+{
+    public function handle()
+    {
+        $this->ask('What is your name?');
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/UseComponentPropertyWithinCommandsRector/Fixture/skip_non_component_methods.php.inc
+++ b/tests/Rector/MethodCall/UseComponentPropertyWithinCommandsRector/Fixture/skip_non_component_methods.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\UseComponentPropertyWithinCommandsRector\Fixture;
+
+use Illuminate\Console\Command;
+
+class CommandWithComponents extends Command
+{
+    public function handle()
+    {
+        $this->test();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\UseComponentPropertyWithinCommandsRector\Fixture;
+
+use Illuminate\Console\Command;
+
+class CommandWithComponents extends Command
+{
+    public function handle()
+    {
+        $this->test();
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/UseComponentPropertyWithinCommandsRector/UseComponentPropertyWithinCommandsRectorTest.php
+++ b/tests/Rector/MethodCall/UseComponentPropertyWithinCommandsRector/UseComponentPropertyWithinCommandsRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\MethodCall\UseComponentPropertyWithinCommandsRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class UseComponentPropertyWithinCommandsRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/UseComponentPropertyWithinCommandsRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/UseComponentPropertyWithinCommandsRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(\RectorLaravel\Rector\MethodCall\UseComponentPropertyWithinCommandsRector::class);
+};


### PR DESCRIPTION
Adds a new rule to refactor commands and make use of the component property that handles using Termwind output like most of the Laravel commands have used.

## UseComponentPropertyWithinCommandsRector

Use `$this->components` property within commands

- class: [`RectorLaravel\Rector\MethodCall\UseComponentPropertyWithinCommandsRector`](../src/Rector/MethodCall/UseComponentPropertyWithinCommandsRector.php)

```diff
 use Illuminate\Console\Command;

 class CommandWithComponents extends Command
 {
     public function handle()
     {
-        $this->ask('What is your name?');
-        $this->line('A line!');
-        $this->info('Info!');
-        $this->error('Error!');
+        $this->components->ask('What is your name?');
+        $this->components->line('A line!');
+        $this->components->info('Info!');
+        $this->components->error('Error!');
     }
 }
```

Will only affect inheriting from Console commands and will only do the specific methods.