### PR TITLE
Bump to Rector 1.2.5 and fix compatible of isObjectType() usage to use ClassLike instead of ClassMethod

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Rector upgrades rules for Laravel Framework",
     "require": {
         "php": ">=8.2",
-        "rector/rector": "^1.2"
+        "rector/rector": "^1.2.5"
     },
     "require-dev": {
         "nikic/php-parser": "^4.18",

--- a/src/Rector/ClassMethod/AddArgumentDefaultValueRector.php
+++ b/src/Rector/ClassMethod/AddArgumentDefaultValueRector.php
@@ -9,7 +9,6 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassLike;
-use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
 use RectorLaravel\ValueObject\AddArgumentDefaultValue;

--- a/src/Rector/ClassMethod/AddArgumentDefaultValueRector.php
+++ b/src/Rector/ClassMethod/AddArgumentDefaultValueRector.php
@@ -8,6 +8,7 @@ use PhpParser\BuilderHelpers;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
@@ -70,40 +71,49 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [ClassMethod::class];
+        return [ClassLike::class];
     }
 
     /**
-     * @param  ClassMethod  $node
+     * @param  ClassLike  $node
      */
-    public function refactor(Node $node): ClassMethod
+    public function refactor(Node $node): ?ClassLike
     {
+        $hasChanged = false;
         foreach ($this->addedArguments as $addedArgument) {
             if (! $this->nodeTypeResolver->isObjectType($node, $addedArgument->getObjectType())) {
                 continue;
             }
 
-            if (! $this->isName($node->name, $addedArgument->getMethod())) {
-                continue;
+            foreach ($node->getMethods() as $classMethod) {
+                if (! $this->isName($classMethod->name, $addedArgument->getMethod())) {
+                    continue;
+                }
+
+                if (! isset($classMethod->params[$addedArgument->getPosition()])) {
+                    continue;
+                }
+
+                $position = $addedArgument->getPosition();
+                $param = $classMethod->params[$position];
+
+                if ($param->default instanceof Expr) {
+                    continue;
+                }
+
+                $classMethod->params[$position] = new Param($param->var, BuilderHelpers::normalizeValue(
+                    $addedArgument->getDefaultValue()
+                ));
+
+                $hasChanged = true;
             }
-
-            if (! isset($node->params[$addedArgument->getPosition()])) {
-                continue;
-            }
-
-            $position = $addedArgument->getPosition();
-            $param = $node->params[$position];
-
-            if ($param->default instanceof Expr) {
-                continue;
-            }
-
-            $node->params[$position] = new Param($param->var, BuilderHelpers::normalizeValue(
-                $addedArgument->getDefaultValue()
-            ));
         }
 
-        return $node;
+        if ($hasChanged) {
+            return $node;
+        }
+
+        return null;
     }
 
     /**

--- a/src/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector.php
+++ b/src/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\ClassLike;
-use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeTraverser;
 use PHPStan\Type\ObjectType;
@@ -139,6 +138,7 @@ CODE_SAMPLE
             $this->traverseNodesWithCallable($classMethod, function (Node $node) use (&$changed, &$hasChanged): Return_|int|null {
                 if ($changed) {
                     $hasChanged = true;
+
                     return NodeTraverser::STOP_TRAVERSAL;
                 }
 

--- a/src/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector.php
+++ b/src/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeTraverser;
@@ -48,15 +49,15 @@ CODE_SAMPLE
 
     public function getNodeTypes(): array
     {
-        return [MethodCall::class, StaticCall::class, ClassMethod::class];
+        return [MethodCall::class, StaticCall::class, ClassLike::class];
     }
 
     /**
-     * @param  MethodCall|StaticCall|ClassMethod  $node
+     * @param  MethodCall|StaticCall|ClassLike  $node
      */
-    public function refactor(Node $node): MethodCall|StaticCall|ClassMethod|null
+    public function refactor(Node $node): MethodCall|StaticCall|ClassLike|null
     {
-        if ($node instanceof ClassMethod) {
+        if ($node instanceof ClassLike) {
             return $this->refactorClassMethod($node);
         }
 
@@ -122,42 +123,46 @@ CODE_SAMPLE
         return $this->processValidationRules($rulesArgument) ? $node : null;
     }
 
-    private function refactorClassMethod(ClassMethod $classMethod): ?ClassMethod
+    private function refactorClassMethod(ClassLike $classLike): ?ClassLike
     {
-        if (! $this->isObjectType($classMethod, new ObjectType('Illuminate\Foundation\Http\FormRequest'))) {
+        if (! $this->isObjectType($classLike, new ObjectType('Illuminate\Foundation\Http\FormRequest'))) {
             return null;
         }
 
-        if (! $this->isName($classMethod, 'rules')) {
-            return null;
+        $hasChanged = false;
+        foreach ($classLike->getMethods() as $classMethod) {
+            if (! $this->isName($classMethod, 'rules')) {
+                continue;
+            }
+
+            $changed = false;
+            $this->traverseNodesWithCallable($classMethod, function (Node $node) use (&$changed, &$hasChanged): Return_|int|null {
+                if ($changed) {
+                    $hasChanged = true;
+                    return NodeTraverser::STOP_TRAVERSAL;
+                }
+
+                if (! $node instanceof Return_) {
+                    return null;
+                }
+
+                if (! $node->expr instanceof Array_) {
+                    return null;
+                }
+
+                if ($this->processValidationRules($node->expr)) {
+                    $hasChanged = true;
+                    $changed = true;
+
+                    return $node;
+                }
+
+                return null;
+            });
         }
 
-        $changed = false;
-
-        $this->traverseNodesWithCallable($classMethod, function (Node $node) use (&$changed): Return_|int|null {
-            if ($changed) {
-                return NodeTraverser::STOP_TRAVERSAL;
-            }
-
-            if (! $node instanceof Return_) {
-                return null;
-            }
-
-            if (! $node->expr instanceof Array_) {
-                return null;
-            }
-
-            if ($this->processValidationRules($node->expr)) {
-                $changed = true;
-
-                return $node;
-            }
-
-            return null;
-        });
-
-        if ($changed) {
-            return $classMethod;
+        if ($hasChanged) {
+            return $classLike;
         }
 
         return null;


### PR DESCRIPTION
see https://github.com/rectorphp/rector/issues/8820#issuecomment-2337955117
Fixes https://github.com/driftingly/rector-laravel/issues/246