### PR TITLE
Fix code style

### DIFF
--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,6 @@
+{
+    "rules": {
+        "single_line_empty_body": false,
+        "concat_space": false
+    }
+}


### PR DESCRIPTION
https://github.com/driftingly/rector-laravel/issues/228

Adds a `pint.json` configuration that skips the new defaults for the rules `single_line_empty_body` and `concat_space`.
