### PR TITLE
Fix Argument Adding rules in Laravel 9 set

### DIFF
--- a/config/sets/laravel80.php
+++ b/config/sets/laravel80.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\MixedType;
 use Rector\Arguments\Rector\ClassMethod\ArgumentAdderRector;
-use Rector\Arguments\ValueObject\ArgumentAdder;
+use Rector\Arguments\ValueObject\ArgumentAdderWithoutDefaultValue;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
@@ -21,12 +21,11 @@ return static function (RectorConfig $rectorConfig): void {
 
     // https://github.com/laravel/framework/commit/4d228d6e9dbcbd4d97c45665980d8b8c685b27e6
     $rectorConfig
-        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
+        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdderWithoutDefaultValue(
             'Illuminate\Contracts\Database\Eloquent\Castable',
             'castUsing',
             0,
             'arguments',
-            [], // TODO: Add argument without default value
             new ArrayType(new MixedType, new MixedType)
         ),
         ]);

--- a/config/sets/laravel90.php
+++ b/config/sets/laravel90.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
+use Rector\Arguments\NodeAnalyzer\ArgumentAddingScope;
 use Rector\Arguments\Rector\ClassMethod\ArgumentAdderRector;
-use Rector\Arguments\ValueObject\ArgumentAdderWithoutDefaultValue;
+use Rector\Arguments\ValueObject\ArgumentAdder;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
@@ -19,41 +20,40 @@ return static function (RectorConfig $rectorConfig): void {
 
     // https://github.com/laravel/framework/commit/8f9ddea4481717943ed4ecff96d86b703c81a87d
     $rectorConfig
-        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdderWithoutDefaultValue(
+        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
             'Illuminate\Contracts\Foundation\Application',
             'storagePath',
             0,
             'path',
+            '',
+            null,
+            ArgumentAddingScope::SCOPE_CLASS_METHOD,
         ),
         ]);
 
     // https://github.com/laravel/framework/commit/e6c8aaea886d35cc55bd3469f1a95ad56d53e474
     $rectorConfig
-        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdderWithoutDefaultValue(
+        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
             'Illuminate\Foundation\Application',
             'langPath',
             0,
             'path',
+            '',
+            null,
+            ArgumentAddingScope::SCOPE_CLASS_METHOD,
         ),
         ]);
 
     // https://github.com/laravel/framework/commit/e095ac0e928b5620f33c9b60816fde5ece867d32
     $rectorConfig
-        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdderWithoutDefaultValue(
+        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
             'Illuminate\Database\Eloquent\Model',
             'touch',
             0,
             'attribute',
-        ),
-        ]);
-
-    // https://github.com/laravel/framework/commit/6daecf43dd931dc503e410645ff4a7d611e3371f
-    $rectorConfig
-        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdderWithoutDefaultValue(
-            'Illuminate\Queue\Failed\FailedJobProviderInterface',
-            'flush',
-            0,
-            'hours',
+            null,
+            null,
+            ArgumentAddingScope::SCOPE_CLASS_METHOD,
         ),
         ]);
 

--- a/stubs/Illuminate/Container/Container.php
+++ b/stubs/Illuminate/Container/Container.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Container;
+
+use Illuminate\Contracts\Container\Container as ContainerContract;
+
+class Container implements ContainerContract
+{
+}

--- a/stubs/Illuminate/Contracts/Container/Container.php
+++ b/stubs/Illuminate/Contracts/Container/Container.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Illuminate\Contracts\Container;
+
+interface Container
+{
+}

--- a/stubs/Illuminate/Contracts/Foundation/Application.php
+++ b/stubs/Illuminate/Contracts/Foundation/Application.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace Illuminate\Contracts\Foundation;
 
+use Illuminate\Contracts\Container\Container;
+
 if (class_exists('Illuminate\Contracts\Foundation\Application')) {
     return;
 }
 
-final class Application
+interface Application extends Container
 {
-    public function tagged(string $tagName): iterable
-    {
-        return [];
-    }
+    public function tagged(string $tagName): iterable;
+
+    public function storagePath($path = '');
 }

--- a/stubs/Illuminate/Database/Eloquent/Model.php
+++ b/stubs/Illuminate/Database/Eloquent/Model.php
@@ -8,4 +8,12 @@ if (class_exists('Illuminate\Database\Eloquent\Model')) {
 
 abstract class Model
 {
+    /**
+     * Exists in the Illuminate/Database/Eloquent/Concerns/HasTimestamps trait
+     * Put here for simplicity
+     */
+    public function touch($attribute = null)
+    {
+        return true;
+    }
 }

--- a/stubs/Illuminate/Foundation/Application.php
+++ b/stubs/Illuminate/Foundation/Application.php
@@ -4,10 +4,27 @@ declare(strict_types=1);
 
 namespace Illuminate\Foundation;
 
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Foundation\Application as ApplicationContract;
+
 if (class_exists('Illuminate\Foundation\Application')) {
     return;
 }
 
-class Application
+class Application extends Container implements ApplicationContract
 {
+    public function tagged(string $tagName): iterable
+    {
+        return [];
+    }
+
+    public function storagePath($path = '')
+    {
+        return $path;
+    }
+
+    public function langPath($path = '')
+    {
+        return $path;
+    }
 }

--- a/stubs/Illuminate/Queue/Failed/FailedJobProviderInterface.php
+++ b/stubs/Illuminate/Queue/Failed/FailedJobProviderInterface.php
@@ -10,4 +10,13 @@ if (class_exists('Illuminate\Queue\Failed\FailedJobProviderInterface')) {
 
 interface FailedJobProviderInterface
 {
+    public function log($connection, $queue, $payload, $exception);
+
+    public function all();
+
+    public function find($id);
+
+    public function forget($id);
+
+    public function flush($hours = null);
 }

--- a/tests/Sets/Laravel90/Fixture/application_class_lang_path_new_attribute.php.inc.php.inc
+++ b/tests/Sets/Laravel90/Fixture/application_class_lang_path_new_attribute.php.inc.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel90\Fixture;
+
+use Illuminate\Foundation\Application;
+
+class CustomApplication extends Application
+{
+    public function langPath(): string
+    {
+        return '';
+    }
+
+}
+
+$customApp = new CustomApplication();
+$customApp->langPath();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel90\Fixture;
+
+use Illuminate\Foundation\Application;
+
+class CustomApplication extends Application
+{
+    public function langPath($path = ''): string
+    {
+        return '';
+    }
+
+}
+
+$customApp = new CustomApplication();
+$customApp->langPath();
+
+?>

--- a/tests/Sets/Laravel90/Fixture/application_class_storage_path_new_attribute.php.inc.php.inc
+++ b/tests/Sets/Laravel90/Fixture/application_class_storage_path_new_attribute.php.inc.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel90\Fixture;
+
+use Illuminate\Foundation\Application;
+
+class CustomApplication extends Application
+{
+    public function storagePath(): string
+    {
+        return '';
+    }
+
+}
+
+$customApp = new CustomApplication();
+$customApp->storagePath();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel90\Fixture;
+
+use Illuminate\Foundation\Application;
+
+class CustomApplication extends Application
+{
+    public function storagePath($path = ''): string
+    {
+        return '';
+    }
+
+}
+
+$customApp = new CustomApplication();
+$customApp->storagePath();
+
+?>

--- a/tests/Sets/Laravel90/Fixture/application_lang_path_new_attribute.php.inc
+++ b/tests/Sets/Laravel90/Fixture/application_lang_path_new_attribute.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace RectorLaravel\Tests\Sets\Laravel90;
+namespace RectorLaravel\Tests\Sets\Laravel90\Fixture;
 
 use Illuminate\Foundation\Application;
 

--- a/tests/Sets/Laravel90/Fixture/application_storage_path_new_attribute.php.inc
+++ b/tests/Sets/Laravel90/Fixture/application_storage_path_new_attribute.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace RectorLaravel\Tests\Sets\Laravel90;
+namespace RectorLaravel\Tests\Sets\Laravel90\Fixture;
 
 use Illuminate\Contracts\Foundation\Application;
 

--- a/tests/Sets/Laravel90/Fixture/exceptions_handler_ignore_with_public_visibility.php.inc
+++ b/tests/Sets/Laravel90/Fixture/exceptions_handler_ignore_with_public_visibility.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace RectorLaravel\Tests\Sets\Laravel90;
+namespace RectorLaravel\Tests\Sets\Laravel90\Fixture;
 
 use Illuminate\Foundation\Exceptions\Handler;
 
@@ -15,7 +15,7 @@ class CustomHandler extends Handler
 -----
 <?php
 
-namespace RectorLaravel\Tests\Sets\Laravel90;
+namespace RectorLaravel\Tests\Sets\Laravel90\Fixture;
 
 use Illuminate\Foundation\Exceptions\Handler;
 

--- a/tests/Sets/Laravel90/Fixture/failed_job_provider_interface_new_attribute.php.inc
+++ b/tests/Sets/Laravel90/Fixture/failed_job_provider_interface_new_attribute.php.inc
@@ -1,12 +1,28 @@
 <?php
 
-namespace RectorLaravel\Tests\Sets\Laravel90;
+namespace RectorLaravel\Tests\Sets\Laravel90\Fixture;
 
 use Illuminate\Queue\Failed\FailedJobProviderInterface;
 
 class FailedJobProvider implements FailedJobProviderInterface
 {
     public function flush($age = null)
+    {
+    }
+
+    public function log($connection, $queue, $payload, $exception)
+    {
+    }
+
+    public function all()
+    {
+    }
+
+    public function find($id)
+    {
+    }
+
+    public function forget($id)
     {
     }
 }

--- a/tests/Sets/Laravel90/Fixture/method_renames.php.inc
+++ b/tests/Sets/Laravel90/Fixture/method_renames.php.inc
@@ -1,15 +1,14 @@
 <?php
 
-namespace RectorLaravel\Tests\Sets\Laravel90;
-
+namespace RectorLaravel\Tests\Sets\Laravel90\Fixture;
 
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailer;
 use Illuminate\Mail\MailManager;
 use Illuminate\Mail\Message;
 use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\Collection;
 use Illuminate\Testing\TestResponse;
-use RectorLaravel\Tests\Sets\Laravel90\Source\Collection;
 
 (new Collection())->reduceWithKeys(fn () => null);
 (new Collection())->reduceMany(fn () => null);
@@ -27,16 +26,15 @@ use RectorLaravel\Tests\Sets\Laravel90\Source\Collection;
 -----
 <?php
 
-namespace RectorLaravel\Tests\Sets\Laravel90;
-
+namespace RectorLaravel\Tests\Sets\Laravel90\Fixture;
 
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailer;
 use Illuminate\Mail\MailManager;
 use Illuminate\Mail\Message;
 use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\Collection;
 use Illuminate\Testing\TestResponse;
-use RectorLaravel\Tests\Sets\Laravel90\Source\Collection;
 
 (new Collection())->reduce(fn () => null);
 (new Collection())->reduceSpread(fn () => null);

--- a/tests/Sets/Laravel90/Fixture/model_touch_new_attribute.php.inc
+++ b/tests/Sets/Laravel90/Fixture/model_touch_new_attribute.php.inc
@@ -1,10 +1,35 @@
 <?php
 
-namespace RectorLaravel\Tests\Sets\Laravel90;
+namespace RectorLaravel\Tests\Sets\Laravel90\Fixture;
 
 use Illuminate\Database\Eloquent\Model;
 
-class User extends Model {}
+class User extends Model
+{
+    public function touch()
+    {
+        return true;
+    }
+}
+
+$user = new User();
+$user->touch();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel90\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    public function touch($attribute = null)
+    {
+        return true;
+    }
+}
 
 $user = new User();
 $user->touch();

--- a/tests/Sets/Laravel90/Source/Collection.php
+++ b/tests/Sets/Laravel90/Source/Collection.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace RectorLaravel\Tests\Sets\Laravel90\Source;
-
-use Illuminate\Support\Enumerable;
-
-class Collection implements Enumerable
-{
-}


### PR DESCRIPTION
Fixes https://github.com/driftingly/rector-laravel/issues/239.

- Fixes a TODO in Laravel 8 set. Apparently, it's the only time we need to use `ArgumentAdderWithoutDefaultValue`.
- Replaces `ArgumentAdderWithoutDefaultValue` with `ArgumentAdder` in Laravel 9 set, while setting the scope to only the `ClassMethod`. This satisfies both conditions of modifying the class extensions where appropriate (#239) and keeping method/static calls intact (https://github.com/driftingly/rector-laravel/issues/220).
- Removes the change for `FailedJobProviderInterface` entirely, since an argument rename is needed in that case, but we don't have a rule in core Rector to only rename arguments, yet. I've kept the old test and improved the stub for future changes.
- Adds missing stubs for Container and Application, reflecting the current implementations in Laravel.
- Removes `tests/Sets/Laravel90/Source/Collection` since we already have a global Collection stub.