### PR TITLE
Declare type configs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Rector upgrades rules for Laravel Framework",
     "require": {
         "php": ">=8.2",
-        "rector/rector": "^1.0"
+        "rector/rector": "main-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5",

--- a/config/sets/type-declaration.php
+++ b/config/sets/type-declaration.php
@@ -1,0 +1,10 @@
+<?php
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../config.php');
+
+    $rectorConfig->import(__DIR__ . '/type-declaration/eloquent.php');
+    $rectorConfig->import(__DIR__ . '/type-declaration/service-container.php');
+};

--- a/config/sets/type-declaration/eloquent.php
+++ b/config/sets/type-declaration/eloquent.php
@@ -1,0 +1,67 @@
+<?php
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\FunctionLike\AddParamTypeForFunctionLikeWithinCallLikeArgDeclarationRector;
+use Rector\TypeDeclaration\ValueObject\AddParamTypeForFunctionLikeWithinCallLikeArgDeclaration;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../config.php');
+
+    $builderClass = new \PHPStan\Type\ObjectType(
+        'Illuminate\Contracts\Database\Query\Builder'
+    );
+
+    $classesToApplyTo = [
+        'Illuminate\Database\Eloquent\Model',
+        'Illuminate\Contracts\Database\Query\Builder',
+        'Illuminate\Contracts\Database\Eloquent\Builder',
+    ];
+
+    $positionOne = [
+        'where', 'orWhere', 'whereNot', 'whereExists',
+    ];
+    $positionTwo = [
+        'where', 'whereHas', 'orWhereHas', 'whereDoesntHave', 'orWhereDoesntHave', 'withWhereHas', 'when',
+    ];
+    $positionThree = [
+        'where', 'whereHasMorph', 'orWhereHasMorph', 'whereDoesntHaveMorph', 'orWhereDoesntHaveMorph', 'when',
+    ];
+
+    $ruleConfiguration = [];
+
+    foreach ($classesToApplyTo as $targetClass) {
+        foreach ($positionOne as $method) {
+            $ruleConfiguration[] = new AddParamTypeForFunctionLikeWithinCallLikeArgDeclaration(
+                $targetClass,
+                $method,
+                0,
+                0,
+                $builderClass,
+            );
+        }
+        foreach ($positionTwo as $method) {
+            $ruleConfiguration[] = new AddParamTypeForFunctionLikeWithinCallLikeArgDeclaration(
+                $targetClass,
+                $method,
+                1,
+                0,
+                $builderClass,
+            );
+        }
+        foreach ($positionThree as $method) {
+            $ruleConfiguration[] = new AddParamTypeForFunctionLikeWithinCallLikeArgDeclaration(
+                $targetClass,
+                $method,
+                2,
+                0,
+                $builderClass,
+            );
+        }
+    }
+
+    $rectorConfig->ruleWithConfiguration(
+        AddParamTypeForFunctionLikeWithinCallLikeArgDeclarationRector::class,
+        $ruleConfiguration
+    );
+
+};

--- a/config/sets/type-declaration/service-container.php
+++ b/config/sets/type-declaration/service-container.php
@@ -1,0 +1,53 @@
+<?php
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\FunctionLike\AddParamTypeForFunctionLikeWithinCallLikeArgDeclarationRector;
+use Rector\TypeDeclaration\ValueObject\AddParamTypeForFunctionLikeWithinCallLikeArgDeclaration;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../config.php');
+
+    $applicationClass = new \PHPStan\Type\ObjectType(
+        'Illuminate\Contracts\Foundation\Application'
+    );
+
+    $classesToApplyTo = [
+        'Illuminate\Support\Facades\App',
+        'Illuminate\Contracts\Foundation\Application',
+    ];
+
+    $ruleConfiguration = [];
+
+    foreach ($classesToApplyTo as $targetClass) {
+        foreach ([
+            'bind', 'bindIf', 'singleton', 'singletonIf', 'scoped', 'scopedIf',
+        ] as $method) {
+            $ruleConfiguration[] = new AddParamTypeForFunctionLikeWithinCallLikeArgDeclaration(
+                $targetClass,
+                $method,
+                1,
+                0,
+                $applicationClass,
+            );
+        }
+        $ruleConfiguration[] = new AddParamTypeForFunctionLikeWithinCallLikeArgDeclaration(
+            $targetClass,
+            'resolving',
+            1,
+            1,
+            $applicationClass,
+        );
+        $ruleConfiguration[] = new AddParamTypeForFunctionLikeWithinCallLikeArgDeclaration(
+            $targetClass,
+            'extends',
+            1,
+            1,
+            $applicationClass,
+        );
+    }
+
+    $rectorConfig->ruleWithConfiguration(
+        AddParamTypeForFunctionLikeWithinCallLikeArgDeclarationRector::class,
+        $ruleConfiguration
+    );
+};

--- a/src/Rector/MethodCall/EloquentWhereRelationTypeHintingParameterRector.php
+++ b/src/Rector/MethodCall/EloquentWhereRelationTypeHintingParameterRector.php
@@ -17,6 +17,7 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
+ * @deprecated use type-declaration set instead
  * @see \RectorLaravel\Tests\Rector\MethodCall\EloquentWhereRelationTypeHintingParameterRector\EloquentWhereRelationTypeHintingParameterRectorTest
  */
 class EloquentWhereRelationTypeHintingParameterRector extends AbstractRector

--- a/src/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector.php
+++ b/src/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector.php
@@ -17,6 +17,7 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
+ * @deprecated use type-declaration set instead
  * @see \RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector\EloquentWhereTypeHintClosureParameterRectorTest
  */
 class EloquentWhereTypeHintClosureParameterRector extends AbstractRector

--- a/tests/Sets/TypeDeclaration/Eloquent/EloquentTypeDeclarationSetTest.php
+++ b/tests/Sets/TypeDeclaration/Eloquent/EloquentTypeDeclarationSetTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Sets\TypeDeclaration\Eloquent;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class EloquentTypeDeclarationSetTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Sets/TypeDeclaration/Eloquent/Fixture/apply-when-to-builder.php.inc
+++ b/tests/Sets/TypeDeclaration/Eloquent/Fixture/apply-when-to-builder.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace RectorLaravel\Tests\Sets\TypeDeclaration\Eloquent\Fixture;
+
+/** @var \Illuminate\Contracts\Database\Query\Builder $query */
+$query->when(true, function ($query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+$query->when(true, function ($query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+}, function ($query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Sets\TypeDeclaration\Eloquent\Fixture;
+
+/** @var \Illuminate\Contracts\Database\Query\Builder $query */
+$query->when(true, function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+$query->when(true, function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+}, function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+?>

--- a/tests/Sets/TypeDeclaration/Eloquent/Fixture/apply-where-relation-to-builder.php.inc
+++ b/tests/Sets/TypeDeclaration/Eloquent/Fixture/apply-where-relation-to-builder.php.inc
@@ -1,0 +1,77 @@
+<?php
+
+namespace RectorLaravel\Tests\Sets\TypeDeclaration\Eloquent\Fixture;
+
+/** @var \Illuminate\Contracts\Database\Query\Builder $query */
+$query->whereHas('posts', function ($query) {
+    $query->where('is_published', true);
+});
+
+$query->orWhereHas('posts', function ($query) {
+    $query->where('is_published', true);
+});
+
+$query->whereDoesntHave('posts', function ($query) {
+    $query->where('is_published', true);
+});
+
+$query->orWhereDoesntHave('posts', function ($query) {
+    $query->where('is_published', true);
+});
+
+$query->whereHasMorph('posts', [], function ($query) {
+    $query->where('is_published', true);
+});
+
+$query->orWhereHasMorph('posts', [], function ($query) {
+    $query->where('is_published', true);
+});
+
+$query->whereDoesntHaveMorph('posts', [], function ($query) {
+    $query->where('is_published', true);
+});
+
+$query->orWhereDoesntHaveMorph('posts', [], function ($query) {
+    $query->where('is_published', true);
+});
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Sets\TypeDeclaration\Eloquent\Fixture;
+
+/** @var \Illuminate\Contracts\Database\Query\Builder $query */
+$query->whereHas('posts', function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('is_published', true);
+});
+
+$query->orWhereHas('posts', function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('is_published', true);
+});
+
+$query->whereDoesntHave('posts', function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('is_published', true);
+});
+
+$query->orWhereDoesntHave('posts', function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('is_published', true);
+});
+
+$query->whereHasMorph('posts', [], function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('is_published', true);
+});
+
+$query->orWhereHasMorph('posts', [], function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('is_published', true);
+});
+
+$query->whereDoesntHaveMorph('posts', [], function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('is_published', true);
+});
+
+$query->orWhereDoesntHaveMorph('posts', [], function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('is_published', true);
+});
+
+?>

--- a/tests/Sets/TypeDeclaration/Eloquent/Fixture/apply-where-relation-to-model.php.inc
+++ b/tests/Sets/TypeDeclaration/Eloquent/Fixture/apply-where-relation-to-model.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace RectorLaravel\Tests\Sets\TypeDeclaration\Eloquent\Fixture;
+
+class User extends \Illuminate\Database\Eloquent\Model
+{
+
+}
+
+User::whereHas('posts', function ($query) {
+    $query->where('is_published', true);
+});
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Sets\TypeDeclaration\Eloquent\Fixture;
+
+class User extends \Illuminate\Database\Eloquent\Model
+{
+
+}
+
+User::whereHas('posts', function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('is_published', true);
+});
+
+?>

--- a/tests/Sets/TypeDeclaration/Eloquent/Fixture/apply-where-to-builder.php.inc
+++ b/tests/Sets/TypeDeclaration/Eloquent/Fixture/apply-where-to-builder.php.inc
@@ -1,0 +1,73 @@
+<?php
+
+namespace RectorLaravel\Tests\Sets\TypeDeclaration\Eloquent\Fixture;
+
+/** @var \Illuminate\Contracts\Database\Query\Builder $query */
+$query->where(function ($query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+$query->where('column', function ($query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+$query->where('column', '>', function ($query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+$query->orWhere(function ($query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+$query->whereNot(function ($query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+$query->whereExists(function ($query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Sets\TypeDeclaration\Eloquent\Fixture;
+
+/** @var \Illuminate\Contracts\Database\Query\Builder $query */
+$query->where(function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+$query->where('column', function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+$query->where('column', '>', function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+$query->orWhere(function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+$query->whereNot(function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+$query->whereExists(function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+?>

--- a/tests/Sets/TypeDeclaration/Eloquent/Fixture/apply-where-to-model.php.inc
+++ b/tests/Sets/TypeDeclaration/Eloquent/Fixture/apply-where-to-model.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace RectorLaravel\Tests\Sets\TypeDeclaration\Eloquent\Fixture;
+
+class User extends \Illuminate\Database\Eloquent\Model
+{
+
+}
+
+User::where(function ($query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Sets\TypeDeclaration\Eloquent\Fixture;
+
+class User extends \Illuminate\Database\Eloquent\Model
+{
+
+}
+
+User::where(function (\Illuminate\Contracts\Database\Query\Builder $query) {
+    $query->where('id', 1)
+        ->orWhere('id', 2);
+});
+
+?>

--- a/tests/Sets/TypeDeclaration/Eloquent/config/configured_rule.php
+++ b/tests/Sets/TypeDeclaration/Eloquent/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/sets/type-declaration/eloquent.php');
+};

--- a/tests/Sets/TypeDeclaration/ServiceContainer/Fixture/apply-bind-to-application.php.inc
+++ b/tests/Sets/TypeDeclaration/ServiceContainer/Fixture/apply-bind-to-application.php.inc
@@ -1,0 +1,75 @@
+<?php
+
+namespace RectorLaravel\Tests\Sets\TypeDeclaration\ServiceContainer\Fixture;
+
+\Illuminate\Support\Facades\App::bind('class', function ($app) {
+    return new \stdClass();
+});
+
+\Illuminate\Support\Facades\App::bindIf('class', function ($app) {
+    return new \stdClass();
+});
+
+\Illuminate\Support\Facades\App::singleton('class', function ($app) {
+    return new \stdClass();
+});
+
+\Illuminate\Support\Facades\App::singletonIf('class', function ($app) {
+    return new \stdClass();
+});
+
+\Illuminate\Support\Facades\App::scoped('class', function ($app) {
+    return new \stdClass();
+});
+
+\Illuminate\Support\Facades\App::scopedIf('class', function ($app) {
+    return new \stdClass();
+});
+
+\Illuminate\Support\Facades\App::extends('class', function ($instance, $app) {
+    return new \stdClass();
+});
+
+\Illuminate\Support\Facades\App::resolving('class', function ($instance, $app) {
+    return new \stdClass();
+});
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Sets\TypeDeclaration\ServiceContainer\Fixture;
+
+\Illuminate\Support\Facades\App::bind('class', function (\Illuminate\Contracts\Foundation\Application $app) {
+    return new \stdClass();
+});
+
+\Illuminate\Support\Facades\App::bindIf('class', function (\Illuminate\Contracts\Foundation\Application $app) {
+    return new \stdClass();
+});
+
+\Illuminate\Support\Facades\App::singleton('class', function (\Illuminate\Contracts\Foundation\Application $app) {
+    return new \stdClass();
+});
+
+\Illuminate\Support\Facades\App::singletonIf('class', function (\Illuminate\Contracts\Foundation\Application $app) {
+    return new \stdClass();
+});
+
+\Illuminate\Support\Facades\App::scoped('class', function (\Illuminate\Contracts\Foundation\Application $app) {
+    return new \stdClass();
+});
+
+\Illuminate\Support\Facades\App::scopedIf('class', function (\Illuminate\Contracts\Foundation\Application $app) {
+    return new \stdClass();
+});
+
+\Illuminate\Support\Facades\App::extends('class', function ($instance, \Illuminate\Contracts\Foundation\Application $app) {
+    return new \stdClass();
+});
+
+\Illuminate\Support\Facades\App::resolving('class', function ($instance, \Illuminate\Contracts\Foundation\Application $app) {
+    return new \stdClass();
+});
+
+?>

--- a/tests/Sets/TypeDeclaration/ServiceContainer/ServiceContainerTypeDeclarationSetTest.php
+++ b/tests/Sets/TypeDeclaration/ServiceContainer/ServiceContainerTypeDeclarationSetTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Sets\TypeDeclaration\ServiceContainer;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ServiceContainerTypeDeclarationSetTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Sets/TypeDeclaration/ServiceContainer/config/configured_rule.php
+++ b/tests/Sets/TypeDeclaration/ServiceContainer/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/sets/type-declaration/service-container.php');
+};


### PR DESCRIPTION
Still a work in progress but would love some early feedback.

# Changes

* deprecates two older rules for the new type declaration sets.
* sets up a dir for tests for the type declaration sets.
* adds new type declaration configs, one for eloquent, one for service container.

# Why

One of the powerful things about Rector is being able to add type declarations. Laravel uses a lot of closures that users of the framework often won't type hint due to not knowing the correct types to apply. These configs make use of the rules I created in the base rector repo. This will allow for configs that define what types to apply to closures.

So far documented common eloquent type hints and service container ones.

# Notes

Currently pointed at rector dev-main until a new release with the closure type hinting exists.