### PR TITLE
Adds the EloquentOrderByToLatestOrOldestRector rule

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 40 Rules Overview
+# 41 Rules Overview
 
 ## AddArgumentDefaultValueRector
 
@@ -469,6 +469,24 @@ Transform certain magic method calls on Eloquent Models into corresponding Query
 -User::where('email', 'test@test.com')->first();
 +User::query()->find(1);
 +User::query()->where('email', 'test@test.com')->first();
+
+<br>
+
+## EloquentOrderByToLatestOrOldestRector
+
+Changes `orderBy()` to `latest()` or `oldest()`
+
+- class: [`RectorLaravel\Rector\MethodCall\EloquentOrderByToLatestOrOldestRector`](../src/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector.php)
+
+```diff
+ use Illuminate\Database\Eloquent\Builder;
+
+-$builder->orderBy('created_at');
+-$builder->orderBy('created_at', 'desc');
+-$builder->orderBy('deleted_at');
++$builder->latest();
++$builder->oldest();
++$builder->latest('deleted_at');
 ```
 
 <br>

--- a/src/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector.php
+++ b/src/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\MethodCall\EloquentOrderByToLatestOrOldestRector\EloquentOrderByToLatestOrOldestRectorTest
+ */
+class EloquentOrderByToLatestOrOldestRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes orderBy() to latest() or oldest()',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Builder;
+
+$builder->orderBy('created_at');
+$builder->orderBy('created_at', 'desc');
+$builder->orderBy('deleted_at');
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Builder;
+
+$builder->latest();
+$builder->oldest();
+$builder->latest('deleted_at');
+CODE_SAMPLE
+                    ,
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node instanceof MethodCall) {
+            return null;
+        }
+
+        if ($this->isOrderByMethodCall($node)) {
+            return $this->convertOrderByToLatest($node);
+        }
+
+        return null;
+    }
+
+    private function isOrderByMethodCall(MethodCall $methodCall): bool
+    {
+        // Check if it's a method call to `orderBy`
+
+        return $this->isObjectType($methodCall->var, new ObjectType('Illuminate\Database\Query\Builder'))
+            && $methodCall->name instanceof Node\Identifier
+            && ($methodCall->name->name === 'orderBy' || $methodCall->name->name === 'orderByDesc')
+            && count($methodCall->args) > 0;
+    }
+
+    private function convertOrderByToLatest(MethodCall $methodCall): MethodCall
+    {
+        if (! isset($methodCall->args[0]) && ! $methodCall->args[0] instanceof Node\VariadicPlaceholder) {
+            return $methodCall;
+        }
+
+        $columnVar = $methodCall->args[0]->value ?? null;
+        if ($columnVar === null) {
+            return $methodCall;
+        }
+
+        $direction = $methodCall->args[1]->value->value ?? 'asc';
+        if ($this->isName($methodCall->name, 'orderByDesc')) {
+            $newMethod = 'oldest';
+        } else {
+            $newMethod = $direction === 'asc' ? 'latest' : 'oldest';
+        }
+        if ($columnVar instanceof Node\Scalar\String_ && $columnVar->value === 'created_at') {
+            $methodCall->name = new Node\Identifier($newMethod);
+            $methodCall->args = [];
+
+            return $methodCall;
+        }
+
+        if ($columnVar instanceof Node\Scalar\String_) {
+            $methodCall->name = new Node\Identifier($newMethod);
+            $methodCall->args = [new Node\Arg(new Node\Scalar\String_($columnVar->value))];
+
+            return $methodCall;
+        }
+
+        $methodCall->name = new Node\Identifier($newMethod);
+        $methodCall->args = [new Node\Arg($columnVar)];
+
+        return $methodCall;
+    }
+}

--- a/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/EloquentOrderByToLatestOrOldestRectorTest.php
+++ b/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/EloquentOrderByToLatestOrOldestRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\MethodCall\EloquentOrderByToLatestOrOldestRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class EloquentOrderByToLatestOrOldestRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/Fixture/fixture.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Cast\DatabaseExpressionCastsToMethodCall\Fixture;
+
+use Illuminate\Database\Query\Builder;
+
+$column = 'tested_at';
+
+/** @var Builder $query */
+$query->orderBy('created_at');
+$query->orderBy('created_at', 'desc');
+$query->orderBy('submitted_at');
+$query->orderByDesc('submitted_at');
+$query->orderBy($column);
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Cast\DatabaseExpressionCastsToMethodCall\Fixture;
+
+use Illuminate\Database\Query\Builder;
+
+$column = 'tested_at';
+
+/** @var Builder $query */
+$query->latest();
+$query->oldest();
+$query->latest('submitted_at');
+$query->oldest('submitted_at');
+$query->latest($column);
+
+?>

--- a/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/Fixture/skip_if_not_eloquent_builder.php.inc
+++ b/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/Fixture/skip_if_not_eloquent_builder.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Cast\DatabaseExpressionCastsToMethodCall\Fixture;
+
+$query->orderBy('created_at');
+
+?>

--- a/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/Fixture/skip_if_not_enough_arguments.php.inc
+++ b/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/Fixture/skip_if_not_enough_arguments.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Cast\DatabaseExpressionCastsToMethodCall\Fixture;
+
+use Illuminate\Database\Query\Builder;
+
+/** @var Builder $query */
+$query->orderBy();
+
+?>

--- a/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\MethodCall\EloquentOrderByToLatestOrOldestRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(EloquentOrderByToLatestOrOldestRector::class);
+};


### PR DESCRIPTION
Created a new rule for swapping out `orderBy` or `orderByDesc` to use `latest` or `oldest` instead.

## EloquentOrderByToLatestOrOldestRector

Changes `orderBy()` to `latest()` or `oldest()`

- class: [`RectorLaravel\Rector\MethodCall\EloquentOrderByToLatestOrOldestRector`](../src/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector.php)

```diff
 use Illuminate\Database\Eloquent\Builder;

-$builder->orderBy('created_at');
-$builder->orderBy('created_at', 'desc');
-$builder->orderBy('deleted_at');
+$builder->latest();
+$builder->oldest();
+$builder->latest('deleted_at');
```