### PR TITLE
Fixes a mix up between latest() and oldest()

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -498,9 +498,9 @@ Changes `orderBy()` to `latest()` or `oldest()`
 -$builder->orderBy('created_at');
 -$builder->orderBy('created_at', 'desc');
 -$builder->orderBy('deleted_at');
-+$builder->latest();
 +$builder->oldest();
-+$builder->latest('deleted_at');
++$builder->latest();
++$builder->oldest('deleted_at');
 ```
 
 <br>

--- a/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/Fixture/fixture.php.inc
@@ -24,10 +24,10 @@ use Illuminate\Database\Query\Builder;
 $column = 'tested_at';
 
 /** @var Builder $query */
-$query->latest();
 $query->oldest();
-$query->latest('submitted_at');
+$query->latest();
 $query->oldest('submitted_at');
-$query->latest($column);
+$query->latest('submitted_at');
+$query->oldest($column);
 
 ?>


### PR DESCRIPTION
Fixes a mistake with `latest()` and `oldest()` being the wrong way around.

Brough up as a problem in #142