### PR TITLE
Adds the EloquentWhereTypeHintClosureParameterRector

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 40 Rules Overview
+# 41 Rules Overview
 
 ## AddArgumentDefaultValueRector
 
@@ -460,15 +460,30 @@ Convert DB Expression `__toString()` calls to `getValue()` method calls.
 
 ## EloquentMagicMethodToQueryBuilderRector
 
-Transform certain magic method calls on Eloquent Models into corresponding Query Builder method calls.
+The EloquentMagicMethodToQueryBuilderRule is designed to automatically transform certain magic method calls on Eloquent Models into corresponding Query Builder method calls.
 
 - class: [`RectorLaravel\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector`](../src/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector.php)
 
 ```diff
--User::find(1);
--User::where('email', 'test@test.com')->first();
-+User::query()->find(1);
-+User::query()->where('email', 'test@test.com')->first();
+ use App\Models\User;
+
+-$user = User::find(1);
++$user = User::query()->find(1);
+```
+
+<br>
+
+## EloquentWhereTypeHintClosureParameterRector
+
+Change typehint of closure parameter in where method of Eloquent Builder
+
+- class: [`RectorLaravel\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector`](../src/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector.php)
+
+```diff
+-$query->where(function ($query) {
++$query->where(function (\Illuminate\Contracts\Database\Eloquent\Builder $query) {
+     $query->where('id', 1);
+ });
 ```
 
 <br>

--- a/src/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector.php
+++ b/src/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\MethodCall;
+
+use PhpParser\Node;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector\EloquentWhereTypeHintClosureParameterRectorTest
+ */
+class EloquentWhereTypeHintClosureParameterRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change typehint of closure parameter in where method of Eloquent Builder',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+$query->where(function ($query) {
+    $query->where('id', 1);
+});
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+$query->where(function (\Illuminate\Contracts\Database\Eloquent\Builder $query) {
+    $query->where('id', 1);
+});
+CODE_SAMPLE
+                    ,
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Node\Expr\MethodCall::class, Node\Expr\StaticCall::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node instanceof Node\Expr\MethodCall && ! $node instanceof Node\Expr\StaticCall) {
+            return null;
+        }
+
+        if ($this->isWhereMethodWithClosureOrArrowFunction($node)) {
+            $this->changeClosureParamType($node);
+
+            return $node;
+        }
+
+        return null;
+    }
+
+    private function isWhereMethodWithClosureOrArrowFunction(
+        Node\Expr\MethodCall|Node\Expr\StaticCall $node
+    ): bool {
+        if (! $this->expectedObjectTypeAndMethodCall($node)) {
+            return false;
+        }
+
+        if (
+            ! ($node->getArgs()[0]->value ?? null) instanceof Node\Expr\Closure &&
+            ! ($node->getArgs()[0]->value ?? null) instanceof Node\Expr\ArrowFunction
+        ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function changeClosureParamType(Node\Expr\MethodCall|Node\Expr\StaticCall $node): void
+    {
+        /** @var Node\Expr\ArrowFunction|Node\Expr\Closure $closure */
+        $closure = $node->getArgs()[0]
+            ->value;
+
+        if (! isset($closure->getParams()[0])) {
+            return;
+        }
+
+        $param = $closure->getParams()[0];
+
+        if ($param->type instanceof Node\Name) {
+            return;
+        }
+
+        $param->type = new Node\Name\FullyQualified('Illuminate\Contracts\Database\Query\Builder');
+    }
+
+    private function expectedObjectTypeAndMethodCall(Node\Expr\MethodCall|Node\Expr\StaticCall $node): bool
+    {
+        return match (true) {
+            $node instanceof Node\Expr\MethodCall && $this->isObjectType(
+                $node->var,
+                new ObjectType('Illuminate\Contracts\Database\Query\Builder')
+            ) => true,
+            $node instanceof Node\Expr\StaticCall && $this->isObjectType(
+                $node->class,
+                new ObjectType('Illuminate\Database\Eloquent\Model')
+            ) => true,
+            default => false,
+        } && $this->isNames($node->name, ['where', 'orWhere']);
+    }
+}

--- a/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/EloquentWhereTypeHintClosureParameterRectorTest.php
+++ b/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/EloquentWhereTypeHintClosureParameterRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class EloquentWhereTypeHintClosureParameterRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/Fixture/fixture.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector\Fixture;
+
+/** @var \Illuminate\Contracts\Database\Query\Builder $query */
+$query->where(function ($query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector\Fixture;
+
+/** @var \Illuminate\Contracts\Database\Query\Builder $query */
+$query->where(function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+?>

--- a/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/Fixture/fixture2.php.inc
+++ b/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/Fixture/fixture2.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector\Fixture;
+
+class User extends \Illuminate\Database\Eloquent\Model
+{
+
+}
+
+User::where(function ($query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector\Fixture;
+
+class User extends \Illuminate\Database\Eloquent\Model
+{
+
+}
+
+User::where(function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+?>

--- a/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/Fixture/fixture3.php.inc
+++ b/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/Fixture/fixture3.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector\Fixture;
+
+/** @var \Illuminate\Contracts\Database\Query\Builder $query */
+$query->where(fn ($query) =>
+    $query->where('id', 1)
+        ->orWhere('id', 2)
+);
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector\Fixture;
+
+/** @var \Illuminate\Contracts\Database\Query\Builder $query */
+$query->where(fn (\Illuminate\Contracts\Database\Query\Builder $query) =>
+    $query->where('id', 1)
+        ->orWhere('id', 2)
+);
+
+?>

--- a/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/Fixture/skip_non_closure_argument.php.inc
+++ b/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/Fixture/skip_non_closure_argument.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+/** @var \Illuminate\Contracts\Database\Query\Builder $query */
+$query->where('name', 'a');
+
+class User extends \Illuminate\Database\Eloquent\Model
+{
+
+}
+
+User::where('name', 'a');
+
+?>

--- a/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/Fixture/skip_non_query_object.php.inc
+++ b/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/Fixture/skip_non_query_object.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector\Fixture;
+
+$obj->whereHas('posts', fn ($query) =>
+    $query->where('is_published', true)
+);
+
+RandomClass::whereHas('posts', fn ($query) =>
+    $query->where('is_published', true)
+);
+
+?>

--- a/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(\RectorLaravel\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector::class);
+};


### PR DESCRIPTION
Adds a new rule to help add type hinting in a similar way to #138 

## EloquentWhereTypeHintClosureParameterRector

Change typehint of closure parameter in where method of Eloquent Builder

- class: [`RectorLaravel\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector`](../src/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector.php)

```diff
-$query->where(function ($query) {
+$query->where(function (\Illuminate\Contracts\Database\Eloquent\Builder $query) {
     $query->where('id', 1);
 });
```

Covers both static use with a Model and the instant's use on the builder.