### PR TITLE
Drop renaming collection `every` to `nth`

### DIFF
--- a/config/sets/laravel54.php
+++ b/config/sets/laravel54.php
@@ -33,11 +33,7 @@ return static function (RectorConfig $rectorConfig): void {
         ]);
 
     $rectorConfig
-        ->ruleWithConfiguration(RenameMethodRector::class, [new MethodCallRename(
-            'Illuminate\Support\Collection',
-            'every',
-            'nth'
-        ),
+        ->ruleWithConfiguration(RenameMethodRector::class, [
             new MethodCallRename('Illuminate\Database\Eloquent\Relations\BelongsToMany', 'setJoin', 'performJoin'),
             new MethodCallRename(
                 'Illuminate\Database\Eloquent\Relations\BelongsToMany',


### PR DESCRIPTION
This PR drops renaming `every` to `nth` for collections. 
This rule is only valid when upgrading from 5.3 to 5.4 but continues to run for all sets.

Fixes #186 