### PR TITLE
Bump PHP and add rector to downgraded composer

### DIFF
--- a/build/composer-php-72.json
+++ b/build/composer-php-72.json
@@ -4,7 +4,8 @@
     "license": "MIT",
     "description": "Rector upgrades rules for Laravel Framework",
     "require": {
-        "php": "^7.2 || ^8.0"
+        "php": "^7.2 || ^8.0",
+        "rector/rector": "^0.18.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "description": "Rector upgrades rules for Laravel Framework",
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "rector/rector": "^0.18.5"
     },
     "require-dev": {


### PR DESCRIPTION
This PR adds the supported Rector version to the downgraded tagged version.

Bump PHP version to 8.2 after adding `LevelSetList::UP_TO_PHP_82` to Rector config.

Closes #150 