### PR TITLE
Add failing test for jobs imported as alias

### DIFF
--- a/tests/Rector/FuncCall/DispatchNonShouldQueueToDispatchSyncRector/Fixture/skip_alias_with_should_queue_implementing_jobs.php.inc
+++ b/tests/Rector/FuncCall/DispatchNonShouldQueueToDispatchSyncRector/Fixture/skip_alias_with_should_queue_implementing_jobs.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\DispatchNonShouldQueueToDispatchSyncRector\Fixture;
+
+use RectorLaravel\Tests\Rector\FuncCall\DispatchNonShouldQueueToDispatchSyncRector\Source\QueueableJob as AliasQueueableJob;
+
+dispatch(new AliasQueueableJob());
+
+?>


### PR DESCRIPTION
Using the rule `DispatchNonShouldQueueToDispatchSyncRector` it should detect the `ShouldQueue` interface on a class even when it is imported as alias. This PR adds a failing test for this case. 