### PR TITLE
Add nikic/php-parser and sort packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,14 +8,15 @@
         "rector/rector": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
-        "phpstan/phpstan": "^1.10",
-        "symplify/phpstan-rules": "^12.4",
-        "symplify/phpstan-extensions": "^11.4",
-        "symplify/rule-doc-generator": "^12.1",
+        "nikic/php-parser": "^4.18",
         "phpstan/extension-installer": "^1.3",
-        "phpstan/phpstan-webmozart-assert": "^1.2",
+        "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-strict-rules": "^1.5",
+        "phpstan/phpstan-webmozart-assert": "^1.2",
+        "phpunit/phpunit": "^10.5",
+        "symplify/phpstan-extensions": "^11.4",
+        "symplify/phpstan-rules": "^12.4",
+        "symplify/rule-doc-generator": "^12.1",
         "tightenco/duster": "^2.7"
     },
     "autoload": {


### PR DESCRIPTION
Currently, the build fails because installing the packages allows for `nikic/php-parser` to install the latest version (^5.0) but currently the new API for v5 breaks PHPStan but resolving the PHPStan issues will cause the tests to fail. For now, locking the dev requirement keeps the build working as expected and doesn't appear to affect the running of tests.