### PR TITLE
[Laravel100] Swap assertTimesSent with assertSentTimes

### DIFF
--- a/config/sets/laravel100.php
+++ b/config/sets/laravel100.php
@@ -11,6 +11,7 @@ use Rector\Renaming\ValueObject\RenameProperty;
 use RectorLaravel\Rector\Cast\DatabaseExpressionCastsToMethodCallRector;
 use RectorLaravel\Rector\Class_\UnifyModelDatesWithCastsRector;
 use RectorLaravel\Rector\MethodCall\DatabaseExpressionToStringToMethodCallRector;
+use RectorLaravel\Rector\StaticCall\ReplaceAssertTimesSendWithAssertSentTimesRector;
 
 // see https://laravel.com/docs/10.x/upgrade
 return static function (RectorConfig $rectorConfig): void {
@@ -22,6 +23,9 @@ return static function (RectorConfig $rectorConfig): void {
     // https://github.com/laravel/framework/pull/44784/files
     $rectorConfig->rule(DatabaseExpressionCastsToMethodCallRector::class);
     $rectorConfig->rule(DatabaseExpressionToStringToMethodCallRector::class);
+
+    // https://github.com/laravel/framework/pull/41136/files
+    $rectorConfig->rule(ReplaceAssertTimesSendWithAssertSentTimesRector::class);
 
     $rectorConfig
         ->ruleWithConfiguration(RenamePropertyRector::class, [

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 46 Rules Overview
+# 47 Rules Overview
 
 ## AddArgumentDefaultValueRector
 
@@ -18,9 +18,14 @@ use RectorLaravel\ValueObject\AddArgumentDefaultValue;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->ruleWithConfiguration(AddArgumentDefaultValueRector::class, [
-        AddArgumentDefaultValueRector::ADDED_ARGUMENTS => [
-            new AddArgumentDefaultValue('SomeClass', 'someMethod', 0, false),
+    $containerConfigurator->extension('rectorConfig', [
+        [
+            'class' => AddArgumentDefaultValueRector::class,
+            'configuration' => [
+                'added_arguments' => [
+                    new AddArgumentDefaultValue('SomeClass', 'someMethod', 0, false),
+                ],
+            ],
         ],
     ]);
 };
@@ -223,8 +228,13 @@ use RectorLaravel\ValueObject\ArgumentFuncCallToMethodCall;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->ruleWithConfiguration(ArgumentFuncCallToMethodCallRector::class, [
-        new ArgumentFuncCallToMethodCall('view', 'Illuminate\Contracts\View\Factory', 'make'),
+    $containerConfigurator->extension('rectorConfig', [
+        [
+            'class' => ArgumentFuncCallToMethodCallRector::class,
+            'configuration' => [
+                new ArgumentFuncCallToMethodCall('view', 'Illuminate\Contracts\View\Factory', 'make'),
+            ],
+        ],
     ]);
 };
 ```
@@ -503,11 +513,16 @@ use RectorLaravel\Rector\MethodCall\EloquentOrderByToLatestOrOldestRector;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->ruleWithConfiguration(EloquentOrderByToLatestOrOldestRector::class, [
-        EloquentOrderByToLatestOrOldestRector::ALLOWED_PATTERNS => [
-            'submitted_a*',
-            '*tested_at',
-            '$allowed_variable_name',
+    $containerConfigurator->extension('rectorConfig', [
+        [
+            'class' => EloquentOrderByToLatestOrOldestRector::class,
+            'configuration' => [
+                'allowed_patterns' => [
+                    'submitted_a*',
+                    '*tested_at',
+                    '$allowed_variable_name',
+                ],
+            ],
         ],
     ]);
 };
@@ -787,9 +802,14 @@ use RectorLaravel\Rector\PropertyFetch\OptionalToNullsafeOperatorRector;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->ruleWithConfiguration(OptionalToNullsafeOperatorRector::class, [
-        OptionalToNullsafeOperatorRector::EXCLUDE_METHODS => [
-            'present',
+    $containerConfigurator->extension('rectorConfig', [
+        [
+            'class' => OptionalToNullsafeOperatorRector::class,
+            'configuration' => [
+                'exclude_methods' => [
+                    'present',
+                ],
+            ],
         ],
     ]);
 };
@@ -945,6 +965,19 @@ Removes the `$model` property from Factories.
 
 <br>
 
+## ReplaceAssertTimesSendWithAssertSentTimesRector
+
+Replace assertTimesSent with assertSentTimes
+
+- class: [`RectorLaravel\Rector\StaticCall\ReplaceAssertTimesSendWithAssertSentTimesRector`](../src/Rector/StaticCall/ReplaceAssertTimesSendWithAssertSentTimesRector.php)
+
+```diff
+-Notification::assertTimesSent(1, SomeNotification::class);
++Notification::assertSentTimes(SomeNotification::class, 1);
+```
+
+<br>
+
 ## ReplaceFakerInstanceWithHelperRector
 
 Replace `$this->faker` with the `fake()` helper function in Factories
@@ -1007,8 +1040,13 @@ use RectorLaravel\Rector\StaticCall\RouteActionCallableRector;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->ruleWithConfiguration(RouteActionCallableRector::class, [
-        RouteActionCallableRector::NAMESPACE => 'App\Http\Controllers',
+    $containerConfigurator->extension('rectorConfig', [
+        [
+            'class' => RouteActionCallableRector::class,
+            'configuration' => [
+                'namespace' => 'App\Http\Controllers',
+            ],
+        ],
     ]);
 };
 ```

--- a/src/Rector/StaticCall/ReplaceAssertTimesSendWithAssertSentTimesRector.php
+++ b/src/Rector/StaticCall/ReplaceAssertTimesSendWithAssertSentTimesRector.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace RectorLaravel\Rector\StaticCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\StaticCall\ReplaceAssertTimesSendWithAssertSentTimesRector\ReplaceAssertTimesSendWithAssertSentTimesRectorTest
+ */
+class ReplaceAssertTimesSendWithAssertSentTimesRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Replace assertTimesSent with assertSentTimes', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+Notification::assertTimesSent(1, SomeNotification::class);
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+Notification::assertSentTimes(SomeNotification::class, 1);
+CODE_SAMPLE,
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [StaticCall::class];
+    }
+
+    /**
+     * @param  Node\Expr\StaticCall  $node
+     */
+    public function refactor(Node $node): ?StaticCall
+    {
+
+        if (! $this->isObjectType(
+            $node->class,
+            new ObjectType('Illuminate\Support\Facades\Notification')
+        )) {
+            return null;
+        }
+
+        if ($this->getName($node->name) !== 'assertTimesSent') {
+            return null;
+        }
+
+        $node->name = new Identifier('assertSentTimes');
+
+        $node->args = array_reverse($node->args);
+
+        return $node;
+    }
+}

--- a/tests/Rector/StaticCall/ReplaceAssertTimesSendWithAssertSentTimesRector/Fixture/fixture.php.inc
+++ b/tests/Rector/StaticCall/ReplaceAssertTimesSendWithAssertSentTimesRector/Fixture/fixture.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\ReplaceAssertTimesSendWithAssertSentTimesRector\Fixture;
+
+use Illuminate\Support\Facades\Notification;
+
+Notification::assertTimesSent(1, SomeNotification::class);
+
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\ReplaceAssertTimesSendWithAssertSentTimesRector\Fixture;
+
+use Illuminate\Support\Facades\Notification;
+
+Notification::assertSentTimes(SomeNotification::class, 1);

--- a/tests/Rector/StaticCall/ReplaceAssertTimesSendWithAssertSentTimesRector/Fixture/skips_other_facades.php.inc
+++ b/tests/Rector/StaticCall/ReplaceAssertTimesSendWithAssertSentTimesRector/Fixture/skips_other_facades.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\ReplaceAssertTimesSendWithAssertSentTimesRector\Fixture;
+
+use Some\Other\Notification;
+
+Notification::assertTimesSent(1, SomeNotification::class);

--- a/tests/Rector/StaticCall/ReplaceAssertTimesSendWithAssertSentTimesRector/Fixture/skips_other_methods.php.inc
+++ b/tests/Rector/StaticCall/ReplaceAssertTimesSendWithAssertSentTimesRector/Fixture/skips_other_methods.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\ReplaceAssertTimesSendWithAssertSentTimesRector\Fixture;
+
+use Illuminate\Support\Facades\Notification;
+
+Notification::assertSentTimes(1, SomeNotification::class);

--- a/tests/Rector/StaticCall/ReplaceAssertTimesSendWithAssertSentTimesRector/ReplaceAssertTimesSendWithAssertSentTimesRectorTest.php
+++ b/tests/Rector/StaticCall/ReplaceAssertTimesSendWithAssertSentTimesRector/ReplaceAssertTimesSendWithAssertSentTimesRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\StaticCall\ReplaceAssertTimesSendWithAssertSentTimesRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReplaceAssertTimesSendWithAssertSentTimesRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/StaticCall/ReplaceAssertTimesSendWithAssertSentTimesRector/config/configured_rule.php
+++ b/tests/Rector/StaticCall/ReplaceAssertTimesSendWithAssertSentTimesRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\StaticCall\ReplaceAssertTimesSendWithAssertSentTimesRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+    $rectorConfig->importNames(importDocBlockNames: false);
+    $rectorConfig->importShortClasses(false);
+    $rectorConfig->rule(ReplaceAssertTimesSendWithAssertSentTimesRector::class);
+};


### PR DESCRIPTION
The rule should work on the Notification facade. I've added the rules to the Laravel100 config 

[PR when the method was removed for Laravel 10](https://github.com/laravel/framework/pull/41136/files#diff-79076a209637866c842a9e9db32a961de43cfa12a3dd8bdfaf95694484dcee7b)