### PR TITLE
[Laravel110] Adds ModelCastsPropertyToCastsMethodRector rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
-        LaravelSetList::LARAVEL_100
+        LaravelSetList::LARAVEL_110
     ]);
 };
 ```

--- a/config/sets/laravel110.php
+++ b/config/sets/laravel110.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\ModelCastsPropertyToCastsMethodRector;
+
+// see https://laravel.com/docs/11.x/upgrade
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../config.php');
+
+    // https://github.com/laravel/framework/pull/47237
+    $rectorConfig->rule(ModelCastsPropertyToCastsMethodRector::class);
+};

--- a/config/sets/level/up-to-laravel-110.php
+++ b/config/sets/level/up-to-laravel-110.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Set\LaravelLevelSetList;
+use RectorLaravel\Set\LaravelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([LaravelSetList::LARAVEL_110, LaravelLevelSetList::UP_TO_LARAVEL_100]);
+};

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 50 Rules Overview
+# 51 Rules Overview
 
 ## AddArgumentDefaultValueRector
 
@@ -8,41 +8,6 @@ Adds default value for arguments in defined methods.
 
 - class: [`RectorLaravel\Rector\ClassMethod\AddArgumentDefaultValueRector`](../src/Rector/ClassMethod/AddArgumentDefaultValueRector.php)
 
-```php
-<?php
-
-declare(strict_types=1);
-
-use RectorLaravel\Rector\ClassMethod\AddArgumentDefaultValueRector;
-use RectorLaravel\ValueObject\AddArgumentDefaultValue;
-use Rector\Config\RectorConfig;
-
-return static function (RectorConfig $rectorConfig): void {
-    $containerConfigurator->extension('rectorConfig', [
-        [
-            'class' => AddArgumentDefaultValueRector::class,
-            'configuration' => [
-                'added_arguments' => [
-                    new AddArgumentDefaultValue('SomeClass', 'someMethod', 0, false),
-                ],
-            ],
-        ],
-    ]);
-};
-```
-
-↓
-
-```diff
- class SomeClass
- {
--    public function someMethod($value)
-+    public function someMethod($value = false)
-     {
-     }
- }
-```
-
 <br>
 
 ## AddExtendsAnnotationToModelFactoriesRector
@@ -50,18 +15,6 @@ return static function (RectorConfig $rectorConfig): void {
 Adds the `@extends` annotation to Factories.
 
 - class: [`RectorLaravel\Rector\Class_\AddExtendsAnnotationToModelFactoriesRector`](../src/Rector/Class_/AddExtendsAnnotationToModelFactoriesRector.php)
-
-```diff
- use Illuminate\Database\Eloquent\Factories\Factory;
-
-+/**
-+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
-+ */
- class UserFactory extends Factory
- {
-     protected $model = \App\Models\User::class;
- }
-```
 
 <br>
 
@@ -71,21 +24,6 @@ Add generic return type to relations in child of `Illuminate\Database\Eloquent\M
 
 - class: [`RectorLaravel\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector`](../src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php)
 
-```diff
- use App\Account;
- use Illuminate\Database\Eloquent\Model;
- use Illuminate\Database\Eloquent\Relations\HasMany;
-
- class User extends Model
- {
-+    /** @return HasMany<Account> */
-     public function accounts(): HasMany
-     {
-         return $this->hasMany(Account::class);
-     }
- }
-```
-
 <br>
 
 ## AddGuardToLoginEventRector
@@ -93,20 +31,6 @@ Add generic return type to relations in child of `Illuminate\Database\Eloquent\M
 Add new `$guard` argument to Illuminate\Auth\Events\Login
 
 - class: [`RectorLaravel\Rector\New_\AddGuardToLoginEventRector`](../src/Rector/New_/AddGuardToLoginEventRector.php)
-
-```diff
- use Illuminate\Auth\Events\Login;
-
- final class SomeClass
- {
-     public function run(): void
-     {
--        $loginEvent = new Login('user', false);
-+        $guard = config('auth.defaults.guard');
-+        $loginEvent = new Login($guard, 'user', false);
-     }
- }
-```
 
 <br>
 
@@ -116,26 +40,6 @@ Add "$this->mockConsoleOutput = false"; to console tests that work with output c
 
 - class: [`RectorLaravel\Rector\Class_\AddMockConsoleOutputFalseToConsoleTestsRector`](../src/Rector/Class_/AddMockConsoleOutputFalseToConsoleTestsRector.php)
 
-```diff
- use Illuminate\Support\Facades\Artisan;
- use Illuminate\Foundation\Testing\TestCase;
-
- final class SomeTest extends TestCase
- {
-+    public function setUp(): void
-+    {
-+        parent::setUp();
-+
-+        $this->mockConsoleOutput = false;
-+    }
-+
-     public function test(): void
-     {
-         $this->assertEquals('content', \trim((new Artisan())::output()));
-     }
- }
-```
-
 <br>
 
 ## AddParentBootToModelClassMethodRector
@@ -143,18 +47,6 @@ Add "$this->mockConsoleOutput = false"; to console tests that work with output c
 Add `parent::boot();` call to `boot()` class method in child of `Illuminate\Database\Eloquent\Model`
 
 - class: [`RectorLaravel\Rector\ClassMethod\AddParentBootToModelClassMethodRector`](../src/Rector/ClassMethod/AddParentBootToModelClassMethodRector.php)
-
-```diff
- use Illuminate\Database\Eloquent\Model;
-
- class Product extends Model
- {
-     public function boot()
-     {
-+        parent::boot();
-     }
- }
-```
 
 <br>
 
@@ -164,18 +56,6 @@ Add `parent::register();` call to `register()` class method in child of `Illumin
 
 - class: [`RectorLaravel\Rector\ClassMethod\AddParentRegisterToEventServiceProviderRector`](../src/Rector/ClassMethod/AddParentRegisterToEventServiceProviderRector.php)
 
-```diff
- use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
-
- class EventServiceProvider extends ServiceProvider
- {
-     public function register()
-     {
-+        parent::register();
-     }
- }
-```
-
 <br>
 
 ## AnonymousMigrationsRector
@@ -184,17 +64,6 @@ Convert migrations to anonymous classes.
 
 - class: [`RectorLaravel\Rector\Class_\AnonymousMigrationsRector`](../src/Rector/Class_/AnonymousMigrationsRector.php)
 
-```diff
- use Illuminate\Database\Migrations\Migration;
-
--class CreateUsersTable extends Migration
-+return new class extends Migration
- {
-     // ...
--}
-+};
-```
-
 <br>
 
 ## AppEnvironmentComparisonToParameterRector
@@ -202,11 +71,6 @@ Convert migrations to anonymous classes.
 Replace `$app->environment() === 'local'` with `$app->environment('local')`
 
 - class: [`RectorLaravel\Rector\Expr\AppEnvironmentComparisonToParameterRector`](../src/Rector/Expr/AppEnvironmentComparisonToParameterRector.php)
-
-```diff
--$app->environment() === 'production';
-+$app->environment('production');
-```
 
 <br>
 
@@ -218,52 +82,6 @@ Move help facade-like function calls to constructor injection
 
 - class: [`RectorLaravel\Rector\FuncCall\ArgumentFuncCallToMethodCallRector`](../src/Rector/FuncCall/ArgumentFuncCallToMethodCallRector.php)
 
-```php
-<?php
-
-declare(strict_types=1);
-
-use RectorLaravel\Rector\FuncCall\ArgumentFuncCallToMethodCallRector;
-use RectorLaravel\ValueObject\ArgumentFuncCallToMethodCall;
-use Rector\Config\RectorConfig;
-
-return static function (RectorConfig $rectorConfig): void {
-    $containerConfigurator->extension('rectorConfig', [
-        [
-            'class' => ArgumentFuncCallToMethodCallRector::class,
-            'configuration' => [
-                new ArgumentFuncCallToMethodCall('view', 'Illuminate\Contracts\View\Factory', 'make'),
-            ],
-        ],
-    ]);
-};
-```
-
-↓
-
-```diff
- class SomeController
- {
-+    /**
-+     * @var \Illuminate\Contracts\View\Factory
-+     */
-+    private $viewFactory;
-+
-+    public function __construct(\Illuminate\Contracts\View\Factory $viewFactory)
-+    {
-+        $this->viewFactory = $viewFactory;
-+    }
-+
-     public function action()
-     {
--        $template = view('template.blade');
--        $viewFactory = view();
-+        $template = $this->viewFactory->make('template.blade');
-+        $viewFactory = $this->viewFactory;
-     }
- }
-```
-
 <br>
 
 ## AssertStatusToAssertMethodRector
@@ -271,111 +89,6 @@ return static function (RectorConfig $rectorConfig): void {
 Replace `(new \Illuminate\Testing\TestResponse)->assertStatus(200)` with `(new \Illuminate\Testing\TestResponse)->assertOk()`
 
 - class: [`RectorLaravel\Rector\MethodCall\AssertStatusToAssertMethodRector`](../src/Rector/MethodCall/AssertStatusToAssertMethodRector.php)
-
-```diff
- class ExampleTest extends \Illuminate\Foundation\Testing\TestCase
- {
-     public function testOk()
-     {
--        $this->get('/')->assertStatus(200);
--        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_OK);
--        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_OK);
-+        $this->get('/')->assertOk();
-+        $this->get('/')->assertOk();
-+        $this->get('/')->assertOk();
-     }
-
-     public function testNoContent()
-     {
--        $this->get('/')->assertStatus(204);
--        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_NO_CONTENT);
--        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_NO_CONTENT);
-+        $this->get('/')->assertNoContent();
-+        $this->get('/')->assertNoContent();
-+        $this->get('/')->assertNoContent();
-     }
-
-     public function testUnauthorized()
-     {
--        $this->get('/')->assertStatus(401);
--        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_UNAUTHORIZED);
--        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_UNAUTHORIZED);
-+        $this->get('/')->assertUnauthorized();
-+        $this->get('/')->assertUnauthorized();
-+        $this->get('/')->assertUnauthorized();
-     }
-
-     public function testForbidden()
-     {
--        $this->get('/')->assertStatus(403);
--        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_FORBIDDEN);
--        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_FORBIDDEN);
-+        $this->get('/')->assertForbidden();
-+        $this->get('/')->assertForbidden();
-+        $this->get('/')->assertForbidden();
-     }
-
-     public function testNotFound()
-     {
--        $this->get('/')->assertStatus(404);
--        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_NOT_FOUND);
--        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND);
-+        $this->get('/')->assertNotFound();
-+        $this->get('/')->assertNotFound();
-+        $this->get('/')->assertNotFound();
-     }
-
-     public function testMethodNotAllowed()
-     {
--        $this->get('/')->assertStatus(405);
--        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_METHOD_NOT_ALLOWED);
--        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_METHOD_NOT_ALLOWED);
-+        $this->get('/')->assertMethodNotAllowed();
-+        $this->get('/')->assertMethodNotAllowed();
-+        $this->get('/')->assertMethodNotAllowed();
-     }
-
-     public function testUnprocessableEntity()
-     {
--        $this->get('/')->assertStatus(422);
--        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_UNPROCESSABLE_ENTITY);
--        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY);
-+        $this->get('/')->assertUnprocessable();
-+        $this->get('/')->assertUnprocessable();
-+        $this->get('/')->assertUnprocessable();
-     }
-
-     public function testGone()
-     {
--        $this->get('/')->assertStatus(410);
--        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_GONE);
--        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_GONE);
-+        $this->get('/')->assertGone();
-+        $this->get('/')->assertGone();
-+        $this->get('/')->assertGone();
-     }
-
-     public function testInternalServerError()
-     {
--        $this->get('/')->assertStatus(500);
--        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_INTERNAL_SERVER_ERROR);
--        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_INTERNAL_SERVER_ERROR);
-+        $this->get('/')->assertInternalServerError();
-+        $this->get('/')->assertInternalServerError();
-+        $this->get('/')->assertInternalServerError();
-     }
-
-     public function testServiceUnavailable()
-     {
--        $this->get('/')->assertStatus(503);
--        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_SERVICE_UNAVAILABLE);
--        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_SERVICE_UNAVAILABLE);
-+        $this->get('/')->asserServiceUnavailable();
-+        $this->get('/')->asserServiceUnavailable();
-+        $this->get('/')->asserServiceUnavailable();
-     }
- }
-```
 
 <br>
 
@@ -385,24 +98,6 @@ Replace magical call on `$this->app["something"]` to standalone type assign vari
 
 - class: [`RectorLaravel\Rector\Assign\CallOnAppArrayAccessToStandaloneAssignRector`](../src/Rector/Assign/CallOnAppArrayAccessToStandaloneAssignRector.php)
 
-```diff
- class SomeClass
- {
-     /**
-      * @var \Illuminate\Contracts\Foundation\Application
-      */
-     private $app;
-
-     public function run()
-     {
--        $validator = $this->app['validator']->make('...');
-+        /** @var \Illuminate\Validation\Factory $validationFactory */
-+        $validationFactory = $this->app['validator'];
-+        $validator = $validationFactory->make('...');
-     }
- }
-```
-
 <br>
 
 ## CashierStripeOptionsToStripeRector
@@ -410,21 +105,6 @@ Replace magical call on `$this->app["something"]` to standalone type assign vari
 Renames the Billable `stripeOptions()` to `stripe().`
 
 - class: [`RectorLaravel\Rector\Class_\CashierStripeOptionsToStripeRector`](../src/Rector/Class_/CashierStripeOptionsToStripeRector.php)
-
-```diff
- use Illuminate\Database\Eloquent\Model;
- use Laravel\Cashier\Billable;
-
- class User extends Model
- {
-     use Billable;
-
--    public function stripeOptions(array $options = []) {
-+    public function stripe(array $options = []) {
-         return [];
-     }
- }
-```
 
 <br>
 
@@ -434,21 +114,6 @@ Add `parent::boot();` call to `boot()` class method in child of `Illuminate\Data
 
 - class: [`RectorLaravel\Rector\MethodCall\ChangeQueryWhereDateValueWithCarbonRector`](../src/Rector/MethodCall/ChangeQueryWhereDateValueWithCarbonRector.php)
 
-```diff
- use Illuminate\Database\Query\Builder;
-
- final class SomeClass
- {
-     public function run(Builder $query)
-     {
--        $query->whereDate('created_at', '<', Carbon::now());
-+        $dateTime = Carbon::now();
-+        $query->whereDate('created_at', '<=', $dateTime);
-+        $query->whereTime('created_at', '<=', $dateTime);
-     }
- }
-```
-
 <br>
 
 ## DatabaseExpressionCastsToMethodCallRector
@@ -457,13 +122,6 @@ Convert DB Expression string casts to `getValue()` method calls.
 
 - class: [`RectorLaravel\Rector\Cast\DatabaseExpressionCastsToMethodCallRector`](../src/Rector/Cast/DatabaseExpressionCastsToMethodCallRector.php)
 
-```diff
- use Illuminate\Support\Facades\DB;
-
--$string = (string) DB::raw('select 1');
-+$string = DB::raw('select 1')->getValue(DB::connection()->getQueryGrammar());
-```
-
 <br>
 
 ## DatabaseExpressionToStringToMethodCallRector
@@ -471,13 +129,6 @@ Convert DB Expression string casts to `getValue()` method calls.
 Convert DB Expression `__toString()` calls to `getValue()` method calls.
 
 - class: [`RectorLaravel\Rector\MethodCall\DatabaseExpressionToStringToMethodCallRector`](../src/Rector/MethodCall/DatabaseExpressionToStringToMethodCallRector.php)
-
-```diff
- use Illuminate\Support\Facades\DB;
-
--$string = DB::raw('select 1')->__toString();
-+$string = DB::raw('select 1')->getValue(DB::connection()->getQueryGrammar());
-```
 
 <br>
 
@@ -489,38 +140,6 @@ The EloquentMagicMethodToQueryBuilderRule is designed to automatically transform
 
 - class: [`RectorLaravel\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector`](../src/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector.php)
 
-```php
-<?php
-
-declare(strict_types=1);
-
-use RectorLaravel\Rector\MethodCall\EloquentOrderByToLatestOrOldestRector;
-use Rector\Config\RectorConfig;
-
-return static function (RectorConfig $rectorConfig): void {
-    $containerConfigurator->extension('rectorConfig', [
-        [
-            'class' => EloquentMagicMethodToQueryBuilderRector::class,
-            'configuration' => [
-                'exclude_methods' => [
-                    'find',
-                    'findOrFail',
-                ],
-            ],
-        ],
-    ]);
-};
-```
-
-↓
-
-```diff
- use App\Models\User;
-
--$user = User::where('x', 1);
-+$user = User::query()->where('x', 1);
-```
-
 <br>
 
 ## EloquentOrderByToLatestOrOldestRector
@@ -531,51 +150,6 @@ Changes `orderBy()` to `latest()` or `oldest()`
 
 - class: [`RectorLaravel\Rector\MethodCall\EloquentOrderByToLatestOrOldestRector`](../src/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector.php)
 
-```php
-<?php
-
-declare(strict_types=1);
-
-use RectorLaravel\Rector\MethodCall\EloquentOrderByToLatestOrOldestRector;
-use Rector\Config\RectorConfig;
-
-return static function (RectorConfig $rectorConfig): void {
-    $containerConfigurator->extension('rectorConfig', [
-        [
-            'class' => EloquentOrderByToLatestOrOldestRector::class,
-            'configuration' => [
-                'allowed_patterns' => [
-                    'submitted_a*',
-                    '*tested_at',
-                    '$allowed_variable_name',
-                ],
-            ],
-        ],
-    ]);
-};
-```
-
-↓
-
-```diff
- use Illuminate\Database\Eloquent\Builder;
-
- $column = 'tested_at';
-
--$builder->orderBy('created_at');
--$builder->orderBy('created_at', 'desc');
--$builder->orderBy('submitted_at');
--$builder->orderByDesc('submitted_at');
--$builder->orderBy($allowed_variable_name);
-+$builder->oldest();
-+$builder->latest();
-+$builder->oldest('submitted_at');
-+$builder->latest('submitted_at');
-+$builder->oldest($allowed_variable_name);
- $builder->orderBy($unallowed_variable_name);
- $builder->orderBy('unallowed_column_name');
-```
-
 <br>
 
 ## EloquentWhereRelationTypeHintingParameterRector
@@ -583,18 +157,6 @@ return static function (RectorConfig $rectorConfig): void {
 Add type hinting to where relation has methods e.g. `whereHas`, `orWhereHas`, `whereDoesntHave`, `orWhereDoesntHave`, `whereHasMorph`, `orWhereHasMorph`, `whereDoesntHaveMorph`, `orWhereDoesntHaveMorph`
 
 - class: [`RectorLaravel\Rector\MethodCall\EloquentWhereRelationTypeHintingParameterRector`](../src/Rector/MethodCall/EloquentWhereRelationTypeHintingParameterRector.php)
-
-```diff
--User::whereHas('posts', function ($query) {
-+User::whereHas('posts', function (\Illuminate\Contracts\Database\Query\Builder $query) {
-     $query->where('is_published', true);
- });
-
--$query->whereHas('posts', function ($query) {
-+$query->whereHas('posts', function (\Illuminate\Contracts\Database\Query\Builder $query) {
-     $query->where('is_published', true);
- });
-```
 
 <br>
 
@@ -604,13 +166,6 @@ Change typehint of closure parameter in where method of Eloquent Builder
 
 - class: [`RectorLaravel\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector`](../src/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector.php)
 
-```diff
--$query->where(function ($query) {
-+$query->where(function (\Illuminate\Contracts\Database\Eloquent\Builder $query) {
-     $query->where('id', 1);
- });
-```
-
 <br>
 
 ## EmptyToBlankAndFilledFuncRector
@@ -618,13 +173,6 @@ Change typehint of closure parameter in where method of Eloquent Builder
 Replace use of the unsafe `empty()` function with Laravel's safer `blank()` & `filled()` functions.
 
 - class: [`RectorLaravel\Rector\Empty_\EmptyToBlankAndFilledFuncRector`](../src/Rector/Empty_/EmptyToBlankAndFilledFuncRector.php)
-
-```diff
--empty([]);
--!empty([]);
-+blank([]);
-+filled([]);
-```
 
 <br>
 
@@ -634,13 +182,6 @@ Call the state methods directly instead of specify the name of state.
 
 - class: [`RectorLaravel\Rector\MethodCall\FactoryApplyingStatesRector`](../src/Rector/MethodCall/FactoryApplyingStatesRector.php)
 
-```diff
--$factory->state('delinquent');
--$factory->states('premium', 'delinquent');
-+$factory->delinquent();
-+$factory->premium()->delinquent();
-```
-
 <br>
 
 ## FactoryDefinitionRector
@@ -648,28 +189,6 @@ Call the state methods directly instead of specify the name of state.
 Upgrade legacy factories to support classes.
 
 - class: [`RectorLaravel\Rector\Namespace_\FactoryDefinitionRector`](../src/Rector/Namespace_/FactoryDefinitionRector.php)
-
-```diff
- use Faker\Generator as Faker;
-
--$factory->define(App\User::class, function (Faker $faker) {
--    return [
--        'name' => $faker->name,
--        'email' => $faker->unique()->safeEmail,
--    ];
--});
-+class UserFactory extends \Illuminate\Database\Eloquent\Factories\Factory
-+{
-+    protected $model = App\User::class;
-+    public function definition()
-+    {
-+        return [
-+            'name' => $this->faker->name,
-+            'email' => $this->faker->unique()->safeEmail,
-+        ];
-+    }
-+}
-```
 
 <br>
 
@@ -679,11 +198,6 @@ Use the static factory method instead of global factory function.
 
 - class: [`RectorLaravel\Rector\FuncCall\FactoryFuncCallToStaticCallRector`](../src/Rector/FuncCall/FactoryFuncCallToStaticCallRector.php)
 
-```diff
--factory(User::class);
-+User::factory();
-```
-
 <br>
 
 ## HelperFuncCallToFacadeClassRector
@@ -691,17 +205,6 @@ Use the static factory method instead of global factory function.
 Change `app()` func calls to facade calls
 
 - class: [`RectorLaravel\Rector\FuncCall\HelperFuncCallToFacadeClassRector`](../src/Rector/FuncCall/HelperFuncCallToFacadeClassRector.php)
-
-```diff
- class SomeClass
- {
-     public function run()
-     {
--        return app('translator')->trans('value');
-+        return \Illuminate\Support\Facades\App::get('translator')->trans('value');
-     }
- }
-```
 
 <br>
 
@@ -711,11 +214,6 @@ Change method calls from `$this->json` to `$this->postJson,` `$this->putJson,` e
 
 - class: [`RectorLaravel\Rector\MethodCall\JsonCallToExplicitJsonCallRector`](../src/Rector/MethodCall/JsonCallToExplicitJsonCallRector.php)
 
-```diff
--$this->json("POST", "/api/v1/users", $data);
-+§this->postJson("/api/v1/users", $data);
-```
-
 <br>
 
 ## LumenRoutesStringActionToUsesArrayRector
@@ -723,11 +221,6 @@ Change method calls from `$this->json` to `$this->postJson,` `$this->putJson,` e
 Changes action in rule definitions from string to array notation.
 
 - class: [`RectorLaravel\Rector\MethodCall\LumenRoutesStringActionToUsesArrayRector`](../src/Rector/MethodCall/LumenRoutesStringActionToUsesArrayRector.php)
-
-```diff
--$router->get('/user', 'UserController@get');
-+$router->get('/user', ['uses => 'UserController@get']);
-```
 
 <br>
 
@@ -737,13 +230,6 @@ Changes middlewares from rule definitions from string to array notation.
 
 - class: [`RectorLaravel\Rector\MethodCall\LumenRoutesStringMiddlewareToArrayRector`](../src/Rector/MethodCall/LumenRoutesStringMiddlewareToArrayRector.php)
 
-```diff
--$router->get('/user', ['middleware => 'test']);
--$router->post('/user', ['middleware => 'test|authentication']);
-+$router->get('/user', ['middleware => ['test']]);
-+$router->post('/user', ['middleware => ['test', 'authentication']]);
-```
-
 <br>
 
 ## MigrateToSimplifiedAttributeRector
@@ -751,30 +237,6 @@ Changes middlewares from rule definitions from string to array notation.
 Migrate to the new Model attributes syntax
 
 - class: [`RectorLaravel\Rector\ClassMethod\MigrateToSimplifiedAttributeRector`](../src/Rector/ClassMethod/MigrateToSimplifiedAttributeRector.php)
-
-```diff
- use Illuminate\Database\Eloquent\Model;
-
- class User extends Model
- {
--    public function getFirstNameAttribute($value)
-+    protected function firstName(): \Illuminate\Database\Eloquent\Casts\Attribute
-     {
--        return ucfirst($value);
--    }
--
--    public function setFirstNameAttribute($value)
--    {
--        $this->attributes['first_name'] = strtolower($value);
--        $this->attributes['first_name_upper'] = strtoupper($value);
-+        return \Illuminate\Database\Eloquent\Casts\Attribute::make(get: function ($value) {
-+            return ucfirst($value);
-+        }, set: function ($value) {
-+            return ['first_name' => strtolower($value), 'first_name_upper' => strtoupper($value)];
-+        });
-     }
- }
-```
 
 <br>
 
@@ -784,16 +246,13 @@ Change minutes argument to seconds in `Illuminate\Contracts\Cache\Store` and Ill
 
 - class: [`RectorLaravel\Rector\StaticCall\MinutesToSecondsInCacheRector`](../src/Rector/StaticCall/MinutesToSecondsInCacheRector.php)
 
-```diff
- class SomeClass
- {
-     public function run()
-     {
--        Illuminate\Support\Facades\Cache::put('key', 'value', 60);
-+        Illuminate\Support\Facades\Cache::put('key', 'value', 60 * 60);
-     }
- }
-```
+<br>
+
+## ModelCastsPropertyToCastsMethodRector
+
+Refactor Model `$casts` property with `casts()` method
+
+- class: [`RectorLaravel\Rector\Class_\ModelCastsPropertyToCastsMethodRector`](../src/Rector/Class_/ModelCastsPropertyToCastsMethodRector.php)
 
 <br>
 
@@ -803,13 +262,6 @@ Swap the use of NotBooleans used with `filled()` and `blank()` to the correct he
 
 - class: [`RectorLaravel\Rector\FuncCall\NotFilledBlankFuncCallToBlankFilledFuncCallRector`](../src/Rector/FuncCall/NotFilledBlankFuncCallToBlankFilledFuncCallRector.php)
 
-```diff
--!filled([]);
--!blank([]);
-+blank([]);
-+filled([]);
-```
-
 <br>
 
 ## NowFuncWithStartOfDayMethodCallToTodayFuncRector
@@ -817,11 +269,6 @@ Swap the use of NotBooleans used with `filled()` and `blank()` to the correct he
 Use `today()` instead of `now()->startOfDay()`
 
 - class: [`RectorLaravel\Rector\FuncCall\NowFuncWithStartOfDayMethodCallToTodayFuncRector`](../src/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector.php)
-
-```diff
--$now = now()->startOfDay();
-+$now = today();
-```
 
 <br>
 
@@ -833,39 +280,6 @@ Convert simple calls to optional helper to use the nullsafe operator
 
 - class: [`RectorLaravel\Rector\PropertyFetch\OptionalToNullsafeOperatorRector`](../src/Rector/PropertyFetch/OptionalToNullsafeOperatorRector.php)
 
-```php
-<?php
-
-declare(strict_types=1);
-
-use RectorLaravel\Rector\PropertyFetch\OptionalToNullsafeOperatorRector;
-use Rector\Config\RectorConfig;
-
-return static function (RectorConfig $rectorConfig): void {
-    $containerConfigurator->extension('rectorConfig', [
-        [
-            'class' => OptionalToNullsafeOperatorRector::class,
-            'configuration' => [
-                'exclude_methods' => [
-                    'present',
-                ],
-            ],
-        ],
-    ]);
-};
-```
-
-↓
-
-```diff
--optional($user)->getKey();
--optional($user)->id;
-+$user?->getKey();
-+$user?->id;
- // macro methods
- optional($user)->present()->getKey();
-```
-
 <br>
 
 ## PropertyDeferToDeferrableProviderToRector
@@ -873,20 +287,6 @@ return static function (RectorConfig $rectorConfig): void {
 Change deprecated `$defer` = true; to `Illuminate\Contracts\Support\DeferrableProvider` interface
 
 - class: [`RectorLaravel\Rector\Class_\PropertyDeferToDeferrableProviderToRector`](../src/Rector/Class_/PropertyDeferToDeferrableProviderToRector.php)
-
-```diff
- use Illuminate\Support\ServiceProvider;
-+use Illuminate\Contracts\Support\DeferrableProvider;
-
--final class SomeServiceProvider extends ServiceProvider
-+final class SomeServiceProvider extends ServiceProvider implements DeferrableProvider
- {
--    /**
--     * @var bool
--     */
--    protected $defer = true;
- }
-```
 
 <br>
 
@@ -896,17 +296,6 @@ Change "redirect" call with 301 to "permanentRedirect"
 
 - class: [`RectorLaravel\Rector\StaticCall\Redirect301ToPermanentRedirectRector`](../src/Rector/StaticCall/Redirect301ToPermanentRedirectRector.php)
 
-```diff
- class SomeClass
- {
-     public function run()
-     {
--        Illuminate\Routing\Route::redirect('/foo', '/bar', 301);
-+        Illuminate\Routing\Route::permanentRedirect('/foo', '/bar');
-     }
- }
-```
-
 <br>
 
 ## RedirectBackToBackHelperRector
@@ -914,25 +303,6 @@ Change "redirect" call with 301 to "permanentRedirect"
 Replace `redirect()->back()` and `Redirect::back()` with `back()`
 
 - class: [`RectorLaravel\Rector\MethodCall\RedirectBackToBackHelperRector`](../src/Rector/MethodCall/RedirectBackToBackHelperRector.php)
-
-```diff
- use Illuminate\Support\Facades\Redirect;
-
- class MyController
- {
-     public function store()
-     {
--        return redirect()->back()->with('error', 'Incorrect Details.')
-+        return back()->with('error', 'Incorrect Details.')
-     }
-
-     public function update()
-     {
--        return Redirect::back()->with('error', 'Incorrect Details.')
-+        return back()->with('error', 'Incorrect Details.')
-     }
- }
-```
 
 <br>
 
@@ -942,25 +312,6 @@ Replace `redirect()->route("home")` and `Redirect::route("home")` with `to_route
 
 - class: [`RectorLaravel\Rector\MethodCall\RedirectRouteToToRouteHelperRector`](../src/Rector/MethodCall/RedirectRouteToToRouteHelperRector.php)
 
-```diff
- use Illuminate\Support\Facades\Redirect;
-
- class MyController
- {
-     public function store()
-     {
--        return redirect()->route('home')->with('error', 'Incorrect Details.')
-+        return to_route('home')->with('error', 'Incorrect Details.')
-     }
-
-     public function update()
-     {
--        return Redirect::route('home')->with('error', 'Incorrect Details.')
-+        return to_route('home')->with('error', 'Incorrect Details.')
-     }
- }
-```
-
 <br>
 
 ## RemoveDumpDataDeadCodeRector
@@ -968,23 +319,6 @@ Replace `redirect()->route("home")` and `Redirect::route("home")` with `to_route
 It will removes the dump data just like dd or dump functions from the code.`
 
 - class: [`RectorLaravel\Rector\FuncCall\RemoveDumpDataDeadCodeRector`](../src/Rector/FuncCall/RemoveDumpDataDeadCodeRector.php)
-
-```diff
- class MyController
- {
-     public function store()
-     {
--        dd('test');
-         return true;
-     }
-
-     public function update()
-     {
--        dump('test');
-         return true;
-     }
- }
-```
 
 <br>
 
@@ -994,15 +328,6 @@ Removes the `$model` property from Factories.
 
 - class: [`RectorLaravel\Rector\Class_\RemoveModelPropertyFromFactoriesRector`](../src/Rector/Class_/RemoveModelPropertyFromFactoriesRector.php)
 
-```diff
- use Illuminate\Database\Eloquent\Factories\Factory;
-
- class UserFactory extends Factory
- {
--    protected $model = \App\Models\User::class;
- }
-```
-
 <br>
 
 ## ReplaceAssertTimesSendWithAssertSentTimesRector
@@ -1010,11 +335,6 @@ Removes the `$model` property from Factories.
 Replace assertTimesSent with assertSentTimes
 
 - class: [`RectorLaravel\Rector\StaticCall\ReplaceAssertTimesSendWithAssertSentTimesRector`](../src/Rector/StaticCall/ReplaceAssertTimesSendWithAssertSentTimesRector.php)
-
-```diff
--Notification::assertTimesSent(1, SomeNotification::class);
-+Notification::assertSentTimes(SomeNotification::class, 1);
-```
 
 <br>
 
@@ -1024,27 +344,6 @@ Replace expectJobs and expectEvents methods in tests
 
 - class: [`RectorLaravel\Rector\Class_\ReplaceExpectsMethodsInTestsRector`](../src/Rector/Class_/ReplaceExpectsMethodsInTestsRector.php)
 
-```diff
- use Illuminate\Foundation\Testing\TestCase;
-
- class SomethingTest extends TestCase
- {
-     public function testSomething()
-     {
--        $this->expectsJobs([\App\Jobs\SomeJob::class, \App\Jobs\SomeOtherJob::class]);
--        $this->expectsEvents(\App\Events\SomeEvent::class);
-+        \Illuminate\Support\Facades\Bus::fake([\App\Jobs\SomeJob::class, \App\Jobs\SomeOtherJob::class]);
-+        \Illuminate\Support\Facades\Event::fake([\App\Events\SomeEvent::class]);
-
-         $this->get('/');
-+
-+        \Illuminate\Support\Facades\Bus::assertDispatched(\App\Jobs\SomeJob::class);
-+        \Illuminate\Support\Facades\Bus::assertDispatched(\App\Jobs\SomeOtherJob::class);
-+        \Illuminate\Support\Facades\Event::assertDispatched(\App\Events\SomeEvent::class);
-     }
- }
-```
-
 <br>
 
 ## ReplaceFakerInstanceWithHelperRector
@@ -1052,21 +351,6 @@ Replace expectJobs and expectEvents methods in tests
 Replace `$this->faker` with the `fake()` helper function in Factories
 
 - class: [`RectorLaravel\Rector\PropertyFetch\ReplaceFakerInstanceWithHelperRector`](../src/Rector/PropertyFetch/ReplaceFakerInstanceWithHelperRector.php)
-
-```diff
- class UserFactory extends Factory
- {
-     public function definition()
-     {
-         return [
--            'name' => $this->faker->name,
--            'email' => $this->faker->unique()->safeEmail,
-+            'name' => fake()->name,
-+            'email' => fake()->unique()->safeEmail,
-         ];
-     }
- }
-```
 
 <br>
 
@@ -1076,15 +360,6 @@ Replace `withoutJobs`, `withoutEvents` and `withoutNotifications` with Facade `f
 
 - class: [`RectorLaravel\Rector\MethodCall\ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector`](../src/Rector/MethodCall/ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector.php)
 
-```diff
--$this->withoutJobs();
--$this->withoutEvents();
--$this->withoutNotifications();
-+\Illuminate\Support\Facades\Bus::fake();
-+\Illuminate\Support\Facades\Event::fake();
-+\Illuminate\Support\Facades\Notification::fake();
-```
-
 <br>
 
 ## RequestStaticValidateToInjectRector
@@ -1092,20 +367,6 @@ Replace `withoutJobs`, `withoutEvents` and `withoutNotifications` with Facade `f
 Change static `validate()` method to `$request->validate()`
 
 - class: [`RectorLaravel\Rector\StaticCall\RequestStaticValidateToInjectRector`](../src/Rector/StaticCall/RequestStaticValidateToInjectRector.php)
-
-```diff
- use Illuminate\Http\Request;
-
- class SomeClass
- {
--    public function store()
-+    public function store(\Illuminate\Http\Request $request)
-     {
--        $validatedData = Request::validate(['some_attribute' => 'required']);
-+        $validatedData = $request->validate(['some_attribute' => 'required']);
-     }
- }
-```
 
 <br>
 
@@ -1117,33 +378,6 @@ Use PHP callable syntax instead of string syntax for controller route declaratio
 
 - class: [`RectorLaravel\Rector\StaticCall\RouteActionCallableRector`](../src/Rector/StaticCall/RouteActionCallableRector.php)
 
-```php
-<?php
-
-declare(strict_types=1);
-
-use RectorLaravel\Rector\StaticCall\RouteActionCallableRector;
-use Rector\Config\RectorConfig;
-
-return static function (RectorConfig $rectorConfig): void {
-    $containerConfigurator->extension('rectorConfig', [
-        [
-            'class' => RouteActionCallableRector::class,
-            'configuration' => [
-                'namespace' => 'App\Http\Controllers',
-            ],
-        ],
-    ]);
-};
-```
-
-↓
-
-```diff
--Route::get('/users', 'UserController@index');
-+Route::get('/users', [\App\Http\Controllers\UserController::class, 'index']);
-```
-
 <br>
 
 ## SleepFuncToSleepStaticCallRector
@@ -1151,11 +385,6 @@ return static function (RectorConfig $rectorConfig): void {
 Use `Sleep::sleep()` and `Sleep::usleep()` instead of the `sleep()` and `usleep()` function.
 
 - class: [`RectorLaravel\Rector\FuncCall\SleepFuncToSleepStaticCallRector`](../src/Rector/FuncCall/SleepFuncToSleepStaticCallRector.php)
-
-```diff
--sleep(5);
-+\Illuminate\Support\Sleep::sleep(5);
-```
 
 <br>
 
@@ -1165,13 +394,6 @@ Use `Str::startsWith()` or `Str::endsWith()` instead of `substr()` === `$str`
 
 - class: [`RectorLaravel\Rector\Expr\SubStrToStartsWithOrEndsWithStaticMethodCallRector\SubStrToStartsWithOrEndsWithStaticMethodCallRector`](../src/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/SubStrToStartsWithOrEndsWithStaticMethodCallRector.php)
 
-```diff
--if (substr($str, 0, 3) === 'foo') {
-+if (Str::startsWith($str, 'foo')) {
-     // do something
- }
-```
-
 <br>
 
 ## ThrowIfRector
@@ -1179,17 +401,6 @@ Use `Str::startsWith()` or `Str::endsWith()` instead of `substr()` === `$str`
 Change if throw to throw_if
 
 - class: [`RectorLaravel\Rector\If_\ThrowIfRector`](../src/Rector/If_/ThrowIfRector.php)
-
-```diff
--if ($condition) {
--    throw new Exception();
--}
--if (!$condition) {
--    throw new Exception();
--}
-+throw_if($condition, new Exception());
-+throw_unless($condition, new Exception());
-```
 
 <br>
 
@@ -1199,20 +410,6 @@ Unify Model `$dates` property with `$casts`
 
 - class: [`RectorLaravel\Rector\Class_\UnifyModelDatesWithCastsRector`](../src/Rector/Class_/UnifyModelDatesWithCastsRector.php)
 
-```diff
- use Illuminate\Database\Eloquent\Model;
-
- class Person extends Model
- {
-     protected $casts = [
--        'age' => 'integer',
-+        'age' => 'integer', 'birthday' => 'datetime',
-     ];
--
--    protected $dates = ['birthday'];
- }
-```
-
 <br>
 
 ## UseComponentPropertyWithinCommandsRector
@@ -1220,24 +417,5 @@ Unify Model `$dates` property with `$casts`
 Use `$this->components` property within commands
 
 - class: [`RectorLaravel\Rector\MethodCall\UseComponentPropertyWithinCommandsRector`](../src/Rector/MethodCall/UseComponentPropertyWithinCommandsRector.php)
-
-```diff
- use Illuminate\Console\Command;
-
- class CommandWithComponents extends Command
- {
-     public function handle()
-     {
--        $this->ask('What is your name?');
--        $this->line('A line!');
--        $this->info('Info!');
--        $this->error('Error!');
-+        $this->components->ask('What is your name?');
-+        $this->components->line('A line!');
-+        $this->components->info('Info!');
-+        $this->components->error('Error!');
-     }
- }
-```
 
 <br>

--- a/src/Rector/Class_/ModelCastsPropertyToCastsMethodRector.php
+++ b/src/Rector/Class_/ModelCastsPropertyToCastsMethodRector.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace RectorLaravel\Rector\Class_;
+
+use PhpParser\BuilderFactory;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Type\ObjectType;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\Class_\ModelCastsPropertyToCastsMethodRector\ModelCastsPropertyToCastsMethodRectorTest
+ */
+class ModelCastsPropertyToCastsMethodRector extends AbstractRector
+{
+    public function __construct(protected BuilderFactory $builderFactory)
+    {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Refactor Model $casts property with casts() method', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+
+class Person extends Model
+{
+    protected $casts = [
+        'age' => 'integer',
+    ];
+}
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+
+class Person extends Model
+{
+    protected function casts(): array
+    {
+        return [
+            'age' => 'integer',
+        ];
+    }
+}
+CODE_SAMPLE,
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param  Class_  $node
+     */
+    public function refactor(Node $node): ?Class_
+    {
+        // Check if it is a Model
+        if (! $this->isObjectType($node, new ObjectType('Illuminate\Database\Eloquent\Model'))) {
+
+            return null;
+        }
+
+        // Check if there is already a casts() method
+        foreach ($node->stmts as $stmt) {
+            if ($stmt instanceof Node\Stmt\ClassMethod) {
+                if ($this->isName($stmt, 'casts')) {
+
+                    return null;
+                }
+            }
+        }
+
+        // Check if there is a protected $casts property
+        foreach ($node->stmts as $index => $stmt) {
+            if ($stmt instanceof Node\Stmt\Property) {
+                if ($this->isName($stmt, 'casts') && $stmt->isProtected()) {
+                    $method = $this->builderFactory->method('casts')
+                        ->setReturnType('array')
+                        ->makePublic();
+
+                    // convert the property to a return statement
+                    $method->addStmt(new Node\Stmt\Return_($stmt->props[0]->default));
+
+                    unset($node->stmts[$index]);
+                    $node->stmts[] = $method->getNode();
+
+                    return $node;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Rector/Class_/ModelCastsPropertyToCastsMethodRector.php
+++ b/src/Rector/Class_/ModelCastsPropertyToCastsMethodRector.php
@@ -82,7 +82,7 @@ CODE_SAMPLE,
                 if ($this->isName($stmt, 'casts') && $stmt->isProtected()) {
                     $method = $this->builderFactory->method('casts')
                         ->setReturnType('array')
-                        ->makePublic();
+                        ->makeProtected();
 
                     // convert the property to a return statement
                     $method->addStmt(new Node\Stmt\Return_($stmt->props[0]->default));

--- a/src/Set/LaravelLevelSetList.php
+++ b/src/Set/LaravelLevelSetList.php
@@ -72,4 +72,9 @@ final class LaravelLevelSetList implements SetListInterface
      * @var string
      */
     final public const UP_TO_LARAVEL_100 = __DIR__ . '/../../config/sets/level/up-to-laravel-100.php';
+
+    /**
+     * @var string
+     */
+    final public const UP_TO_LARAVEL_110 = __DIR__ . '/../../config/sets/level/up-to-laravel-110.php';
 }

--- a/src/Set/LaravelSetList.php
+++ b/src/Set/LaravelSetList.php
@@ -86,6 +86,11 @@ final class LaravelSetList implements SetListInterface
     /**
      * @var string
      */
+    final public const LARAVEL_110 = __DIR__ . '/../../config/sets/laravel110.php';
+
+    /**
+     * @var string
+     */
     final public const LARAVEL_STATIC_TO_INJECTION = __DIR__ . '/../../config/sets/laravel-static-to-injection.php';
 
     /**

--- a/tests/Rector/Class_/ModelCastsPropertyToCastsMethodRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/ModelCastsPropertyToCastsMethodRector/Fixture/fixture.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\ModelCastsPropertyToCastsMethodRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CastsPropertyExists extends Model
+{
+    protected $casts = [
+        'birthday' => 'datetime',
+        'age' => 'integer',
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\ModelCastsPropertyToCastsMethodRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CastsPropertyExists extends Model
+{
+    public function casts(): array
+    {
+        return [
+            'birthday' => 'datetime',
+            'age' => 'integer',
+        ];
+    }
+}
+
+?>

--- a/tests/Rector/Class_/ModelCastsPropertyToCastsMethodRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/ModelCastsPropertyToCastsMethodRector/Fixture/fixture.php.inc
@@ -22,7 +22,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class CastsPropertyExists extends Model
 {
-    public function casts(): array
+    protected function casts(): array
     {
         return [
             'birthday' => 'datetime',

--- a/tests/Rector/Class_/ModelCastsPropertyToCastsMethodRector/Fixture/skip_class_with_casts_method.php.inc
+++ b/tests/Rector/Class_/ModelCastsPropertyToCastsMethodRector/Fixture/skip_class_with_casts_method.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\ModelCastsPropertyToCastsMethodRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ClassWithCastsMethod extends Model
+{
+    protected $casts = [
+        'name' => 'string',
+    ];
+
+    public function casts(): array
+    {
+        return [
+            'birthday' => 'datetime',
+            'age' => 'integer',
+        ];
+    }
+}
+
+?>

--- a/tests/Rector/Class_/ModelCastsPropertyToCastsMethodRector/Fixture/skip_class_with_casts_method.php.inc
+++ b/tests/Rector/Class_/ModelCastsPropertyToCastsMethodRector/Fixture/skip_class_with_casts_method.php.inc
@@ -10,7 +10,7 @@ class ClassWithCastsMethod extends Model
         'name' => 'string',
     ];
 
-    public function casts(): array
+    private function casts(): array
     {
         return [
             'birthday' => 'datetime',

--- a/tests/Rector/Class_/ModelCastsPropertyToCastsMethodRector/Fixture/skip_non_model_classes.php.inc
+++ b/tests/Rector/Class_/ModelCastsPropertyToCastsMethodRector/Fixture/skip_non_model_classes.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\ModelCastsPropertyToCastsMethodRector\Fixture;
+
+class NonModelClass
+{
+    protected $casts = [
+        'birthday' => 'datetime',
+        'age' => 'integer',
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/ModelCastsPropertyToCastsMethodRector/ModelCastsPropertyToCastsMethodRectorTest.php
+++ b/tests/Rector/Class_/ModelCastsPropertyToCastsMethodRector/ModelCastsPropertyToCastsMethodRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\Class_\ModelCastsPropertyToCastsMethodRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ModelCastsPropertyToCastsMethodRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/ModelCastsPropertyToCastsMethodRector/config/configured_rule.php
+++ b/tests/Rector/Class_/ModelCastsPropertyToCastsMethodRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\ModelCastsPropertyToCastsMethodRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(ModelCastsPropertyToCastsMethodRector::class);
+};


### PR DESCRIPTION
# Changes

* Adds a rule to change the `$casts` property to a `casts()` class method.
* Adds the Laravel 11 group
* Adds tests for the new rule
* Generates documentation

# Why

This is [a new bit of functionality for Laravel 11](https://benjamincrozat.com/laravel-11#new-feature-the-new-and-more-convenient-modelcasts-method-goes-live-laravel-11).

[The PR in Laravel](https://github.com/laravel/framework/pull/47237)

# Notes

Doc were generated with the fix from #172 so it's removed lots of examples.