### PR TITLE
Remove redundant ArgumentAdderRector for nullable arguments

### DIFF
--- a/config/sets/laravel60.php
+++ b/config/sets/laravel60.php
@@ -71,8 +71,5 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig
         ->ruleWithConfiguration(ArgumentAdderRector::class, [                // https://github.com/laravel/framework/commit/6c1e014943a508afb2c10869c3175f7783a004e1
             new ArgumentAdder('Illuminate\Database\Capsule\Manager', 'table', 1, 'as', null),
-            new ArgumentAdder('Illuminate\Database\Connection', 'table', 1, 'as', null),
-            new ArgumentAdder('Illuminate\Database\ConnectionInterface', 'table', 1, 'as', null),
-            new ArgumentAdder('Illuminate\Database\Query\Builder', 'from', 1, 'as', null),
         ]);
 };


### PR DESCRIPTION
Fixes #110 

The 3 rules can be safely removed, as the methods previously did not expect a second parameter ([framework change link](https://github.com/laravel/framework/commit/6c1e014943a508afb2c10869c3175f7783a004e1)).

The only class where the `as` parameter was put in the middle of two other parameters was `Illuminate/Database/Capsule/Manager::table()`, so I left that in the Laravel 6 set. The chances of extending it are small and, in that case, this rule would probably help.

Ideally, we'd also modify the original `ArgumentAdderRector` class to not add these default parameters in MethodCalls or StaticCalls, but that's another more complex problem.