### PR TITLE
Use FullyQualified for class instead of Name

### DIFF
--- a/src/Rector/StaticCall/DispatchToHelperFunctionsRector.php
+++ b/src/Rector/StaticCall/DispatchToHelperFunctionsRector.php
@@ -128,7 +128,7 @@ final class DispatchToHelperFunctionsRector extends AbstractRector
         return new FuncCall(
             new Name($method),
             [
-                new Arg(new New_(new Name($class), $staticCall->args)),
+                new Arg(new New_(new Name\FullyQualified($class), $staticCall->args)),
             ],
         );
     }

--- a/src/Rector/StaticCall/DispatchToHelperFunctionsRector.php
+++ b/src/Rector/StaticCall/DispatchToHelperFunctionsRector.php
@@ -2,13 +2,13 @@
 
 namespace RectorLaravel\Rector\StaticCall;
 
-use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Broker\ClassNotFoundException;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;

--- a/src/Rector/StaticCall/DispatchToHelperFunctionsRector.php
+++ b/src/Rector/StaticCall/DispatchToHelperFunctionsRector.php
@@ -2,6 +2,7 @@
 
 namespace RectorLaravel\Rector\StaticCall;
 
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\FuncCall;
@@ -128,7 +129,7 @@ final class DispatchToHelperFunctionsRector extends AbstractRector
         return new FuncCall(
             new Name($method),
             [
-                new Arg(new New_(new Name\FullyQualified($class), $staticCall->args)),
+                new Arg(new New_(new FullyQualified($class), $staticCall->args)),
             ],
         );
     }

--- a/tests/Rector/StaticCall/DispatchToHelperFunctionsRector/Fixture/bus_dispatchable.php.inc
+++ b/tests/Rector/StaticCall/DispatchToHelperFunctionsRector/Fixture/bus_dispatchable.php.inc
@@ -12,4 +12,4 @@ namespace RectorLaravel\Tests\Rector\StaticCall\DispatchToHelperFunctionsRector\
 
 use RectorLaravel\Tests\Rector\StaticCall\DispatchToHelperFunctionsRector\Source\TestJob;
 
-dispatch(new RectorLaravel\Tests\Rector\StaticCall\DispatchToHelperFunctionsRector\Source\TestJob('param1', 'param2'));
+dispatch(new \RectorLaravel\Tests\Rector\StaticCall\DispatchToHelperFunctionsRector\Source\TestJob('param1', 'param2'));

--- a/tests/Rector/StaticCall/DispatchToHelperFunctionsRector/Fixture/event_dispatchable.php.inc
+++ b/tests/Rector/StaticCall/DispatchToHelperFunctionsRector/Fixture/event_dispatchable.php.inc
@@ -12,4 +12,4 @@ namespace RectorLaravel\Tests\Rector\StaticCall\DispatchToHelperFunctionsRector\
 
 use RectorLaravel\Tests\Rector\StaticCall\DispatchToHelperFunctionsRector\Source\TestEvent;
 
-event(new RectorLaravel\Tests\Rector\StaticCall\DispatchToHelperFunctionsRector\Source\TestEvent('param1', 'param2'));
+event(new \RectorLaravel\Tests\Rector\StaticCall\DispatchToHelperFunctionsRector\Source\TestEvent('param1', 'param2'));


### PR DESCRIPTION
This ensures a leading slash `\` is added to the namespace of the class that is newed up, ensuring the namespace is loaded from the root and not relative to the current namespace.

Currently this rector breaks my code as it changes the code into something that does not work.

```diff
@@ @@
     public function handleTenant(TenantWithDatabase $tenant): void
     {
         $tenant->run(function (): void {
-            CreateTenantBrandingAvatarsJob::dispatch()->onQueue(Queue::CENTRAL);
+            dispatch(new App\Central\Jobs\CreateTenantBrandingAvatarsJob())->onQueue(Queue::CENTRAL);
         });
     }
 }
    ----------- end diff -----------

Applied rules:
 * DispatchToHelperFunctionsRector
```

Note the missing `\` before `App`. This results in a namespace that can not be resolved. And broken tests

![image](https://github.com/driftingly/rector-laravel/assets/2302867/ad9bf868-7df0-420a-805f-268997866a53)

But with the leading slash, it's correct.

![image](https://github.com/driftingly/rector-laravel/assets/2302867/2125ebc4-11ad-4d29-9c7a-50ac6c7b1183)
