### PR TITLE
Fixes duplicate entries and adds a test

### DIFF
--- a/src/Set/LaravelSetProvider.php
+++ b/src/Set/LaravelSetProvider.php
@@ -2,6 +2,7 @@
 
 namespace RectorLaravel\Set;
 
+use Rector\Set\Contract\SetInterface;
 use Rector\Set\Contract\SetProviderInterface;
 use Rector\Set\ValueObject\Set;
 use RectorLaravel\Set\Packages\Livewire\LivewireSetList;
@@ -38,7 +39,7 @@ final class LaravelSetProvider implements SetProviderInterface
     ];
 
     /**
-     * @return \Rector\Set\Contract\SetInterface[]
+     * @return SetInterface[]
      */
     public function provide(): array
     {

--- a/src/Set/LaravelSetProvider.php
+++ b/src/Set/LaravelSetProvider.php
@@ -37,6 +37,9 @@ final class LaravelSetProvider implements SetProviderInterface
         LaravelSetList::LARAVEL_110,
     ];
 
+    /**
+     * @return \Rector\Set\Contract\SetInterface[]
+     */
     public function provide(): array
     {
         return [
@@ -45,27 +48,15 @@ final class LaravelSetProvider implements SetProviderInterface
                 'array/str func to static calls',
                 LaravelSetList::ARRAY_STR_FUNCTIONS_TO_STATIC_CALL
             ),
-            new Set(self::GROUP_NAME, 'Code quality', LaravelSetList::LARAVEL_CODE_QUALITY),
+            new Set(
+                self::GROUP_NAME,
+                'Code quality',
+                LaravelSetList::LARAVEL_CODE_QUALITY
+            ),
             new Set(
                 self::GROUP_NAME,
                 'Container strings to FQN types',
                 LaravelSetList::LARAVEL_CONTAINER_STRING_TO_FULLY_QUALIFIED_NAME,
-            ),
-            new Set(
-                'Laravel Code Quality',
-                'array/str functions to static calls',
-                LaravelSetList::ARRAY_STR_FUNCTIONS_TO_STATIC_CALL
-            ),
-            new Set(self::GROUP_NAME, 'Code quality', LaravelSetList::LARAVEL_CODE_QUALITY),
-            new Set(
-                self::GROUP_NAME,
-                'Container strings to FQN types',
-                LaravelSetList::LARAVEL_CONTAINER_STRING_TO_FULLY_QUALIFIED_NAME,
-            ),
-            new Set(
-                self::GROUP_NAME,
-                'Code Quality for Laravel',
-                LaravelSetList::LARAVEL_CODE_QUALITY,
             ),
             new Set(
                 self::GROUP_NAME,

--- a/tests/Sets/LaravelSetProviderTest.php
+++ b/tests/Sets/LaravelSetProviderTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace RectorLaravel\Tests\Sets;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use Rector\Set\Contract\SetInterface;
+use RectorLaravel\Set\LaravelSetList;
+use RectorLaravel\Set\LaravelSetProvider;
+
+final class LaravelSetProviderTest extends TestCase
+{
+    private const LARAVEL_VERSION_SETS = [
+        LaravelSetList::LARAVEL_50,
+        LaravelSetList::LARAVEL_51,
+        LaravelSetList::LARAVEL_52,
+        LaravelSetList::LARAVEL_53,
+        LaravelSetList::LARAVEL_54,
+        LaravelSetList::LARAVEL_55,
+        LaravelSetList::LARAVEL_56,
+        LaravelSetList::LARAVEL_57,
+        LaravelSetList::LARAVEL_58,
+        LaravelSetList::LARAVEL_60,
+        LaravelSetList::LARAVEL_70,
+        LaravelSetList::LARAVEL_80,
+        LaravelSetList::LARAVEL_90,
+        LaravelSetList::LARAVEL_100,
+        LaravelSetList::LARAVEL_110,
+    ];
+
+    public function testItProvidesSets(): void
+    {
+        $provider = new LaravelSetProvider();
+
+        Assert::assertContainsOnlyInstancesOf(
+            SetInterface::class,
+            $provider->provide()
+        );
+    }
+
+    public function testItReturnsUniqueSets(): void
+    {
+        $provider = new LaravelSetProvider();
+
+        $sets = $provider->provide();
+
+        $uniqueSets = array_unique(array_map(fn (SetInterface $set) => $set->getSetFilePath(), $sets));
+
+        Assert::assertCount(count($sets), $uniqueSets);
+    }
+
+    public function testItProvidesAllLaravelVersions(): void
+    {
+        $provider = new LaravelSetProvider();
+
+        $sets = $provider->provide();
+
+        $sets = array_filter(
+            array_map(
+                fn (SetInterface $set) => $set->getSetFilePath(),
+                $sets
+            ),
+            fn(string $filePath) => in_array($filePath, self::LARAVEL_VERSION_SETS, true),
+        );
+
+        Assert::assertCount(count(self::LARAVEL_VERSION_SETS), $sets);
+    }
+}

--- a/tests/Sets/LaravelSetProviderTest.php
+++ b/tests/Sets/LaravelSetProviderTest.php
@@ -30,19 +30,19 @@ final class LaravelSetProviderTest extends TestCase
 
     public function testItProvidesSets(): void
     {
-        $provider = new LaravelSetProvider();
+        $laravelSetProvider = new LaravelSetProvider();
 
         Assert::assertContainsOnlyInstancesOf(
             SetInterface::class,
-            $provider->provide()
+            $laravelSetProvider->provide()
         );
     }
 
     public function testItReturnsUniqueSets(): void
     {
-        $provider = new LaravelSetProvider();
+        $laravelSetProvider = new LaravelSetProvider();
 
-        $sets = $provider->provide();
+        $sets = $laravelSetProvider->provide();
 
         $uniqueSets = array_unique(array_map(fn (SetInterface $set) => $set->getSetFilePath(), $sets));
 
@@ -51,16 +51,16 @@ final class LaravelSetProviderTest extends TestCase
 
     public function testItProvidesAllLaravelVersions(): void
     {
-        $provider = new LaravelSetProvider();
+        $laravelSetProvider = new LaravelSetProvider();
 
-        $sets = $provider->provide();
+        $sets = $laravelSetProvider->provide();
 
         $sets = array_filter(
             array_map(
                 fn (SetInterface $set) => $set->getSetFilePath(),
                 $sets
             ),
-            fn(string $filePath) => in_array($filePath, self::LARAVEL_VERSION_SETS, true),
+            fn (string $filePath) => in_array($filePath, self::LARAVEL_VERSION_SETS, true),
         );
 
         Assert::assertCount(count(self::LARAVEL_VERSION_SETS), $sets);


### PR DESCRIPTION
# Changes

- Fixes the duplicate entries for the LaravelSetProvider
- Adds a unit test to check if it's providing the sets correctly.

# Why

Picked up as a mistake from #248