### PR TITLE
Add JsonCallToExplicitJsonCallRector

### DIFF
--- a/src/Rector/MethodCall/JsonCallToExplicitJsonCallRector.php
+++ b/src/Rector/MethodCall/JsonCallToExplicitJsonCallRector.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\MethodCall\JsonCallToExplicitJsonCallRector\JsonCallToExplicitJsonCallRectorTest
+ */
+final class JsonCallToExplicitJsonCallRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change method calls from $this->json to $this->postJson, $this->putJson, etc.',
+            [
+                new CodeSample(
+                    // code before
+                    '$this->json("POST", "/api/v1/users", $data);',
+                    // code after
+                    '§this->postJson("/api/v1/users", $data);'
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if ($node instanceof MethodCall) {
+            return $this->updateCall($node);
+        }
+
+        return null;
+    }
+
+    private function updateCall(MethodCall $methodCall): ?MethodCall
+    {
+        $methodCallName = $this->getName($methodCall->name);
+        if ($methodCallName === null) {
+            return null;
+        }
+
+        if (! $this->isObjectType(
+            $methodCall->var,
+            new ObjectType('Illuminate\Foundation\Testing\Concerns\MakesHttpRequests')
+        )) {
+            return null;
+        }
+
+        if ($methodCallName !== 'json') {
+            return null;
+        }
+
+        $arg = $methodCall->getArgs()[0];
+        $argValue = $arg->value;
+
+        if (! $argValue instanceof Node\Scalar\String_) {
+            return null;
+        }
+
+        $supportedMethods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
+
+        if (in_array($argValue->value, $supportedMethods, true)) {
+            $methodCall->name = new Identifier(strtolower($argValue->value) . 'Json');
+            $methodCall->args = array_slice($methodCall->args, 1);
+
+            return $methodCall;
+        }
+
+        return null;
+    }
+}

--- a/tests/Rector/MethodCall/JsonCallToExplicitJsonCallRector/Fixture/fixture_with_json_calls.php.inc
+++ b/tests/Rector/MethodCall/JsonCallToExplicitJsonCallRector/Fixture/fixture_with_json_calls.php.inc
@@ -1,0 +1,78 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\JsonCallToExplicitJsonCallRector\Fixture;
+
+class FixtureWithJsonCalls
+{
+    public function testGet(\Illuminate\Foundation\Testing\Concerns\MakesHttpRequests $http)
+    {
+        $http->json('get', '/');
+    }
+
+    public function testPost(\Illuminate\Foundation\Testing\Concerns\MakesHttpRequests $http)
+    {
+        $http->json('post', '/');
+    }
+
+    public function testPut(\Illuminate\Foundation\Testing\Concerns\MakesHttpRequests $http)
+    {
+        $http->json('put', '/');
+    }
+
+    public function testPatch(\Illuminate\Foundation\Testing\Concerns\MakesHttpRequests $http)
+    {
+        $http->json('patch', '/');
+    }
+
+    public function testDelete(\Illuminate\Foundation\Testing\Concerns\MakesHttpRequests $http)
+    {
+        $http->json('delete', '/');
+    }
+
+    public function testOptions(\Illuminate\Foundation\Testing\Concerns\MakesHttpRequests $http)
+    {
+        $http->json('options', '/');
+    }
+}
+
+?>
+---
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\AssertStatusToAssertMethodRector\Fixture;
+
+class FixtureWithJsonCalls
+{
+    public function testGet(\Illuminate\Foundation\Testing\Concerns\MakesHttpRequests $http)
+    {
+        $http->getJson('/');
+    }
+
+    public function testPost(\Illuminate\Foundation\Testing\Concerns\MakesHttpRequests $http)
+    {
+        $http->postJson('/');
+    }
+
+    public function testPut(\Illuminate\Foundation\Testing\Concerns\MakesHttpRequests $http)
+    {
+        $http->putJson('/');
+    }
+
+    public function testPatch(\Illuminate\Foundation\Testing\Concerns\MakesHttpRequests $http)
+    {
+        $http->patchJson('/');
+    }
+
+    public function testDelete(\Illuminate\Foundation\Testing\Concerns\MakesHttpRequests $http)
+    {
+        $http->deleteJson('/');
+    }
+
+    public function testOptions(\Illuminate\Foundation\Testing\Concerns\MakesHttpRequests $http)
+    {
+        $http->optionsJson('/');
+    }
+}
+
+?>
+

--- a/tests/Rector/MethodCall/JsonCallToExplicitJsonCallRector/Fixture/fixture_with_json_calls_to_skip.php.inc
+++ b/tests/Rector/MethodCall/JsonCallToExplicitJsonCallRector/Fixture/fixture_with_json_calls_to_skip.php.inc
@@ -1,0 +1,48 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\JsonCallToExplicitJsonCallRector\Fixture;
+
+class FixtureWithJsonCalls
+{
+    public function testHead(\Illuminate\Foundation\Testing\Concerns\MakesHttpRequests $http)
+    {
+        $http->json('head', '/');
+    }
+
+    public function testTrace(\Illuminate\Foundation\Testing\Concerns\MakesHttpRequests $http)
+    {
+        $http->json('trace', '/');
+    }
+
+    public function testConnect(\Illuminate\Foundation\Testing\Concerns\MakesHttpRequests $http)
+    {
+        $http->json('connect', '/');
+    }
+}
+
+?>
+---
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\AssertStatusToAssertMethodRector\Fixture;
+
+class FixtureWithJsonCalls
+{
+    public function testHead(\Illuminate\Foundation\Testing\Concerns\MakesHttpRequests $http)
+    {
+        $http->json('head', '/');
+    }
+
+    public function testTrace(\Illuminate\Foundation\Testing\Concerns\MakesHttpRequests $http)
+    {
+        $http->json('trace', '/');
+    }
+
+    public function testConnect(\Illuminate\Foundation\Testing\Concerns\MakesHttpRequests $http)
+    {
+        $http->json('connect', '/');
+    }
+}
+
+?>
+

--- a/tests/Rector/MethodCall/JsonCallToExplicitJsonCallRector/JsonCallToExplicitJsonCallRectorTest.php
+++ b/tests/Rector/MethodCall/JsonCallToExplicitJsonCallRector/JsonCallToExplicitJsonCallRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\MethodCall\JsonCallToExplicitJsonCallRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class JsonCallToExplicitJsonCallRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/JsonCallToExplicitJsonCallRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/JsonCallToExplicitJsonCallRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\MethodCall\JsonCallToExplicitJsonCallRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(JsonCallToExplicitJsonCallRector::class);
+};


### PR DESCRIPTION
Adds the following rule:
## JsonCallToExplicitJsonCallRector

Changes Method Calls of `$this->json()` in PHPUnit Feature Tests to the more explicit version `$this->postJson()`, $this->putJson(), etc..
 

* class: [`\RectorLaravel\Rector\MethodCall\JsonCallToExplicitJsonCallRector`](../src/Rector/MethodCall/JsonCallToExplicitJsonCallRector.php)

```diff
-$this->json("POST", "/api/v1/users", $data);
+$this->postJson("/api/v1/users", $data);

-$this->json("PUT", "/api/v1/users", $data);
+$this->putJson("/api/v1/users", $data);
```

