### PR TITLE
Adds the ThrowIFAndThrowUnlessExceptionsToUseClassStringRector rule

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 53 Rules Overview
+# 54 Rules Overview
 
 ## AddArgumentDefaultValueRector
 
@@ -1076,6 +1076,19 @@ Use `Str::startsWith()` or `Str::endsWith()` instead of `substr()` === `$str`
 +if (Str::startsWith($str, 'foo')) {
      // do something
  }
+```
+
+<br>
+
+## ThrowIfAndThrowUnlessExceptionsToUseClassStringRector
+
+changes use of a new throw instance to class string
+
+- class: [`RectorLaravel\Rector\FuncCall\ThrowIfAndThrowUnlessExceptionsToUseClassStringRector`](../src/Rector/FuncCall/ThrowIfAndThrowUnlessExceptionsToUseClassStringRector.php)
+
+```diff
+-throw_if($condition, new MyException('custom message'));
++throw_if($condition, MyException::class, 'custom message');
 ```
 
 <br>

--- a/src/Rector/FuncCall/ThrowIfAndThrowUnlessExceptionsToUseClassStringRector.php
+++ b/src/Rector/FuncCall/ThrowIfAndThrowUnlessExceptionsToUseClassStringRector.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace RectorLaravel\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\FuncCall\ThrowIfAndThrowUnlessExceptionsToUseClassStringRector\ThrowIfAndThrowUnlessExceptionsToUseClassStringRectorTest
+ */
+class ThrowIfAndThrowUnlessExceptionsToUseClassStringRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('changes use of a new throw instance to class string', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+throw_if($condition, new MyException('custom message'));
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+throw_if($condition, MyException::class, 'custom message');
+CODE_SAMPLE,
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param  FuncCall  $node
+     */
+    public function refactor(Node $node): ?FuncCall
+    {
+        if (! $this->isNames($node, ['throw_if', 'throw_unless'])) {
+            return null;
+        }
+
+        if (count($node->args) !== 2 || ! $node->args[1] instanceof Arg) {
+            return null;
+        }
+
+        $exception = $node->args[1]->value;
+        if (! $exception instanceof New_) {
+            return null;
+        }
+
+        $class = $exception->class;
+        if (! $class instanceof Name) {
+            return null;
+        }
+
+        // convert the class to a class string
+        $node->args[1] = new Arg(new ClassConstFetch($class, 'class'));
+        $node->args = [
+            ...$node->args,
+            ...$exception->getArgs(),
+        ];
+
+        return $node;
+    }
+}

--- a/tests/Rector/FuncCall/ThrowIfAndThrowUnlessExceptionsToUseClassStringRector/Fixture/fixture.php.inc
+++ b/tests/Rector/FuncCall/ThrowIfAndThrowUnlessExceptionsToUseClassStringRector/Fixture/fixture.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\ThrowIfAndThrowUnlessExceptionsToUseClassStringRector\Fixture;
+
+throw_if(true, new \Exception('message'));
+throw_unless(false, new \Exception('message', 'code'));
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\ThrowIfAndThrowUnlessExceptionsToUseClassStringRector\Fixture;
+
+throw_if(true, \Exception::class, 'message');
+throw_unless(false, \Exception::class, 'message', 'code');
+
+?>

--- a/tests/Rector/FuncCall/ThrowIfAndThrowUnlessExceptionsToUseClassStringRector/Fixture/skip_where_already_using_class_string.php.inc
+++ b/tests/Rector/FuncCall/ThrowIfAndThrowUnlessExceptionsToUseClassStringRector/Fixture/skip_where_already_using_class_string.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\ThrowIfAndThrowUnlessExceptionsToUseClassStringRector\Fixture;
+
+throw_if(true, \Exception::class, 'message');
+
+?>

--- a/tests/Rector/FuncCall/ThrowIfAndThrowUnlessExceptionsToUseClassStringRector/ThrowIfAndThrowUnlessExceptionsToUseClassStringRectorTest.php
+++ b/tests/Rector/FuncCall/ThrowIfAndThrowUnlessExceptionsToUseClassStringRector/ThrowIfAndThrowUnlessExceptionsToUseClassStringRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\FuncCall\ThrowIfAndThrowUnlessExceptionsToUseClassStringRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ThrowIfAndThrowUnlessExceptionsToUseClassStringRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/FuncCall/ThrowIfAndThrowUnlessExceptionsToUseClassStringRector/config/configured_rule.php
+++ b/tests/Rector/FuncCall/ThrowIfAndThrowUnlessExceptionsToUseClassStringRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\FuncCall\ThrowIfAndThrowUnlessExceptionsToUseClassStringRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(ThrowIfAndThrowUnlessExceptionsToUseClassStringRector::class);
+};


### PR DESCRIPTION
# Changes

* New rule
* Tests for the rule
* Docs update

# Why

A nice little rule to change the parameters of `throw_if()` and `throw_unless()` to use a class string.

```diff
-throw_if($condition, new MyException('custom message'));
+throw_if($condition, MyException::class, 'custom message');
```