### PR TITLE
[Laravel110] Blueprint geometry columns

### DIFF
--- a/config/sets/laravel110.php
+++ b/config/sets/laravel110.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use RectorLaravel\Rector\Class_\ModelCastsPropertyToCastsMethodRector;
+use RectorLaravel\Rector\MethodCall\RefactorBlueprintGeometryColumnsRector;
 
 // see https://laravel.com/docs/11.x/upgrade
 return static function (RectorConfig $rectorConfig): void {
@@ -11,4 +12,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     // https://github.com/laravel/framework/pull/47237
     $rectorConfig->rule(ModelCastsPropertyToCastsMethodRector::class);
+
+    // https://github.com/laravel/framework/pull/49810
+    $rectorConfig->rule(RefactorBlueprintGeometryColumnsRector::class);
 };

--- a/config/sets/laravel110.php
+++ b/config/sets/laravel110.php
@@ -13,6 +13,6 @@ return static function (RectorConfig $rectorConfig): void {
     // https://github.com/laravel/framework/pull/47237
     $rectorConfig->rule(ModelCastsPropertyToCastsMethodRector::class);
 
-    // https://github.com/laravel/framework/pull/49810
+    // https://github.com/laravel/framework/pull/49634
     $rectorConfig->rule(RefactorBlueprintGeometryColumnsRector::class);
 };

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 60 Rules Overview
+# 61 Rules Overview
 
 ## AbortIfRector
 
@@ -917,6 +917,19 @@ Replace `redirect()->route("home")` and `Redirect::route("home")` with `to_route
 +        return to_route('home')->with('error', 'Incorrect Details.')
      }
  }
+```
+
+<br>
+
+## RefactorBlueprintGeometryColumnsRector
+
+refactors calls with the pre Laravel 11 methods for blueprint geometry columns
+
+- class: [`RectorLaravel\Rector\MethodCall\RefactorBlueprintGeometryColumnsRector`](../src/Rector/MethodCall/RefactorBlueprintGeometryColumnsRector.php)
+
+```diff
+-$blueprint->point('coordinates')->spatialIndex();
++$blueprint->geometry('coordinates', 'point')->spatialIndex();
 ```
 
 <br>

--- a/src/Rector/MethodCall/RefactorBlueprintGeometryColumnsRector.php
+++ b/src/Rector/MethodCall/RefactorBlueprintGeometryColumnsRector.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace RectorLaravel\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Type\ObjectType;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\MethodCall\RefactorBlueprintGeometryColumnsRector\RefactorBlueprintGeometryColumnsRectorTest
+ */
+class RefactorBlueprintGeometryColumnsRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'refactors calls with the pre Laravel 11 methods for blueprint geometry columns',
+            [new CodeSample(<<<'CODE_SAMPLE'
+$blueprint->point('coordinates')->spatialIndex();
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+$blueprint->geometry('coordinates', 'point')->spatialIndex();
+CODE_SAMPLE,
+            )]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param  Node\Expr\MethodCall  $node
+     */
+    public function refactor(Node $node): ?MethodCall
+    {
+        if (! $this->isNames($node->name, [
+            'point',
+            'linestring',
+            'polygon',
+            'geometrycollection',
+            'multipoint',
+            'multilinestring',
+            'multipolygon',
+
+        ])) {
+            return null;
+        }
+
+        if (! $node->name instanceof Identifier) {
+            return null;
+        }
+
+        if (! $this->isObjectType($node->var, new ObjectType('Illuminate\Database\Schema\Blueprint'))) {
+            return null;
+        }
+
+        $previousName = $node->name;
+
+        $node->name = new Identifier('geometry');
+        $node->args[] = new Arg(new String_($previousName->name));
+
+        return $node;
+    }
+}

--- a/tests/Rector/MethodCall/RefactorBlueprintGeometryColumnsRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/RefactorBlueprintGeometryColumnsRector/Fixture/fixture.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RefactorBlueprintGeometryColumnsRector\Fixture;
+
+/** @var \Illuminate\Database\Schema\Blueprint $table */
+$table->point('coordinates')->spatialIndex();
+$table->linestring('coordinates')->spatialIndex();
+$table->polygon('coordinates')->spatialIndex();
+$table->geometrycollection('coordinates')->spatialIndex();
+$table->multipoint('coordinates')->spatialIndex();
+$table->multilinestring('coordinates')->spatialIndex();
+$table->multipolygon('coordinates')->spatialIndex();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RefactorBlueprintGeometryColumnsRector\Fixture;
+
+/** @var \Illuminate\Database\Schema\Blueprint $table */
+$table->geometry('coordinates', 'point')->spatialIndex();
+$table->geometry('coordinates', 'linestring')->spatialIndex();
+$table->geometry('coordinates', 'polygon')->spatialIndex();
+$table->geometry('coordinates', 'geometrycollection')->spatialIndex();
+$table->geometry('coordinates', 'multipoint')->spatialIndex();
+$table->geometry('coordinates', 'multilinestring')->spatialIndex();
+$table->geometry('coordinates', 'multipolygon')->spatialIndex();
+
+?>

--- a/tests/Rector/MethodCall/RefactorBlueprintGeometryColumnsRector/Fixture/skip_non_blueprint_objects.php.inc
+++ b/tests/Rector/MethodCall/RefactorBlueprintGeometryColumnsRector/Fixture/skip_non_blueprint_objects.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RefactorBlueprintGeometryColumnsRector\Fixture;
+
+/** @var \stdClass $table */
+$table->point('coordinates')->spatialIndex();
+$table->linestring('coordinates')->spatialIndex();
+$table->polygon('coordinates')->spatialIndex();
+$table->geometrycollection('coordinates')->spatialIndex();
+$table->multipoint('coordinates')->spatialIndex();
+$table->multilinestring('coordinates')->spatialIndex();
+$table->multipolygon('coordinates')->spatialIndex();
+
+?>

--- a/tests/Rector/MethodCall/RefactorBlueprintGeometryColumnsRector/Fixture/skip_non_matching_method_call.php.inc
+++ b/tests/Rector/MethodCall/RefactorBlueprintGeometryColumnsRector/Fixture/skip_non_matching_method_call.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RefactorBlueprintGeometryColumnsRector\Fixture;
+
+/** @var \Illuminate\Database\Schema\Blueprint $table */
+$table->string('coordinates')->nullable();
+
+?>

--- a/tests/Rector/MethodCall/RefactorBlueprintGeometryColumnsRector/RefactorBlueprintGeometryColumnsRectorTest.php
+++ b/tests/Rector/MethodCall/RefactorBlueprintGeometryColumnsRector/RefactorBlueprintGeometryColumnsRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RefactorBlueprintGeometryColumnsRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RefactorBlueprintGeometryColumnsRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/RefactorBlueprintGeometryColumnsRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/RefactorBlueprintGeometryColumnsRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\MethodCall\RefactorBlueprintGeometryColumnsRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(RefactorBlueprintGeometryColumnsRector::class);
+};


### PR DESCRIPTION
# Changes

* Additional rule
* Tests for the rule
* Docs updates
* Adds the rule to the Laravel 11 set

# Why

Adds a new rule for Laravel 11 to cover Spatial types in migrations https://laravel.com/docs/11.x/upgrade#spatial-types

# Notes

This probably doesn't cover all cases but is a good start at least. It's quite hard to follow all the changes in the PR.