### PR TITLE
Adds a fix for ThrowIfRector causing issues with assigned vars

### DIFF
--- a/src/Rector/If_/ThrowIfRector.php
+++ b/src/Rector/If_/ThrowIfRector.php
@@ -4,12 +4,16 @@ namespace RectorLaravel\Rector\If_;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Throw_;
+use PhpParser\NodeTraverser;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -58,6 +62,10 @@ CODE_SAMPLE
             $condition = $node->cond;
             $throwExpr = $ifStmts[0]->expr;
 
+            if ($this->exceptionUsesVariablesAssignedByCondition($throwExpr, $condition)) {
+                return null;
+            }
+
             // Check if the condition is a negation
             if ($condition instanceof BooleanNot) {
                 // Create a new throw_unless function call
@@ -75,5 +83,35 @@ CODE_SAMPLE
         }
 
         return null;
+    }
+
+    /**
+     * Make sure the exception doesn't use variables assigned by the condition or this
+     * will cause broken code to be generated
+     */
+    private function exceptionUsesVariablesAssignedByCondition(Expr $throwExpr, Expr $condition): bool
+    {
+        $conditionVariables = [];
+        $returnValue = false;
+
+        $this->traverseNodesWithCallable($condition, function (Node $node) use (&$conditionVariables): null {
+            if ($node instanceof Assign) {
+                $conditionVariables[] = $this->getName($node->var);
+            }
+
+            return null;
+        });
+
+        $this->traverseNodesWithCallable($throwExpr, function (Node $node) use ($conditionVariables, &$returnValue): ?int {
+            if ($node instanceof Variable && in_array($this->getName($node), $conditionVariables, true)) {
+                $returnValue = true;
+
+                return NodeTraverser::STOP_TRAVERSAL;
+            }
+
+            return null;
+        });
+
+        return $returnValue;
     }
 }

--- a/tests/Rector/If_/ThrowIfRector/Fixture/fixture.php.inc
+++ b/tests/Rector/If_/ThrowIfRector/Fixture/fixture.php.inc
@@ -12,6 +12,12 @@ class Fixture
         if (!$condition) {
             throw new Exception();
         }
+        if ($condition = call()) {
+            throw new Exception();
+        }
+        if ($condition) {
+            throw new Exception($condition);
+        }
     }
 }
 
@@ -27,6 +33,8 @@ class Fixture
     {
         throw_if($condition, new Exception());
         throw_unless($condition, new Exception());
+        throw_if($condition = call(), new Exception());
+        throw_if($condition, new Exception($condition));
     }
 }
 

--- a/tests/Rector/If_/ThrowIfRector/Fixture/skip_where_condition_contains_assigns_var_for_exception.php.inc
+++ b/tests/Rector/If_/ThrowIfRector/Fixture/skip_where_condition_contains_assigns_var_for_exception.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\If_\ThrowIfRector\Fixture;
+
+if ($foo = call() && $bar = call()) {
+    throw new \Exception($foo, $bar);
+}
+
+?>


### PR DESCRIPTION
# Changes

* alters the IfThrowRector rule
* adds more test scenarios

# Why

Sometimes the rule could generate broken code where a variable might not exist as it's created in the If statement's condition. In this instance the rule shouldn't make any changes.

```php
if ($foo && $bar = call()) {
    throw new Exception($foo, $bar);
}
```