### PR TITLE
Allow configuring EloquentOrderByToLatestOrOldestRector

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -499,16 +499,15 @@ Changes `orderBy()` to `latest()` or `oldest()`
 
 declare(strict_types=1);
 
-use RectorLaravel\Rector\PropertyFetch\EloquentOrderByToLatestOrOldestRector;
+use RectorLaravel\Rector\MethodCall\EloquentOrderByToLatestOrOldestRector;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(EloquentOrderByToLatestOrOldestRector::class, [
         EloquentOrderByToLatestOrOldestRector::ALLOWED_PATTERNS => [
-            'created_at',
-            'date*',
-            '*datetime*',
-            '$renameable_variable_name',
+            'submitted_a*',
+            '*tested_at',
+            '$allowed_variable_name',
         ],
     ]);
 };
@@ -519,17 +518,20 @@ return static function (RectorConfig $rectorConfig): void {
 ```diff
  use Illuminate\Database\Eloquent\Builder;
 
+ $column = 'tested_at';
+
 -$builder->orderBy('created_at');
 -$builder->orderBy('created_at', 'desc');
--$builder->orderBy('date_created', 'desc');
--$builder->orderBy('created_datetime', 'asc');
--$builder->orderBy($renameable_variable_name, 'desc');
+-$builder->orderBy('submitted_at');
+-$builder->orderByDesc('submitted_at');
+-$builder->orderBy($allowed_variable_name);
 +$builder->oldest();
 +$builder->latest();
-+$builder->latest('date_created');
-+$builder->oldest('created_datetime');
-+$builder->latest($renameable_variable_name);
-$builder->orderBy('deleted_at');
++$builder->oldest('submitted_at');
++$builder->latest('submitted_at');
++$builder->oldest($allowed_variable_name);
+ $builder->orderBy($unallowed_variable_name);
+ $builder->orderBy('unallowed_column_name');
 ```
 
 <br>

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -490,17 +490,46 @@ The EloquentMagicMethodToQueryBuilderRule is designed to automatically transform
 
 Changes `orderBy()` to `latest()` or `oldest()`
 
+:wrench: **configure it!**
+
 - class: [`RectorLaravel\Rector\MethodCall\EloquentOrderByToLatestOrOldestRector`](../src/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector.php)
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use RectorLaravel\Rector\PropertyFetch\EloquentOrderByToLatestOrOldestRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(EloquentOrderByToLatestOrOldestRector::class, [
+        EloquentOrderByToLatestOrOldestRector::ALLOWED_PATTERNS => [
+            'created_at',
+            'date*',
+            '*datetime*',
+            '$renameable_variable_name',
+        ],
+    ]);
+};
+```
+
+↓
 
 ```diff
  use Illuminate\Database\Eloquent\Builder;
 
 -$builder->orderBy('created_at');
 -$builder->orderBy('created_at', 'desc');
--$builder->orderBy('deleted_at');
+-$builder->orderBy('date_created', 'desc');
+-$builder->orderBy('created_datetime', 'asc');
+-$builder->orderBy($renameable_variable_name, 'desc');
 +$builder->oldest();
 +$builder->latest();
-+$builder->oldest('deleted_at');
++$builder->latest('date_created');
++$builder->oldest('created_datetime');
++$builder->latest($renameable_variable_name);
+$builder->orderBy('deleted_at');
 ```
 
 <br>

--- a/src/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector.php
+++ b/src/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector.php
@@ -174,6 +174,7 @@ CODE_SAMPLE
     {
         $allowedPatterns = $configuration[self::ALLOWED_PATTERNS] ?? [];
         Assert::isArray($allowedPatterns);
+        Assert::allString($allowedPatterns);
 
         $this->allowedPatterns = $allowedPatterns;
     }

--- a/src/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector.php
+++ b/src/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector.php
@@ -10,6 +10,7 @@ use PHPStan\Type\ObjectType;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
 
@@ -33,24 +34,36 @@ class EloquentOrderByToLatestOrOldestRector extends AbstractRector implements Co
         return new RuleDefinition(
             'Changes orderBy() to latest() or oldest()',
             [
-                new CodeSample(
-                    <<<'CODE_SAMPLE'
+                new ConfiguredCodeSample(<<<'CODE_SAMPLE'
 use Illuminate\Database\Eloquent\Builder;
+
+$column = 'tested_at';
 
 $builder->orderBy('created_at');
 $builder->orderBy('created_at', 'desc');
-$builder->orderBy('deleted_at');
+$builder->orderBy('submitted_at');
+$builder->orderByDesc('submitted_at');
+$builder->orderBy($allowed_variable_name);
+$builder->orderBy($unallowed_variable_name);
+$builder->orderBy('unallowed_column_name');
 CODE_SAMPLE
-                    ,
-                    <<<'CODE_SAMPLE'
+,<<<'CODE_SAMPLE'
 use Illuminate\Database\Eloquent\Builder;
+
+$column = 'tested_at';
 
 $builder->oldest();
 $builder->latest();
-$builder->oldest('deleted_at');
+$builder->oldest('submitted_at');
+$builder->latest('submitted_at');
+$builder->oldest($allowed_variable_name);
+$builder->orderBy($unallowed_variable_name);
+$builder->orderBy('unallowed_column_name');
 CODE_SAMPLE
-                    ,
-                ),
+, [self::ALLOWED_PATTERNS => [
+    'submitted_a*',
+    '*tested_at',
+    '$allowed_variable_name',]]),
             ]
         );
     }

--- a/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/Fixture/fixture.php.inc
@@ -11,7 +11,9 @@ $query->orderBy('created_at');
 $query->orderBy('created_at', 'desc');
 $query->orderBy('submitted_at');
 $query->orderByDesc('submitted_at');
-$query->orderBy($column);
+$query->orderBy($renameable_variable_name);
+$query->orderBy($unrenameable_variable_name);
+$query->orderBy('disallowed_column_name');
 
 ?>
 -----
@@ -28,6 +30,8 @@ $query->oldest();
 $query->latest();
 $query->oldest('submitted_at');
 $query->latest('submitted_at');
-$query->oldest($column);
+$query->oldest($renameable_variable_name);
+$query->orderBy($unrenameable_variable_name);
+$query->orderBy('disallowed_column_name');
 
 ?>

--- a/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/Fixture/fixture.php.inc
@@ -12,8 +12,6 @@ $query->orderBy('created_at', 'desc');
 $query->orderBy('submitted_at');
 $query->orderByDesc('submitted_at');
 $query->orderBy($allowed_variable_name);
-$query->orderBy($unallowed_variable_name);
-$query->orderBy('unallowed_column_name');
 
 ?>
 -----
@@ -31,7 +29,5 @@ $query->latest();
 $query->oldest('submitted_at');
 $query->latest('submitted_at');
 $query->oldest($allowed_variable_name);
-$query->orderBy($unallowed_variable_name);
-$query->orderBy('unallowed_column_name');
 
 ?>

--- a/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/Fixture/fixture.php.inc
@@ -11,9 +11,9 @@ $query->orderBy('created_at');
 $query->orderBy('created_at', 'desc');
 $query->orderBy('submitted_at');
 $query->orderByDesc('submitted_at');
-$query->orderBy($renameable_variable_name);
-$query->orderBy($unrenameable_variable_name);
-$query->orderBy('disallowed_column_name');
+$query->orderBy($allowed_variable_name);
+$query->orderBy($unallowed_variable_name);
+$query->orderBy('unallowed_column_name');
 
 ?>
 -----
@@ -30,8 +30,8 @@ $query->oldest();
 $query->latest();
 $query->oldest('submitted_at');
 $query->latest('submitted_at');
-$query->oldest($renameable_variable_name);
-$query->orderBy($unrenameable_variable_name);
-$query->orderBy('disallowed_column_name');
+$query->oldest($allowed_variable_name);
+$query->orderBy($unallowed_variable_name);
+$query->orderBy('unallowed_column_name');
 
 ?>

--- a/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/Fixture/skip_if_column_not_allowed.php.inc
+++ b/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/Fixture/skip_if_column_not_allowed.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Cast\DatabaseExpressionCastsToMethodCall\Fixture;
+
+$query->orderBy($unallowed_variable_name);
+$query->orderBy('unallowed_column_name');
+
+?>

--- a/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/config/configured_rule.php
@@ -15,7 +15,7 @@ return static function (RectorConfig $rectorConfig): void {
                 'created_at',
                 'submitted_a*',
                 '*tested_at',
-                '$renameable_variable_name',
+                '$allowed_variable_name',
             ],
         ],
     );

--- a/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector/config/configured_rule.php
@@ -8,5 +8,15 @@ use RectorLaravel\Rector\MethodCall\EloquentOrderByToLatestOrOldestRector;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
 
-    $rectorConfig->rule(EloquentOrderByToLatestOrOldestRector::class);
+    $rectorConfig->ruleWithConfiguration(
+        EloquentOrderByToLatestOrOldestRector::class,
+        [
+            EloquentOrderByToLatestOrOldestRector::ALLOWED_PATTERNS => [
+                'created_at',
+                'submitted_a*',
+                '*tested_at',
+                '$renameable_variable_name',
+            ],
+        ],
+    );
 };


### PR DESCRIPTION
Resolves #147.

- Allows an `ALLOWED_PATTERNS` array of strings to apply this rule to
- Adds additional test items for variable handling

#### Notes

- The way this is implemented, it will always change `created_at` columns (as it did before)
- Because static analysis cannot get the value of a variable, we instead allow for specifying variable names

#### Tested

- Current test scenario
- Scenario where no rule configuration is present