### PR TITLE
Add new rule AssertSeeToAssertSeeHtmlRector

### DIFF
--- a/config/sets/laravel110.php
+++ b/config/sets/laravel110.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use RectorLaravel\Rector\Class_\ModelCastsPropertyToCastsMethodRector;
+use RectorLaravel\Rector\MethodCall\AssertSeeToAssertSeeHtmlRector;
 use RectorLaravel\Rector\MethodCall\RefactorBlueprintGeometryColumnsRector;
 
 // see https://laravel.com/docs/11.x/upgrade
@@ -15,4 +16,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     // https://github.com/laravel/framework/pull/49634
     $rectorConfig->rule(RefactorBlueprintGeometryColumnsRector::class);
+
+    // https://github.com/laravel/framework/pull/52285
+    $rectorConfig->rule(AssertSeeToAssertSeeHtmlRector::class);
 };

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 66 Rules Overview
+# 68 Rules Overview
 
 ## AbortIfRector
 
@@ -233,6 +233,33 @@ Move help facade-like function calls to constructor injection
 +        $viewFactory = $this->viewFactory;
      }
  }
+```
+
+<br>
+
+## AssertSeeToAssertSeeHtmlRector
+
+Replace assertSee with assertSeeHtml when testing HTML with escape set to false
+
+- class: [`RectorLaravel\Rector\MethodCall\AssertSeeToAssertSeeHtmlRector`](../src/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector.php)
+
+```diff
+-$response->assertSee("<li>foo</li>", false);
++$response->assertSeeHtml("<li>foo</li>");
+```
+
+<br>
+
+```diff
+-$response->assertDontSee("<li>foo</li>", false);
++$response->assertDontSeeHtml("<li>foo</li>");
+```
+
+<br>
+
+```diff
+-$response->assertSeeInOrder(["<li>foo</li>", "<li>bar</li>"], false);
++$response->assertSeeHtmlInOrder(["<li>foo</li>", "<li>bar</li>"]);
 ```
 
 <br>

--- a/src/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector.php
+++ b/src/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector.php
@@ -17,6 +17,15 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class AssertSeeToAssertSeeHtmlRector extends AbstractRector
 {
+    /**
+     * @var string[]
+     */
+    protected array $methodsToReplace = [
+        'assertSee' => 'assertSeeHtml',
+        'assertDontSee' => 'assertDontSeeHtml',
+        'assertSeeInOrder' => 'assertSeeHtmlInOrder',
+    ];
+
     public function __construct(
         private readonly ValueResolver $valueResolver
     ) {
@@ -60,15 +69,9 @@ final class AssertSeeToAssertSeeHtmlRector extends AbstractRector
             return null;
         }
 
-        $methodsToReplace = [
-            'assertSee' => 'assertSeeHtml',
-            'assertDontSee' => 'assertDontSeeHtml',
-            'assertSeeInOrder' => 'assertSeeHtmlInOrder',
-        ];
-
         $methodCallName = (string) $this->getName($node->name);
 
-        if (! array_key_exists($methodCallName, $methodsToReplace)) {
+        if (! array_key_exists($methodCallName, $this->methodsToReplace)) {
             return null;
         }
 
@@ -82,7 +85,7 @@ final class AssertSeeToAssertSeeHtmlRector extends AbstractRector
 
         return $this->nodeFactory->createMethodCall(
             $node->var,
-            $methodsToReplace[$methodCallName],
+            $this->methodsToReplace[$methodCallName],
             [$node->getArgs()[0]]
         );
     }

--- a/src/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector.php
+++ b/src/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Type\ObjectType;
+use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\MethodCall\AssertSeeToAssertSeeHtmlRector\AssertSeeToAssertSeeHtmlRectorTest
+ */
+final class AssertSeeToAssertSeeHtmlRector extends AbstractRector
+{
+    public function __construct(
+        private readonly ValueResolver $valueResolver
+
+    )
+    {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace assertSee with assertSeeHtml when testing HTML with escape set to false',
+            [
+                new CodeSample(
+                    '$response->assertSee("<li>foo</li>", false);',
+                    '$response->assertSeeHtml("<li>foo</li>");'
+                ),
+                new CodeSample(
+                    '$response->assertDontSee("<li>foo</li>", false);',
+                    '$response->assertDontSeeHtml("<li>foo</li>");'
+                ),
+                new CodeSample(
+                    '$response->assertSeeInOrder(["<li>foo</li>", "<li>bar</li>"], false);',
+                    '$response->assertSeeHtmlInOrder(["<li>foo</li>", "<li>bar</li>"]);'
+                )
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param  MethodCall  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isObjectType($node->var, new ObjectType('Illuminate\Testing\TestResponse'))) {
+            return null;
+        }
+
+        $methodsToReplace = [
+            'assertSee' => 'assertSeeHtml',
+            'assertDontSee' => 'assertDontSeeHtml',
+            'assertSeeInOrder' => 'assertSeeHtmlInOrder',
+        ];
+
+        $methodCallName = (string) $this->getName($node->name);
+
+        if (! array_key_exists($methodCallName, $methodsToReplace)) {
+            return null;
+        }
+
+        if (count($node->getArgs()) !== 2) {
+            return null;
+        }
+
+        if (! $this->valueResolver->isFalse($node->getArgs()[1]->value)) {
+            return null;
+        }
+
+        return $this->nodeFactory->createMethodCall(
+            $node->var,
+            $methodsToReplace[$methodCallName],
+            [$node->getArgs()[0]]
+        );
+    }
+}

--- a/src/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector.php
+++ b/src/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector.php
@@ -19,9 +19,7 @@ final class AssertSeeToAssertSeeHtmlRector extends AbstractRector
 {
     public function __construct(
         private readonly ValueResolver $valueResolver
-
-    )
-    {
+    ) {
     }
 
     public function getRuleDefinition(): RuleDefinition
@@ -40,7 +38,7 @@ final class AssertSeeToAssertSeeHtmlRector extends AbstractRector
                 new CodeSample(
                     '$response->assertSeeInOrder(["<li>foo</li>", "<li>bar</li>"], false);',
                     '$response->assertSeeHtmlInOrder(["<li>foo</li>", "<li>bar</li>"]);'
-                )
+                ),
             ]
         );
     }

--- a/tests/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector/AssertSeeToAssertSeeHtmlRectorTest.php
+++ b/tests/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector/AssertSeeToAssertSeeHtmlRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\MethodCall\AssertSeeToAssertSeeHtmlRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AssertSeeToAssertSeeHtmlRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector/Fixture/fixture_with_html_escape_false.php.inc
+++ b/tests/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector/Fixture/fixture_with_html_escape_false.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\AssertStatusToAssertMethodRector\Fixture;
+
+use Illuminate\Testing\TestResponse;
+
+class FixtureWithHtmlEscapeFalse
+{
+    public function testSeeHtml(TestResponse $response)
+    {
+        $response->assertSee("<li>foo</li>", false);
+        $response->assertDontSee("<li>bar</li>", false);
+        $response->assertSeeInOrder(["<li>foo</li>", "<li>bar</li>", "<li>baz</li>"], false);
+    }
+}
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\AssertStatusToAssertMethodRector\Fixture;
+
+use Illuminate\Testing\TestResponse;
+
+class FixtureWithHtmlEscapeFalse
+{
+    public function testSeeHtml(TestResponse $response)
+    {
+        $response->assertSeeHtml("<li>foo</li>");
+        $response->assertDontSeeHtml("<li>bar</li>");
+        $response->assertSeeHtmlInOrder(["<li>foo</li>", "<li>bar</li>", "<li>baz</li>"]);
+    }
+}
+?>

--- a/tests/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector/Fixture/skip_with_html_escape_true_or_missing.php.inc
+++ b/tests/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector/Fixture/skip_with_html_escape_true_or_missing.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\AssertStatusToAssertMethodRector\Fixture;
+
+use Illuminate\Testing\TestResponse;
+
+class FixtureWithHtmlEscapeTrueOrMissing
+{
+    public function testSeeHtml(TestResponse $response)
+    {
+        $response->assertSee("<li>foo</li>", true);
+        $response->assertSee("<li>foo</li>", 1);
+        $response->assertDontSee("<li>bar</li>");
+    }
+}
+?>

--- a/tests/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector/Fixture/skip_with_html_escape_true_or_missing.php.inc
+++ b/tests/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector/Fixture/skip_with_html_escape_true_or_missing.php.inc
@@ -10,7 +10,13 @@ class FixtureWithHtmlEscapeTrueOrMissing
     {
         $response->assertSee("<li>foo</li>", true);
         $response->assertSee("<li>foo</li>", 1);
-        $response->assertDontSee("<li>bar</li>");
+        $response->assertSee("<li>bar</li>");
+        $response->assertDontSeeHtml("<li>bar</li>", true);
+        $response->assertDontSeeHtml("<li>bar</li>", 1);
+        $response->assertDontSeeHtml("<li>bar</li>");
+        $response->assertSeeInOrder(["<li>foo</li>", "<li>bar</li>", "<li>baz</li>"], true);
+        $response->assertSeeInOrder(["<li>foo</li>", "<li>bar</li>", "<li>baz</li>"], 1);
+        $response->assertSeeInOrder(["<li>foo</li>", "<li>bar</li>", "<li>baz</li>"]);
     }
 }
 ?>

--- a/tests/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector/Fixture/skip_with_non_test_response.php.inc
+++ b/tests/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector/Fixture/skip_with_non_test_response.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\AssertStatusToAssertMethodRector\Fixture;
+
+class FixtureWithHtmlEscapeTrueOrMissing
+{
+    public function testSeeHtml($response)
+    {
+        $response->assertSee("<li>foo</li>", false);
+        $response->assertSee("<li>foo</li>", false);
+        $response->assertDontSee("<li>bar</li>", false);
+    }
+}
+?>

--- a/tests/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector/Fixture/skip_with_non_test_response.php.inc
+++ b/tests/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector/Fixture/skip_with_non_test_response.php.inc
@@ -2,7 +2,7 @@
 
 namespace RectorLaravel\Tests\Rector\MethodCall\AssertStatusToAssertMethodRector\Fixture;
 
-class FixtureWithHtmlEscapeTrueOrMissing
+class FixtureWithNonTestResponse
 {
     public function testSeeHtml($response)
     {

--- a/tests/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector/Fixture/skip_with_other_method_names.php.inc
+++ b/tests/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector/Fixture/skip_with_other_method_names.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\AssertStatusToAssertMethodRector\Fixture;
+
+use Illuminate\Testing\TestResponse;
+
+class FixtureWithHtmlEscapeTrueOrMissing
+{
+    public function testSeeHtml(TestResponse $response)
+    {
+        $response->assertSomethingElse("<li>foo</li>", false);
+        $response->assertSeeText("<li>foo</li>", false);
+    }
+}
+?>

--- a/tests/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector/Fixture/skip_with_other_method_names.php.inc
+++ b/tests/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector/Fixture/skip_with_other_method_names.php.inc
@@ -4,7 +4,7 @@ namespace RectorLaravel\Tests\Rector\MethodCall\AssertStatusToAssertMethodRector
 
 use Illuminate\Testing\TestResponse;
 
-class FixtureWithHtmlEscapeTrueOrMissing
+class FixtureWithOtherMethodNames
 {
     public function testSeeHtml(TestResponse $response)
     {

--- a/tests/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\MethodCall\AssertSeeToAssertSeeHtmlRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(AssertSeeToAssertSeeHtmlRector::class);
+};


### PR DESCRIPTION
The new rule is available from Laravel 11 ([PR](https://github.com/laravel/framework/pull/52285))
- Adds AssertSeeToAssertSeeHtmlRector.
- The rule is set as part of the Laravel 11 set.
- Docs are updated.

The rule changes:

```diff
-$response->assertSee("<li>foo</li>", false);
+$response->assertSeeHtml("<li>foo</li>");
```


```diff
-$response->assertDontSee("<li>foo</li>", false);
+$response->assertDontSeeHtml("<li>foo</li>");
```


```diff
-$response->assertSeeInOrder(["<li>foo</li>", "<li>bar</li>"], false);
+$response->assertSeeHtmlInOrder(["<li>foo</li>", "<li>bar</li>"]);
```