### PR TITLE
Fix redundant default arguments in Laravel 9 Set

### DIFF
--- a/config/sets/laravel90.php
+++ b/config/sets/laravel90.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Arguments\Rector\ClassMethod\ArgumentAdderRector;
-use Rector\Arguments\ValueObject\ArgumentAdder;
+use Rector\Arguments\ValueObject\ArgumentAdderWithoutDefaultValue;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
@@ -19,29 +19,27 @@ return static function (RectorConfig $rectorConfig): void {
 
     // https://github.com/laravel/framework/commit/8f9ddea4481717943ed4ecff96d86b703c81a87d
     $rectorConfig
-        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
+        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdderWithoutDefaultValue(
             'Illuminate\Contracts\Foundation\Application',
             'storagePath',
             0,
             'path',
-            ''
         ),
         ]);
 
     // https://github.com/laravel/framework/commit/e6c8aaea886d35cc55bd3469f1a95ad56d53e474
     $rectorConfig
-        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
+        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdderWithoutDefaultValue(
             'Illuminate\Foundation\Application',
             'langPath',
             0,
             'path',
-            ''
         ),
         ]);
 
     // https://github.com/laravel/framework/commit/e095ac0e928b5620f33c9b60816fde5ece867d32
     $rectorConfig
-        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
+        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdderWithoutDefaultValue(
             'Illuminate\Database\Eloquent\Model',
             'touch',
             0,
@@ -51,7 +49,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     // https://github.com/laravel/framework/commit/6daecf43dd931dc503e410645ff4a7d611e3371f
     $rectorConfig
-        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
+        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdderWithoutDefaultValue(
             'Illuminate\Queue\Failed\FailedJobProviderInterface',
             'flush',
             0,

--- a/stubs/Illuminate/Foundation/Application.php
+++ b/stubs/Illuminate/Foundation/Application.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Foundation;
+
+if (class_exists('Illuminate\Foundation\Application')) {
+    return;
+}
+
+class Application
+{
+}

--- a/stubs/Illuminate/Foundation/Exceptions/Handler.php
+++ b/stubs/Illuminate/Foundation/Exceptions/Handler.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Foundation\Exceptions;
+
+if (class_exists('Illuminate\Foundation\Exceptions\Handler')) {
+    return;
+}
+
+class Handler
+{
+}

--- a/stubs/Illuminate/Mail/MailManager.php
+++ b/stubs/Illuminate/Mail/MailManager.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Mail;
+
+if (class_exists('Illuminate\Mail\MailManager')) {
+    return;
+}
+
+class MailManager
+{
+}

--- a/stubs/Illuminate/Mail/Mailable.php
+++ b/stubs/Illuminate/Mail/Mailable.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Mail;
+
+if (class_exists('Illuminate\Mail\Mailable')) {
+    return;
+}
+
+class Mailable
+{
+}

--- a/stubs/Illuminate/Mail/Mailer.php
+++ b/stubs/Illuminate/Mail/Mailer.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Mail;
+
+if (class_exists('Illuminate\Mail\Mailer')) {
+    return;
+}
+
+class Mailer
+{
+}

--- a/stubs/Illuminate/Mail/Message.php
+++ b/stubs/Illuminate/Mail/Message.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Mail;
+
+if (class_exists('Illuminate\Mail\Message')) {
+    return;
+}
+
+class Message
+{
+}

--- a/stubs/Illuminate/Notifications/Messages/MailMessage.php
+++ b/stubs/Illuminate/Notifications/Messages/MailMessage.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Notifications\Messages;
+
+if (class_exists('Illuminate\Notifications\Messages\MailMessage')) {
+    return;
+}
+
+class MailMessage
+{
+}

--- a/stubs/Illuminate/Queue/Failed/FailedJobProviderInterface.php
+++ b/stubs/Illuminate/Queue/Failed/FailedJobProviderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Queue\Failed;
+
+if (class_exists('Illuminate\Queue\Failed\FailedJobProviderInterface')) {
+    return;
+}
+
+interface FailedJobProviderInterface
+{
+}

--- a/stubs/Illuminate/Support/Enumerable.php
+++ b/stubs/Illuminate/Support/Enumerable.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Support;
+
+if (class_exists('Illuminate\Support\Enumerable')) {
+    return;
+}
+
+interface Enumerable
+{
+}

--- a/stubs/Illuminate/Testing/TestResponse.php
+++ b/stubs/Illuminate/Testing/TestResponse.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Testing;
+
+if (class_exists('Illuminate\Testing\TestResponse')) {
+    return;
+}
+
+class TestResponse
+{
+}

--- a/tests/Sets/Laravel90/Fixture/application_lang_path_new_attribute.php.inc
+++ b/tests/Sets/Laravel90/Fixture/application_lang_path_new_attribute.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel90;
+
+use Illuminate\Foundation\Application;
+
+class SomeFixture
+{
+    protected Application $app;
+
+    public function run(): void
+    {
+        $this->app->langPath();
+    }
+}
+
+?>

--- a/tests/Sets/Laravel90/Fixture/application_storage_path_new_attribute.php.inc
+++ b/tests/Sets/Laravel90/Fixture/application_storage_path_new_attribute.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel90;
+
+use Illuminate\Contracts\Foundation\Application;
+
+class SomeFixture
+{
+    protected Application $app;
+
+    public function run(): void
+    {
+        $this->app->storagePath();
+    }
+}
+
+?>

--- a/tests/Sets/Laravel90/Fixture/exceptions_handler_ignore_with_public_visibility.php.inc
+++ b/tests/Sets/Laravel90/Fixture/exceptions_handler_ignore_with_public_visibility.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel90;
+
+use Illuminate\Foundation\Exceptions\Handler;
+
+class CustomHandler extends Handler
+{
+    protected function ignore(string $class)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel90;
+
+use Illuminate\Foundation\Exceptions\Handler;
+
+class CustomHandler extends Handler
+{
+    public function ignore(string $class)
+    {
+    }
+}
+
+?>

--- a/tests/Sets/Laravel90/Fixture/failed_job_provider_interface_new_attribute.php.inc
+++ b/tests/Sets/Laravel90/Fixture/failed_job_provider_interface_new_attribute.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel90;
+
+use Illuminate\Queue\Failed\FailedJobProviderInterface;
+
+class FailedJobProvider implements FailedJobProviderInterface
+{
+    public function flush($age = null)
+    {
+    }
+}
+
+$provider = new FailedJobProvider();
+$provider->flush();
+$provider->flush(10);
+
+?>

--- a/tests/Sets/Laravel90/Fixture/method_renames.php.inc
+++ b/tests/Sets/Laravel90/Fixture/method_renames.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel90;
+
+
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailer;
+use Illuminate\Mail\MailManager;
+use Illuminate\Mail\Message;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Testing\TestResponse;
+use RectorLaravel\Tests\Sets\Laravel90\Source\Collection;
+
+(new Collection())->reduceWithKeys(fn () => null);
+(new Collection())->reduceMany(fn () => null);
+
+(new Message())->getSwiftMessage();
+(new Mailable())->withSwiftMessage();
+(new MailMessage())->withSwiftMessage();
+(new Mailer())->getSwiftMailer();
+(new Mailer())->setSwiftMailer();
+(new MailManager())->createTransport();
+
+(new TestResponse())->assertDeleted(null);
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel90;
+
+
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailer;
+use Illuminate\Mail\MailManager;
+use Illuminate\Mail\Message;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Testing\TestResponse;
+use RectorLaravel\Tests\Sets\Laravel90\Source\Collection;
+
+(new Collection())->reduce(fn () => null);
+(new Collection())->reduceSpread(fn () => null);
+
+(new Message())->getSymfonyMessage();
+(new Mailable())->withSymfonyMessage();
+(new MailMessage())->withSymfonyMessage();
+(new Mailer())->getSymfonyTransport();
+(new Mailer())->setSymfonyTransport();
+(new MailManager())->createSymfonyTransport();
+
+(new TestResponse())->assertModelMissing(null);
+
+?>

--- a/tests/Sets/Laravel90/Fixture/model_touch_new_attribute.php.inc
+++ b/tests/Sets/Laravel90/Fixture/model_touch_new_attribute.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel90;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model {}
+
+$user = new User();
+$user->touch();
+
+?>

--- a/tests/Sets/Laravel90/Laravel90Test.php
+++ b/tests/Sets/Laravel90/Laravel90Test.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Sets\Laravel90;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class Laravel90Test extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Sets/Laravel90/Source/Collection.php
+++ b/tests/Sets/Laravel90/Source/Collection.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel90\Source;
+
+use Illuminate\Support\Enumerable;
+
+class Collection implements Enumerable
+{
+}

--- a/tests/Sets/Laravel90/config/configured_rule.php
+++ b/tests/Sets/Laravel90/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../config/sets/laravel90.php');
+};


### PR DESCRIPTION
Fixes https://github.com/driftingly/rector-laravel/issues/220.

This PR also handles similar cases in the Laravel 9 set, where we add redundant default variables, and covers with tests all the changes of the set.