### PR TITLE
Validation Rule string value to Array

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1150,7 +1150,7 @@ Use `$this->components` property within commands
 
 ## ValidationRuleArrayStringValueToArrayRector
 
-Convert string validation rules into arrays for Laravel's Validator::make.
+Convert string validation rules into arrays for Laravel's Validator.
 
 - class: [`RectorLaravel\Rector\MethodCall\ValidationRuleArrayStringValueToArrayRector`](../src/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector.php)
 

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 53 Rules Overview
+# 54 Rules Overview
 
 ## AddArgumentDefaultValueRector
 
@@ -1144,6 +1144,21 @@ Use `$this->components` property within commands
 +        $this->components->error('Error!');
      }
  }
+```
+
+<br>
+
+## ValidationRuleArrayStringValueToArrayRector
+
+Convert string validation rules into arrays for Laravel's Validator::make.
+
+- class: [`RectorLaravel\Rector\MethodCall\ValidationRuleArrayStringValueToArrayRector`](../src/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector.php)
+
+```diff
+ Validator::make($data, [
+-    'field' => 'required|nullable|string|max:255',
++    'field' => ['required', 'nullable', 'string', 'max:255'],
+ ]);
 ```
 
 <br>

--- a/src/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector.php
+++ b/src/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace RectorLaravel\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Type\ObjectType;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class ValidationRuleArrayStringValueToArrayRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Convert string validation rules into arrays for Laravel\'s Validator::make.',
+            [
+                new CodeSample(
+                    // Code before
+                    <<<'CODE_SAMPLE'
+Validator::make($data, [
+    'field' => 'required|nullable|string|max:255',
+]);
+CODE_SAMPLE
+                    ,
+                    // Code after
+                    <<<'CODE_SAMPLE'
+Validator::make($data, [
+    'field' => ['required', 'nullable', 'string', 'max:255'],
+]);
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param  MethodCall  $node
+     */
+    public function refactor(Node $node): ?MethodCall
+    {
+        if (
+            ! $this->isName($node->name, 'make') &&
+            $this->isObjectType(
+                $node->var,
+                new ObjectType('Illuminate\Validation\Factory')
+            )
+        ) {
+            return null;
+        }
+
+        if (count($node->args) !== 2) {
+            return null;
+        }
+        if (! $node->args[1] instanceof Arg) {
+            return null;
+        }
+
+        // The second argument should be the rules array
+        $rulesArgument = $node->args[1]->value;
+
+        if (! $rulesArgument instanceof Array_) {
+            return null;
+        }
+
+        $changed = false;
+
+        foreach ($rulesArgument->items as $item) {
+            if ($item instanceof ArrayItem && $item->value instanceof String_) {
+                $stringRules = $item->value->value;
+                $arrayRules = explode('|', $stringRules);
+                $item->value = new Array_(array_map(static fn ($rule) => new ArrayItem(new String_($rule)), $arrayRules));
+                $changed = true;
+            }
+        }
+
+        if ($changed) {
+            return $node;
+        }
+
+        return null;
+    }
+}

--- a/tests/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector/Fixture/SkipNonFormRequestClass.php.inc
+++ b/tests/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector/Fixture/SkipNonFormRequestClass.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ValidationRuleArrayStringValueToArrayRector\Fixture;
+
+class SkipNonFormRequestClass
+{
+    public function rules()
+    {
+        return [
+            'name' => 'required|string',
+        ];
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector/Fixture/applies_to_classes_extending_form_request.php.inc
+++ b/tests/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector/Fixture/applies_to_classes_extending_form_request.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ValidationRuleArrayStringValueToArrayRector\Fixture;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SomeFormRequest extends FormRequest
+{
+    public function rules()
+    {
+        return [
+            'name' => 'required|string',
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ValidationRuleArrayStringValueToArrayRector\Fixture;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SomeFormRequest extends FormRequest
+{
+    public function rules()
+    {
+        return [
+            'name' => ['required', 'string'],
+        ];
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector/Fixture/fixture.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ValidationRuleArrayStringValueToArrayRector\Fixture;
+
+function something(\Illuminate\Validation\Factory $validator) {
+    $validator->make(['name' => 'value'], [
+        'name' => 'required|string',
+    ]);
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ValidationRuleArrayStringValueToArrayRector\Fixture;
+
+function something(\Illuminate\Validation\Factory $validator) {
+    $validator->make(['name' => 'value'], [
+        'name' => ['required', 'string'],
+    ]);
+}
+
+?>

--- a/tests/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector/Fixture/fixture.php.inc
@@ -3,6 +3,10 @@
 namespace RectorLaravel\Tests\Rector\MethodCall\ValidationRuleArrayStringValueToArrayRector\Fixture;
 
 function something(\Illuminate\Validation\Factory $validator) {
+    \Illuminate\Support\Facades\Validator::make(['name' => 'value'], [
+        'name' => 'required|string',
+    ]);
+
     $validator->make(['name' => 'value'], [
         'name' => 'required|string',
     ]);
@@ -15,6 +19,10 @@ function something(\Illuminate\Validation\Factory $validator) {
 namespace RectorLaravel\Tests\Rector\MethodCall\ValidationRuleArrayStringValueToArrayRector\Fixture;
 
 function something(\Illuminate\Validation\Factory $validator) {
+    \Illuminate\Support\Facades\Validator::make(['name' => 'value'], [
+        'name' => ['required', 'string'],
+    ]);
+
     $validator->make(['name' => 'value'], [
         'name' => ['required', 'string'],
     ]);

--- a/tests/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector/Fixture/skip_form_request_non_rules_class_method.php.inc
+++ b/tests/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector/Fixture/skip_form_request_non_rules_class_method.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ValidationRuleArrayStringValueToArrayRector\Fixture;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SkipFormRequestNonRulesClassMethod extends FormRequest
+{
+    public function someMethod()
+    {
+        return [
+            'name' => 'required|string',
+        ];
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector/Fixture/skips_arrays_with_sub_arrays_already.php.inc
+++ b/tests/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector/Fixture/skips_arrays_with_sub_arrays_already.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ValidationRuleArrayStringValueToArrayRector\Fixture;
+
+function skip_arrays_with_sub_arrays_already(\Illuminate\Validation\Factory $validator) {
+    $validator->make(['name' => 'value'], [
+        'name' => ['required', 'string'],
+    ]);
+}
+
+?>

--- a/tests/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector/Fixture/skips_non_validator_method_call.php.inc
+++ b/tests/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector/Fixture/skips_non_validator_method_call.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ValidationRuleArrayStringValueToArrayRector\Fixture;
+
+function skip_non_validator_method_call($validator) {
+    $validator->make(['name' => 'value'], [
+        'name' => ['required', 'string'],
+    ]);
+}
+
+?>

--- a/tests/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector/ValidationRuleArrayStringValueToArrayRectorTest.php
+++ b/tests/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector/ValidationRuleArrayStringValueToArrayRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ValidationRuleArrayStringValueToArrayRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ValidationRuleArrayStringValueToArrayRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\MethodCall\ValidationRuleArrayStringValueToArrayRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(ValidationRuleArrayStringValueToArrayRector::class);
+};


### PR DESCRIPTION
# Changes

* Adds the ValidationRuleArrayStringValueToArrayRector rule.
* adds tests for the rule
* update the docs

# Why

It would be neat to automatically configure validation rules that are in the single string format to become arrays.

e.g.

```diff
 Validator::make($data, [
-    'field' => 'required|nullable|string|max:255',
+    'field' => ['required', 'nullable', 'string', 'max:255'],
 ]);
```

This rule will also work with the Validator facade and classes that extend the FormRequest class and have a rules method.
