### PR TITLE
Update laravel-container-string-to-fully-qualified-name.php

### DIFF
--- a/config/sets/laravel-container-string-to-fully-qualified-name.php
+++ b/config/sets/laravel-container-string-to-fully-qualified-name.php
@@ -47,7 +47,7 @@ return static function (RectorConfig $rectorConfig): void {
         'migrator' => 'Illuminate\Database\Migrations\Migrator',
         'migration.creator' => 'Illuminate\Database\Migrations\MigrationCreator',
         'composer' => 'Illuminate\Support\Composer',
-        'hash' => 'Illuminate\Contracts\Hashing\Hasher',
+        'hash' => 'Illuminate\Hashing\HashManager',
         'hash.driver' => 'Illuminate\Contracts\Hashing\Hasher',
         'mail.manager' => 'Illuminate\Contracts\Mail\Factory',
         'mailer' => 'Illuminate\Mail\Mailer',

--- a/tests/Sets/ContainerStringToFullyQualifiedName/Fixture/fixture.php.inc
+++ b/tests/Sets/ContainerStringToFullyQualifiedName/Fixture/fixture.php.inc
@@ -53,7 +53,7 @@ app(\Illuminate\Cache\Repository::class);
 app(\Illuminate\Contracts\Filesystem\Factory::class);
 app(\Illuminate\Encryption\Encrypter::class);
 app(\Illuminate\Filesystem\Filesystem::class);
-app(\Illuminate\Contracts\Hashing\Hasher::class);
+app(\Illuminate\Hashing\HashManager::class);
 app(\Illuminate\Mail\Mailer::class);
 
 ?>


### PR DESCRIPTION
# Why

'hash' points to the incorrect implementation and should point to `Illuminate\Hashing\HashManager` instead of the Hasher contract.