### PR TITLE
Update laravel-arrayaccess-to-method-call.php

### DIFF
--- a/config/sets/laravel-arrayaccess-to-method-call.php
+++ b/config/sets/laravel-arrayaccess-to-method-call.php
@@ -29,6 +29,14 @@ return static function (RectorConfig $rectorConfig): void {
                     new ObjectType('Illuminate\Contracts\Config\Repository'),
                     'make',
                 ),
+                new ArrayDimFetchToMethodCall(
+                    new ObjectType('Illuminate\Contracts\Container\Container\Application'),
+                    'make',
+                ),
+                new ArrayDimFetchToMethodCall(
+                    new ObjectType('Illuminate\Contracts\Container\Container'),
+                    'make',
+                ),
             ],
         );
 };

--- a/config/sets/laravel-arrayaccess-to-method-call.php
+++ b/config/sets/laravel-arrayaccess-to-method-call.php
@@ -18,8 +18,16 @@ return static function (RectorConfig $rectorConfig): void {
                     'make',
                 ),
                 new ArrayDimFetchToMethodCall(
+                    new ObjectType('Illuminate\Contracts\Foundation\Application'),
+                    'make',
+                ),
+                new ArrayDimFetchToMethodCall(
                     new ObjectType('Illuminate\Config\Repository'),
                     'get',
+                ),
+                new ArrayDimFetchToMethodCall(
+                    new ObjectType('Illuminate\Contracts\Config\Repository'),
+                    'make',
                 ),
             ],
         );


### PR DESCRIPTION
# Changes

This adds the interface types to the config

# Why

Without these it's likely the set will miss a number of the instances where the rule could be applied.