### PR TITLE
Add method exclusions for `EloquentMagicMethodToQueryBuilderRector`

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -485,13 +485,40 @@ Convert DB Expression `__toString()` calls to `getValue()` method calls.
 
 The EloquentMagicMethodToQueryBuilderRule is designed to automatically transform certain magic method calls on Eloquent Models into corresponding Query Builder method calls.
 
+:wrench: **configure it!**
+
 - class: [`RectorLaravel\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector`](../src/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector.php)
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use RectorLaravel\Rector\MethodCall\EloquentOrderByToLatestOrOldestRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $containerConfigurator->extension('rectorConfig', [
+        [
+            'class' => EloquentMagicMethodToQueryBuilderRector::class,
+            'configuration' => [
+                'exclude_methods' => [
+                    'find',
+                    'findOrFail',
+                ],
+            ],
+        ],
+    ]);
+};
+```
+
+↓
 
 ```diff
  use App\Models\User;
 
--$user = User::find(1);
-+$user = User::query()->find(1);
+-$user = User::where('x', 1);
++$user = User::query()->where('x', 1);
 ```
 
 <br>

--- a/src/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector.php
+++ b/src/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector.php
@@ -118,7 +118,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param mixed[] $configuration
+     * @param  mixed[]  $configuration
      */
     public function configure(array $configuration): void
     {
@@ -131,7 +131,7 @@ CODE_SAMPLE
 
     public function isMagicMethod(string $className, string $methodName): bool
     {
-        if (in_array($methodName, $this->excludeMethods)) {
+        if (in_array($methodName, $this->excludeMethods, true)) {
             return false;
         }
 

--- a/src/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector.php
+++ b/src/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector.php
@@ -10,17 +10,29 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
 use PhpParser\Node;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
 use ReflectionException;
 use ReflectionMethod;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\EloquentMagicMethodToQueryBuilderRectorTest
  */
-final class EloquentMagicMethodToQueryBuilderRector extends AbstractRector
+final class EloquentMagicMethodToQueryBuilderRector extends AbstractRector implements ConfigurableRectorInterface
 {
+    /**
+     * @var string
+     */
+    final public const EXCLUDE_METHODS = 'exclude_methods';
+
+    /**
+     * @var string[]
+     */
+    private array $excludeMethods = [];
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -105,8 +117,24 @@ CODE_SAMPLE
         return $newNode;
     }
 
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        $excludeMethods = $configuration[self::EXCLUDE_METHODS] ?? $configuration;
+        Assert::isArray($excludeMethods);
+        Assert::allString($excludeMethods);
+
+        $this->excludeMethods = $excludeMethods;
+    }
+
     public function isMagicMethod(string $className, string $methodName): bool
     {
+        if (in_array($methodName, $this->excludeMethods)) {
+            return false;
+        }
+
         try {
             $reflectionMethod = new ReflectionMethod($className, $methodName);
         } catch (ReflectionException) {

--- a/stubs/Illuminate/Database/Eloquent/Builder.php
+++ b/stubs/Illuminate/Database/Eloquent/Builder.php
@@ -13,4 +13,8 @@ class Builder extends QueryBuilder
     public function publicMethodBelongsToEloquentQueryBuilder(): void
     {
     }
+
+    public function excludedPublicMethodBelongsToEloquentQueryBuilder(): void
+    {
+    }
 }

--- a/stubs/Illuminate/Database/Eloquent/Builder.php
+++ b/stubs/Illuminate/Database/Eloquent/Builder.php
@@ -14,7 +14,7 @@ class Builder extends QueryBuilder
     {
     }
 
-    public function excludedPublicMethodBelongsToEloquentQueryBuilder(): void
+    public function excludablePublicMethodBelongsToEloquentQueryBuilder(): void
     {
     }
 }

--- a/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Fixture/with_exclude_methods.php.inc
+++ b/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Fixture/with_exclude_methods.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Fixture;
+
+use RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\User;
+
+class SomeController
+{
+    public function getUser()
+    {
+        # eligible
+        $user = User::publicMethodBelongsToQueryBuilder();
+
+        # not eligible
+        $user = User::excludedPublicMethodBelongsToEloquentQueryBuilder();
+    }
+}
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Fixture;
+
+use RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\User;
+
+class SomeController
+{
+    public function getUser()
+    {
+        # eligible
+        $user = User::query()->publicMethodBelongsToQueryBuilder();
+
+        # not eligible
+        $user = User::excludedPublicMethodBelongsToEloquentQueryBuilder();
+    }
+}

--- a/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Fixture/with_exclude_methods.php.inc
+++ b/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Fixture/with_exclude_methods.php.inc
@@ -12,7 +12,7 @@ class SomeController
         $user = User::publicMethodBelongsToQueryBuilder();
 
         # not eligible
-        $user = User::excludedPublicMethodBelongsToEloquentQueryBuilder();
+        $user = User::excludablePublicMethodBelongsToEloquentQueryBuilder();
     }
 }
 -----
@@ -30,6 +30,6 @@ class SomeController
         $user = User::query()->publicMethodBelongsToQueryBuilder();
 
         # not eligible
-        $user = User::excludedPublicMethodBelongsToEloquentQueryBuilder();
+        $user = User::excludablePublicMethodBelongsToEloquentQueryBuilder();
     }
 }

--- a/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/config/configured_rule.php
+++ b/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/config/configured_rule.php
@@ -9,5 +9,10 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
     $rectorConfig->importNames(importDocBlockNames: false);
     $rectorConfig->importShortClasses(false);
-    $rectorConfig->rule(EloquentMagicMethodToQueryBuilderRector::class);
+    $rectorConfig->ruleWithConfiguration(
+        EloquentMagicMethodToQueryBuilderRector::class,
+        [
+            EloquentMagicMethodToQueryBuilderRector::EXCLUDE_METHODS => ['excludedPublicMethodBelongsToEloquentQueryBuilder'],
+        ],
+    );
 };

--- a/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/config/configured_rule.php
+++ b/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/config/configured_rule.php
@@ -12,7 +12,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(
         EloquentMagicMethodToQueryBuilderRector::class,
         [
-            EloquentMagicMethodToQueryBuilderRector::EXCLUDE_METHODS => ['excludedPublicMethodBelongsToEloquentQueryBuilder'],
+            EloquentMagicMethodToQueryBuilderRector::EXCLUDE_METHODS => ['excludablePublicMethodBelongsToEloquentQueryBuilder'],
         ],
     );
 };


### PR DESCRIPTION
Add ability to exclude methods from the rector `EloquentMagicMethodToQueryBuilderRector`

I found this beneficial for `find()` and `findOrFail()`, as these are often used in simple statements without chaining, and subjectively appear overly verbose when `::query()->` is added to them.

e.g.

```php
<?php

declare(strict_types=1);

use RectorLaravel\Rector\MethodCall\EloquentOrderByToLatestOrOldestRector;
use Rector\Config\RectorConfig;

return static function (RectorConfig $rectorConfig): void {
    $containerConfigurator->extension('rectorConfig', [
        [
            'class' => EloquentMagicMethodToQueryBuilderRector::class,
            'configuration' => [
                'exclude_methods' => [
                    'find',
                    'findOrFail',
                ],
            ],
        ],
    ]);
};
```

↓

```diff
 use App\Models\User;

$user = User::find(1); // no change

-$user = User::where('x', 1);
+$user = User::query()->where('x', 1);
```