### PR TITLE
[CodeQuality] Adds rules for the with and value helpers

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 51 Rules Overview
+# 53 Rules Overview
 
 ## AddArgumentDefaultValueRector
 
@@ -903,6 +903,32 @@ Removes the `$model` property from Factories.
  {
 -    protected $model = \App\Models\User::class;
  }
+```
+
+<br>
+
+## RemoveRedundantValueCallsRector
+
+Removes redundant value helper calls
+
+- class: [`RectorLaravel\Rector\FuncCall\RemoveRedundantValueCallsRector`](../src/Rector/FuncCall/RemoveRedundantValueCallsRector.php)
+
+```diff
+-value(new Object())->something();
++(new Object())->something();
+```
+
+<br>
+
+## RemoveRedundantWithCallsRector
+
+Removes redundant with helper calls
+
+- class: [`RectorLaravel\Rector\FuncCall\RemoveRedundantWithCallsRector`](../src/Rector/FuncCall/RemoveRedundantWithCallsRector.php)
+
+```diff
+-with(new Object())->something();
++(new Object())->something();
 ```
 
 <br>

--- a/src/Rector/FuncCall/RemoveRedundantValueCallsRector.php
+++ b/src/Rector/FuncCall/RemoveRedundantValueCallsRector.php
@@ -4,7 +4,6 @@ namespace RectorLaravel\Rector\FuncCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\ClosureType;

--- a/src/Rector/FuncCall/RemoveRedundantValueCallsRector.php
+++ b/src/Rector/FuncCall/RemoveRedundantValueCallsRector.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace RectorLaravel\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\ClosureType;
+use PHPStan\Type\MixedType;
+use Rector\Rector\AbstractScopeAwareRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\FuncCall\RemoveRedundantValueCallsRector\RemoveRedundantValueCallsRectorTest
+ */
+class RemoveRedundantValueCallsRector extends AbstractScopeAwareRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Removes redundant value helper calls', [
+            new CodeSample(
+                'value(new Object())->something();',
+                '(new Object())->something();'
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    public function refactorWithScope(Node $node, Scope $scope): ?Node
+    {
+        if (! $node instanceof FuncCall) {
+            return null;
+        }
+
+        if (! $node->name instanceof Name) {
+            return null;
+        }
+
+        if (! $this->isName($node->name, 'value')) {
+            return null;
+        }
+
+        $args = $node->getArgs();
+
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        if ($scope->getType($args[0]->value)->isSuperTypeOf(new ClosureType([], new MixedType, true))->no() === false) {
+            return null;
+        }
+
+        return $args[0]->value;
+    }
+}

--- a/src/Rector/FuncCall/RemoveRedundantWithCallsRector.php
+++ b/src/Rector/FuncCall/RemoveRedundantWithCallsRector.php
@@ -4,7 +4,6 @@ namespace RectorLaravel\Rector\FuncCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use Rector\Rector\AbstractScopeAwareRector;

--- a/src/Rector/FuncCall/RemoveRedundantWithCallsRector.php
+++ b/src/Rector/FuncCall/RemoveRedundantWithCallsRector.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace RectorLaravel\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use Rector\Rector\AbstractScopeAwareRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\FuncCall\RemoveRedundantWithCallsRector\RemoveRedundantWithCallsRectorTest
+ */
+class RemoveRedundantWithCallsRector extends AbstractScopeAwareRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Removes redundant with helper calls', [
+            new CodeSample(
+                'with(new Object())->something();',
+                '(new Object())->something();'
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    public function refactorWithScope(Node $node, Scope $scope): ?Node
+    {
+        if (! $node instanceof FuncCall) {
+            return null;
+        }
+
+        if (! $node->name instanceof Name) {
+            return null;
+        }
+
+        if (! $this->isName($node->name, 'with')) {
+            return null;
+        }
+
+        $args = $node->getArgs();
+
+        if (count($args) < 1 || count($args) > 2) {
+            return null;
+        }
+
+        if (count($args) === 2) {
+            $secondArgumentType = $scope->getType($args[1]->value);
+
+            if ($secondArgumentType->isCallable()->no() === false) {
+                return null;
+            }
+        }
+
+        return $args[0]->value;
+    }
+}

--- a/tests/Rector/FuncCall/RemoveRedundantValueCallsRector/Fixture/fixture.php.inc
+++ b/tests/Rector/FuncCall/RemoveRedundantValueCallsRector/Fixture/fixture.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\RemoveRedundantValueCallsRector\Fixture;
+
+use RectorLaravel\Tests\Rector\FuncCall\RemoveRedundantValueCallsRector\Source\HelperObject;
+
+value(new HelperObject())->store();
+
+$foo = value(new HelperObject());
+
+$user = 'a';
+
+value($user)->store();
+
+$foo = value($user);
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\RemoveRedundantValueCallsRector\Fixture;
+
+use RectorLaravel\Tests\Rector\FuncCall\RemoveRedundantValueCallsRector\Source\HelperObject;
+
+(new HelperObject())->store();
+
+$foo = new HelperObject();
+
+$user = 'a';
+
+$user->store();
+
+$foo = $user;
+
+?>

--- a/tests/Rector/FuncCall/RemoveRedundantValueCallsRector/Fixture/skips_object_without_an_obvious_type.php.inc
+++ b/tests/Rector/FuncCall/RemoveRedundantValueCallsRector/Fixture/skips_object_without_an_obvious_type.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\RemoveRedundantValueCallsRector\Fixture;
+
+value(new UndefinedClass())->store();
+
+$foo = value(new UndefinedClass());
+
+$user = new UndefinedClass();
+
+value($user)->store();

--- a/tests/Rector/FuncCall/RemoveRedundantValueCallsRector/RemoveRedundantValueCallsRectorTest.php
+++ b/tests/Rector/FuncCall/RemoveRedundantValueCallsRector/RemoveRedundantValueCallsRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\FuncCall\RemoveRedundantValueCallsRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveRedundantValueCallsRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/FuncCall/RemoveRedundantValueCallsRector/Source/HelperObject.php
+++ b/tests/Rector/FuncCall/RemoveRedundantValueCallsRector/Source/HelperObject.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\RemoveRedundantValueCallsRector\Source;
+
+class HelperObject
+{
+    public function store(): void
+    {
+    }
+}

--- a/tests/Rector/FuncCall/RemoveRedundantValueCallsRector/config/configured_rule.php
+++ b/tests/Rector/FuncCall/RemoveRedundantValueCallsRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\FuncCall\RemoveRedundantValueCallsRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(RemoveRedundantValueCallsRector::class);
+};

--- a/tests/Rector/FuncCall/RemoveRedundantWithCallsRector/Fixture/fixture.php.inc
+++ b/tests/Rector/FuncCall/RemoveRedundantWithCallsRector/Fixture/fixture.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\RemoveRedundantWithCallsRector\Fixture;
+
+use RectorLaravel\Tests\Rector\FuncCall\RemoveRedundantWithCallsRector\Source\HelperObject;
+
+with(new HelperObject())->store();
+
+$foo = with(new HelperObject());
+
+$user = 'a';
+
+with($user)->store();
+
+$foo = with($user);
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\RemoveRedundantWithCallsRector\Fixture;
+
+use RectorLaravel\Tests\Rector\FuncCall\RemoveRedundantWithCallsRector\Source\HelperObject;
+
+(new HelperObject())->store();
+
+$foo = new HelperObject();
+
+$user = 'a';
+
+$user->store();
+
+$foo = $user;
+
+?>

--- a/tests/Rector/FuncCall/RemoveRedundantWithCallsRector/Fixture/skips_calls_with_callables_as_a_second_arg.php.inc
+++ b/tests/Rector/FuncCall/RemoveRedundantWithCallsRector/Fixture/skips_calls_with_callables_as_a_second_arg.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\RemoveRedundantWithCallsRector\Fixture;
+
+use RectorLaravel\Tests\Rector\FuncCall\RemoveRedundantWithCallsRector\Source\HelperObject;
+
+with(new HelperObject(), function () {
+
+})->store();

--- a/tests/Rector/FuncCall/RemoveRedundantWithCallsRector/Fixture/skips_object_without_an_obvious_type.php.inc
+++ b/tests/Rector/FuncCall/RemoveRedundantWithCallsRector/Fixture/skips_object_without_an_obvious_type.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\RemoveRedundantWithCallsRector\Fixture;
+
+with(new UndefinedClass(), new AnotherUndefinedType())->store();
+
+$foo = with(new UndefinedClass(), new AnotherUndefinedType());
+
+$user = new UndefinedClass();
+$bar = new AnotherUndefinedType();
+
+with($user, $bar)->store();

--- a/tests/Rector/FuncCall/RemoveRedundantWithCallsRector/RemoveRedundantWithCallsRectorTest.php
+++ b/tests/Rector/FuncCall/RemoveRedundantWithCallsRector/RemoveRedundantWithCallsRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\FuncCall\RemoveRedundantWithCallsRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveRedundantWithCallsRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/FuncCall/RemoveRedundantWithCallsRector/Source/HelperObject.php
+++ b/tests/Rector/FuncCall/RemoveRedundantWithCallsRector/Source/HelperObject.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\RemoveRedundantWithCallsRector\Source;
+
+class HelperObject
+{
+    public function store(): void
+    {
+    }
+}

--- a/tests/Rector/FuncCall/RemoveRedundantWithCallsRector/config/configured_rule.php
+++ b/tests/Rector/FuncCall/RemoveRedundantWithCallsRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\FuncCall\RemoveRedundantWithCallsRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(RemoveRedundantWithCallsRector::class);
+};


### PR DESCRIPTION
# Changes

* Adds a rule for removing redundant with() helper usage
* Adds a rule for removing redundant value() helper usage
* Adds tests for both new rules
* Updates rule list

# Why

Based on rules from Larastan. These are quite simple little use cases where we can remove the use of a helper when it's not needed.

```diff
-value(new Object())->something();
+(new Object())->something();
```

-with(new Object())->something();
+(new Object())->something();

value() => https://github.com/larastan/larastan/blob/2.x/src/Rules/UselessConstructs/NoUselessValueFunctionCallsRule.php
with() => https://github.com/larastan/larastan/blob/2.x/src/Rules/UselessConstructs/NoUselessWithFunctionCallsRule.php