### PR TITLE
Remove deprecated `rector/phpstan-rules`

### DIFF
--- a/build/composer-php-72.json
+++ b/build/composer-php-72.json
@@ -5,7 +5,7 @@
     "description": "Rector upgrades rules for Laravel Framework",
     "require": {
         "php": "^7.2 || ^8.0",
-        "rector/rector": "^0.18.5"
+        "rector/rector": "^0.19.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         "symplify/phpstan-rules": "^11.0",
         "symplify/phpstan-extensions": "^11.0",
         "symplify/rule-doc-generator": "^11.0",
-        "rector/phpstan-rules": "^0.6",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-webmozart-assert": "^1.1",
         "phpstan/phpstan-strict-rules": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require-dev": {
         "phpunit/phpunit": "^10.0",
         "phpstan/phpstan": "^1.8.2",
-        "symplify/phpstan-rules": "^11.0",
+        "symplify/phpstan-rules": "^12.4",
         "symplify/phpstan-extensions": "^11.0",
         "symplify/rule-doc-generator": "^11.0",
         "phpstan/extension-installer": "^1.1",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,5 @@
+includes:
+    - vendor/symplify/phpstan-rules/config/rector-rules.neon
 parameters:
     level: max
 


### PR DESCRIPTION
This PR removes the deprecated `rector/phpstan-rules` package.

https://github.com/rectorphp/phpstan-rules#deprecated---switch-to-symplifyphpstan-rules