### PR TITLE
Refactor If statements to use helpers with conditionals and provides a set

### DIFF
--- a/config/sets/laravel-if-helpers.php
+++ b/config/sets/laravel-if-helpers.php
@@ -1,12 +1,10 @@
 <?php
 
 declare(strict_types=1);
+use Rector\Config\RectorConfig;
 use RectorLaravel\Rector\If_\AbortIfRector;
 use RectorLaravel\Rector\If_\ReportIfRector;
 use RectorLaravel\Rector\If_\ThrowIfRector;
-
-use Rector\Config\RectorConfig;
-use RectorLaravel\Rector\Class_\ModelCastsPropertyToCastsMethodRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../config.php');

--- a/config/sets/laravel-if-helpers.php
+++ b/config/sets/laravel-if-helpers.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+use RectorLaravel\Rector\If_\AbortIfRector;
+use RectorLaravel\Rector\If_\ReportIfRector;
+use RectorLaravel\Rector\If_\ThrowIfRector;
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\ModelCastsPropertyToCastsMethodRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../config.php');
+
+    $rectorConfig->rule(AbortIfRector::class);
+    $rectorConfig->rule(ReportIfRector::class);
+    $rectorConfig->rule(ThrowIfRector::class);
+};

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,23 @@
-# 57 Rules Overview
+# 59 Rules Overview
+
+## AbortIfRector
+
+Change if abort to abort_if
+
+- class: [`RectorLaravel\Rector\If_\AbortIfRector`](../src/Rector/If_/AbortIfRector.php)
+
+```diff
+-if ($condition) {
+-    abort(404);
+-}
+-if (!$condition) {
+-    abort(404);
+-}
++abort_if($condition, 404);
++abort_unless($condition, 404);
+```
+
+<br>
 
 ## AddArgumentDefaultValueRector
 
@@ -1045,6 +1064,25 @@ Replace `withoutJobs`, `withoutEvents` and `withoutNotifications` with Facade `f
 +\Illuminate\Support\Facades\Bus::fake();
 +\Illuminate\Support\Facades\Event::fake();
 +\Illuminate\Support\Facades\Notification::fake();
+```
+
+<br>
+
+## ReportIfRector
+
+Change if report to report_if
+
+- class: [`RectorLaravel\Rector\If_\ReportIfRector`](../src/Rector/If_/ReportIfRector.php)
+
+```diff
+-if ($condition) {
+-    report(new Exception());
+-}
+-if (!$condition) {
+-    report(new Exception());
+-}
++report_if($condition, new Exception());
++report_unless($condition, new Exception());
 ```
 
 <br>

--- a/rector.php
+++ b/rector.php
@@ -10,6 +10,7 @@ return RectorConfig::configure()
     ->withPaths([
         __DIR__ . '/src',
         __DIR__ . '/tests',
+        __DIR__ . '/config',
     ])
     ->withSkip([
         // for tests

--- a/src/Rector/If_/AbortIfRector.php
+++ b/src/Rector/If_/AbortIfRector.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace RectorLaravel\Rector\If_;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\If_;
+use PhpParser\NodeTraverser;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\If_\AbortIfRector\AbortIfRectorTest
+ */
+class AbortIfRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change if abort to abort_if', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+if ($condition) {
+    abort(404);
+}
+if (!$condition) {
+    abort(404);
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+abort_if($condition, 404);
+abort_unless($condition, 404);
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [If_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node instanceof If_) {
+            return null;
+        }
+
+        $ifStmts = $node->stmts;
+
+        // Check if there's a single statement inside the if block to call abort()
+        if (
+            count($ifStmts) === 1 &&
+            $ifStmts[0] instanceof Expression &&
+            $ifStmts[0]->expr instanceof FuncCall &&
+            $ifStmts[0]->expr->name instanceof Name &&
+            $this->isName($ifStmts[0]->expr, 'abort')
+        ) {
+            $condition = $node->cond;
+            /** @var FuncCall $abortCall */
+            $abortCall = $ifStmts[0]->expr;
+
+            if ($this->exceptionUsesVariablesAssignedByCondition($abortCall, $condition)) {
+                return null;
+            }
+
+            // Check if the condition is a negation
+            if ($condition instanceof BooleanNot) {
+                // Create a new throw_unless function call
+                return new Expression(new FuncCall(new Name('abort_unless'), [
+                    new Arg($condition->expr),
+                    ...$abortCall->args,
+                ]));
+            } else {
+                // Create a new throw_if function call
+                return new Expression(new FuncCall(new Name('abort_if'), [
+                    new Arg($condition),
+                    ...$abortCall->args,
+                ]));
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Make sure the exception doesn't use variables assigned by the condition or this
+     * will cause broken code to be generated
+     */
+    private function exceptionUsesVariablesAssignedByCondition(Expr $throwExpr, Expr $condition): bool
+    {
+        $conditionVariables = [];
+        $returnValue = false;
+
+        $this->traverseNodesWithCallable($condition, function (Node $node) use (&$conditionVariables): null {
+            if ($node instanceof Assign) {
+                $conditionVariables[] = $this->getName($node->var);
+            }
+
+            return null;
+        });
+
+        $this->traverseNodesWithCallable($throwExpr, function (Node $node) use ($conditionVariables, &$returnValue): ?int {
+            if ($node instanceof Variable && in_array($this->getName($node), $conditionVariables, true)) {
+                $returnValue = true;
+
+                return NodeTraverser::STOP_TRAVERSAL;
+            }
+
+            return null;
+        });
+
+        return $returnValue;
+    }
+}

--- a/src/Rector/If_/ReportIfRector.php
+++ b/src/Rector/If_/ReportIfRector.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace RectorLaravel\Rector\If_;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\If_;
+use PhpParser\NodeTraverser;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\If_\ReportIfRector\ReportIfRectorTest
+ */
+class ReportIfRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change if report to report_if', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+if ($condition) {
+    report(new Exception());
+}
+if (!$condition) {
+    report(new Exception());
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+report_if($condition, new Exception());
+report_unless($condition, new Exception());
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [If_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node instanceof If_) {
+            return null;
+        }
+
+        $ifStmts = $node->stmts;
+
+        // Check if there's a single statement inside the if block to call abort()
+        if (
+            count($ifStmts) === 1 &&
+            $ifStmts[0] instanceof Expression &&
+            $ifStmts[0]->expr instanceof FuncCall &&
+            $ifStmts[0]->expr->name instanceof Name &&
+            $this->isName($ifStmts[0]->expr, 'report')
+        ) {
+            $condition = $node->cond;
+            /** @var FuncCall $abortCall */
+            $abortCall = $ifStmts[0]->expr;
+
+            if ($this->exceptionUsesVariablesAssignedByCondition($abortCall, $condition)) {
+                return null;
+            }
+
+            // Check if the condition is a negation
+            if ($condition instanceof BooleanNot) {
+                // Create a new throw_unless function call
+                return new Expression(new FuncCall(new Name('report_unless'), [
+                    new Arg($condition->expr),
+                    ...$abortCall->args,
+                ]));
+            } else {
+                // Create a new throw_if function call
+                return new Expression(new FuncCall(new Name('report_if'), [
+                    new Arg($condition),
+                    ...$abortCall->args,
+                ]));
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Make sure the exception doesn't use variables assigned by the condition or this
+     * will cause broken code to be generated
+     */
+    private function exceptionUsesVariablesAssignedByCondition(Expr $throwExpr, Expr $condition): bool
+    {
+        $conditionVariables = [];
+        $returnValue = false;
+
+        $this->traverseNodesWithCallable($condition, function (Node $node) use (&$conditionVariables): null {
+            if ($node instanceof Assign) {
+                $conditionVariables[] = $this->getName($node->var);
+            }
+
+            return null;
+        });
+
+        $this->traverseNodesWithCallable($throwExpr, function (Node $node) use ($conditionVariables, &$returnValue): ?int {
+            if ($node instanceof Variable && in_array($this->getName($node), $conditionVariables, true)) {
+                $returnValue = true;
+
+                return NodeTraverser::STOP_TRAVERSAL;
+            }
+
+            return null;
+        });
+
+        return $returnValue;
+    }
+}

--- a/tests/Rector/If_/AbortIfRector/AbortIfRectorTest.php
+++ b/tests/Rector/If_/AbortIfRector/AbortIfRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\If_\AbortIfRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AbortIfRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/If_/AbortIfRector/Fixture/fixture.php.inc
+++ b/tests/Rector/If_/AbortIfRector/Fixture/fixture.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\If_\AbortIfRector\Fixture;
+
+class Fixture
+{
+    public function handle($condition)
+    {
+        if ($condition) {
+            abort(404);
+        }
+        if (!$condition) {
+            abort(404);
+        }
+        if ($condition = call()) {
+            abort(404);
+        }
+        if ($condition) {
+            abort(404);
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\If_\AbortIfRector\Fixture;
+
+class Fixture
+{
+    public function handle($condition)
+    {
+        abort_if($condition, 404);
+        abort_unless($condition, 404);
+        abort_if($condition = call(), 404);
+        abort_if($condition, 404);
+    }
+}
+
+?>

--- a/tests/Rector/If_/AbortIfRector/Fixture/skip_if_more_statements.php.inc
+++ b/tests/Rector/If_/AbortIfRector/Fixture/skip_if_more_statements.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\If_\AbortIfRector\Fixture;
+
+class SkipIfMoreStatements
+{
+    public function run($condition)
+    {
+        if ($condition) {
+            echo 'hello';
+            abort(404);
+        }
+        if ($condition) {
+            throw new Exception();
+            abort(404);
+        }
+        if ($condition) {
+        }
+    }
+}
+
+?>

--- a/tests/Rector/If_/AbortIfRector/Fixture/skip_where_condition_contains_assigns_var_for_exception.php.inc
+++ b/tests/Rector/If_/AbortIfRector/Fixture/skip_where_condition_contains_assigns_var_for_exception.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\If_\AbortIfRector\Fixture;
+
+if ($foo = call() && $bar = call()) {
+    abort($bar);
+}
+
+?>

--- a/tests/Rector/If_/AbortIfRector/config/configured_rule.php
+++ b/tests/Rector/If_/AbortIfRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\If_\AbortIfRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(AbortIfRector::class);
+};

--- a/tests/Rector/If_/ReportIfRector/Fixture/fixture.php.inc
+++ b/tests/Rector/If_/ReportIfRector/Fixture/fixture.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\If_\ReportIfRector\Fixture;
+
+class Fixture
+{
+    public function handle($condition)
+    {
+        if ($condition) {
+            report(new \Exception());
+        }
+        if (!$condition) {
+            report(new \Exception());
+        }
+        if ($condition = call()) {
+            report(new \Exception());
+        }
+        if ($condition) {
+            report(new \Exception());
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\If_\ReportIfRector\Fixture;
+
+class Fixture
+{
+    public function handle($condition)
+    {
+        report_if($condition, new \Exception());
+        report_unless($condition, new \Exception());
+        report_if($condition = call(), new \Exception());
+        report_if($condition, new \Exception());
+    }
+}
+
+?>

--- a/tests/Rector/If_/ReportIfRector/Fixture/skip_if_more_statements.php.inc
+++ b/tests/Rector/If_/ReportIfRector/Fixture/skip_if_more_statements.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\If_\ReportIfRector\Fixture;
+
+class SkipIfMoreStatements
+{
+    public function run($condition)
+    {
+        if ($condition) {
+            echo 'hello';
+            report(new \Exception());
+        }
+        if ($condition) {
+        }
+    }
+}
+
+?>

--- a/tests/Rector/If_/ReportIfRector/Fixture/skip_where_condition_contains_assigns_var_for_exception.php.inc
+++ b/tests/Rector/If_/ReportIfRector/Fixture/skip_where_condition_contains_assigns_var_for_exception.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\If_\ReportIfRector\Fixture;
+
+if ($foo = call() && $bar = call()) {
+    report($bar);
+}
+
+?>

--- a/tests/Rector/If_/ReportIfRector/ReportIfRectorTest.php
+++ b/tests/Rector/If_/ReportIfRector/ReportIfRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\If_\ReportIfRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReportIfRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/If_/ReportIfRector/config/configured_rule.php
+++ b/tests/Rector/If_/ReportIfRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\If_\ReportIfRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(ReportIfRector::class);
+};


### PR DESCRIPTION
# Changes

* Adds rules for `abort_if` and `report_if` function calls as replacement for If statements containing `abort` or `report`.
* Adds tests for both rules
* Adds a set to handle the two new rules and the previous `throw_if` related rule. The set making it easier to just use all of them.
* Adds the `config` dir to rector

# Why

Makes sense to cover all the possible helpers and have a set that covers the three scenarios. The only one missing would be the Dispatchable trait static calls (dispatchIf) but it would require a new rule and feels a bit more niche compared to the helpers.