### PR TITLE
Update downgrade script for new PHP version

### DIFF
--- a/.github/workflows/downgraded_release.yaml
+++ b/.github/workflows/downgraded_release.yaml
@@ -20,7 +20,7 @@ jobs:
             -
                 uses: "shivammathur/setup-php@v2"
                 with:
-                    php-version: 8.1
+                    php-version: 8.2
                     coverage: none
 
             -   uses: "ramsey/composer-install@v2"


### PR DESCRIPTION
This PR bumps the PHP version in the downgrade action to PHP 8.2