### PR TITLE
Replaces without jobs/events/notifications to the appropriate facade

### DIFF
--- a/config/sets/laravel100.php
+++ b/config/sets/laravel100.php
@@ -12,6 +12,7 @@ use RectorLaravel\Rector\Cast\DatabaseExpressionCastsToMethodCallRector;
 use RectorLaravel\Rector\Class_\ReplaceExpectsMethodsInTestsRector;
 use RectorLaravel\Rector\Class_\UnifyModelDatesWithCastsRector;
 use RectorLaravel\Rector\MethodCall\DatabaseExpressionToStringToMethodCallRector;
+use RectorLaravel\Rector\MethodCall\ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector;
 use RectorLaravel\Rector\StaticCall\ReplaceAssertTimesSendWithAssertSentTimesRector;
 
 // see https://laravel.com/docs/10.x/upgrade
@@ -28,6 +29,7 @@ return static function (RectorConfig $rectorConfig): void {
     // https://github.com/laravel/framework/pull/41136/files
     $rectorConfig->rule(ReplaceExpectsMethodsInTestsRector::class);
     $rectorConfig->rule(ReplaceAssertTimesSendWithAssertSentTimesRector::class);
+    $rectorConfig->rule(ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector::class);
 
     $rectorConfig
         ->ruleWithConfiguration(RenamePropertyRector::class, [

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 47 Rules Overview
+# 50 Rules Overview
 
 ## AddArgumentDefaultValueRector
 
@@ -678,6 +678,19 @@ Change `app()` func calls to facade calls
 
 <br>
 
+## JsonCallToExplicitJsonCallRector
+
+Change method calls from `$this->json` to `$this->postJson,` `$this->putJson,` etc.
+
+- class: [`RectorLaravel\Rector\MethodCall\JsonCallToExplicitJsonCallRector`](../src/Rector/MethodCall/JsonCallToExplicitJsonCallRector.php)
+
+```diff
+-$this->json("POST", "/api/v1/users", $data);
++§this->postJson("/api/v1/users", $data);
+```
+
+<br>
+
 ## LumenRoutesStringActionToUsesArrayRector
 
 Changes action in rule definitions from string to array notation.
@@ -978,7 +991,6 @@ Replace assertTimesSent with assertSentTimes
 
 <br>
 
-
 ## ReplaceExpectsMethodsInTestsRector
 
 Replace expectJobs and expectEvents methods in tests
@@ -1027,6 +1039,23 @@ Replace `$this->faker` with the `fake()` helper function in Factories
          ];
      }
  }
+```
+
+<br>
+
+## ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector
+
+Replace `withoutJobs`, `withoutEvents` and `withoutNotifications` with Facade `fake`
+
+- class: [`RectorLaravel\Rector\MethodCall\ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector`](../src/Rector/MethodCall/ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector.php)
+
+```diff
+-$this->withoutJobs();
+-$this->withoutEvents();
+-$this->withoutNotifications();
++\Illuminate\Support\Facades\Bus::fake();
++\Illuminate\Support\Facades\Event::fake();
++\Illuminate\Support\Facades\Notification::fake();
 ```
 
 <br>

--- a/src/Rector/MethodCall/ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector.php
+++ b/src/Rector/MethodCall/ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace RectorLaravel\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\MethodCall\ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector\ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRectorTest
+ */
+class ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace `withoutJobs`, `withoutEvents` and `withoutNotifications` with Facade `fake`',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+$this->withoutJobs();
+$this->withoutEvents();
+$this->withoutNotifications();
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+\Illuminate\Support\Facades\Bus::fake();
+\Illuminate\Support\Facades\Event::fake();
+\Illuminate\Support\Facades\Notification::fake();
+CODE_SAMPLE,
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param  Node\Expr\MethodCall  $node
+     */
+    public function refactor(Node $node): ?StaticCall
+    {
+        if (! $this->isNames($node->name, ['withoutJobs', 'withoutEvents', 'withoutNotifications'])) {
+            return null;
+        }
+
+        if (! $this->isObjectType($node->var, new ObjectType('Illuminate\Foundation\Testing\TestCase'))) {
+            return null;
+        }
+
+        if (! $node->name instanceof Identifier) {
+            return null;
+        }
+
+        $facade = match ($node->name->name) {
+            'withoutJobs' => 'Bus',
+            'withoutEvents' => 'Event',
+            'withoutNotifications' => 'Notification',
+            default => null,
+        };
+
+        if ($facade === null) {
+            return null;
+        }
+
+        return $this->nodeFactory->createStaticCall('Illuminate\Support\Facades\\' . $facade, 'fake');
+    }
+}

--- a/tests/Rector/MethodCall/ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector/Fixture/fixture.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector\Fixture;
+
+use Illuminate\Foundation\Testing\TestCase;
+
+class SomeTest extends TestCase
+{
+    public function testSomething()
+    {
+        $this->withoutJobs();
+        $this->withoutEvents();
+        $this->withoutNotifications();
+
+        $this->get('/');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector\Fixture;
+
+use Illuminate\Foundation\Testing\TestCase;
+
+class SomeTest extends TestCase
+{
+    public function testSomething()
+    {
+        \Illuminate\Support\Facades\Bus::fake();
+        \Illuminate\Support\Facades\Event::fake();
+        \Illuminate\Support\Facades\Notification::fake();
+
+        $this->get('/');
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector/Fixture/skip_non_test_case.php.inc
+++ b/tests/Rector/MethodCall/ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector/Fixture/skip_non_test_case.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector\Fixture;
+
+
+class SkipNonTestCaseTest extends TestCase
+{
+    public function testSomething()
+    {
+        $this->withoutJobs();
+        $this->withoutEvents();
+        $this->withoutNotifications();
+
+        $this->get('/');
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector/ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRectorTest.php
+++ b/tests/Rector/MethodCall/ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector/ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\MethodCall\ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector::class);
+};


### PR DESCRIPTION
Another change related to the deprecated trait

```diff
-$this->withoutJobs();
-$this->withoutEvents();
-$this->withoutNotifications();
+\Illuminate\Support\Facades\Bus::fake();
+\Illuminate\Support\Facades\Event::fake();
+\Illuminate\Support\Facades\Notification::fake();
```

This should be pretty straight forward when used to stop no Jobs/Events/Notifications to be fired during tests.