### PR TITLE
Improvements to the AssertStatusToAssertMethodRector

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -273,103 +273,27 @@ Replace `(new \Illuminate\Testing\TestResponse)->assertStatus(200)` with `(new \
 ```diff
  class ExampleTest extends \Illuminate\Foundation\Testing\TestCase
  {
-     public function testOk()
+     public function testFoo()
      {
 -        $this->get('/')->assertStatus(200);
--        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_OK);
--        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_OK);
-+        $this->get('/')->assertOk();
-+        $this->get('/')->assertOk();
-+        $this->get('/')->assertOk();
-     }
-
-     public function testNoContent()
-     {
 -        $this->get('/')->assertStatus(204);
--        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_NO_CONTENT);
--        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_NO_CONTENT);
-+        $this->get('/')->assertNoContent();
-+        $this->get('/')->assertNoContent();
-+        $this->get('/')->assertNoContent();
-     }
-
-     public function testUnauthorized()
-     {
 -        $this->get('/')->assertStatus(401);
--        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_UNAUTHORIZED);
--        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_UNAUTHORIZED);
-+        $this->get('/')->assertUnauthorized();
-+        $this->get('/')->assertUnauthorized();
-+        $this->get('/')->assertUnauthorized();
-     }
-
-     public function testForbidden()
-     {
 -        $this->get('/')->assertStatus(403);
--        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_FORBIDDEN);
--        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_FORBIDDEN);
-+        $this->get('/')->assertForbidden();
-+        $this->get('/')->assertForbidden();
-+        $this->get('/')->assertForbidden();
-     }
-
-     public function testNotFound()
-     {
 -        $this->get('/')->assertStatus(404);
--        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_NOT_FOUND);
--        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND);
-+        $this->get('/')->assertNotFound();
-+        $this->get('/')->assertNotFound();
-+        $this->get('/')->assertNotFound();
-     }
-
-     public function testMethodNotAllowed()
-     {
 -        $this->get('/')->assertStatus(405);
--        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_METHOD_NOT_ALLOWED);
--        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_METHOD_NOT_ALLOWED);
-+        $this->get('/')->assertMethodNotAllowed();
-+        $this->get('/')->assertMethodNotAllowed();
-+        $this->get('/')->assertMethodNotAllowed();
-     }
-
-     public function testUnprocessableEntity()
-     {
 -        $this->get('/')->assertStatus(422);
--        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_UNPROCESSABLE_ENTITY);
--        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY);
-+        $this->get('/')->assertUnprocessable();
-+        $this->get('/')->assertUnprocessable();
-+        $this->get('/')->assertUnprocessable();
-     }
-
-     public function testGone()
-     {
 -        $this->get('/')->assertStatus(410);
--        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_GONE);
--        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_GONE);
-+        $this->get('/')->assertGone();
-+        $this->get('/')->assertGone();
-+        $this->get('/')->assertGone();
-     }
-
-     public function testInternalServerError()
-     {
 -        $this->get('/')->assertStatus(500);
--        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_INTERNAL_SERVER_ERROR);
--        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_INTERNAL_SERVER_ERROR);
-+        $this->get('/')->assertInternalServerError();
-+        $this->get('/')->assertInternalServerError();
-+        $this->get('/')->assertInternalServerError();
-     }
-
-     public function testServiceUnavailable()
-     {
 -        $this->get('/')->assertStatus(503);
--        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_SERVICE_UNAVAILABLE);
--        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_SERVICE_UNAVAILABLE);
-+        $this->get('/')->assertServiceUnavailable();
-+        $this->get('/')->assertServiceUnavailable();
++        $this->get('/')->assertOk();
++        $this->get('/')->assertNoContent();
++        $this->get('/')->assertUnauthorized();
++        $this->get('/')->assertForbidden();
++        $this->get('/')->assertNotFound();
++        $this->get('/')->assertMethodNotAllowed();
++        $this->get('/')->assertUnprocessable();
++        $this->get('/')->assertGone();
++        $this->get('/')->assertInternalServerError();
 +        $this->get('/')->assertServiceUnavailable();
      }
  }

--- a/src/Rector/MethodCall/AssertStatusToAssertMethodRector.php
+++ b/src/Rector/MethodCall/AssertStatusToAssertMethodRector.php
@@ -26,74 +26,18 @@ final class AssertStatusToAssertMethodRector extends AbstractRector
                     <<<'CODE_SAMPLE'
 class ExampleTest extends \Illuminate\Foundation\Testing\TestCase
 {
-    public function testOk()
+    public function testFoo()
     {
         $this->get('/')->assertStatus(200);
-        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_OK);
-        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_OK);
-    }
-
-    public function testNoContent()
-    {
         $this->get('/')->assertStatus(204);
-        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_NO_CONTENT);
-        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_NO_CONTENT);
-    }
-
-    public function testUnauthorized()
-    {
         $this->get('/')->assertStatus(401);
-        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_UNAUTHORIZED);
-        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_UNAUTHORIZED);
-    }
-
-    public function testForbidden()
-    {
         $this->get('/')->assertStatus(403);
-        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_FORBIDDEN);
-        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_FORBIDDEN);
-    }
-
-    public function testNotFound()
-    {
         $this->get('/')->assertStatus(404);
-        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_NOT_FOUND);
-        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND);
-    }
-
-    public function testMethodNotAllowed()
-    {
         $this->get('/')->assertStatus(405);
-        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_METHOD_NOT_ALLOWED);
-        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_METHOD_NOT_ALLOWED);
-    }
-
-    public function testUnprocessableEntity()
-    {
         $this->get('/')->assertStatus(422);
-        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_UNPROCESSABLE_ENTITY);
-        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY);
-    }
-
-    public function testGone()
-    {
         $this->get('/')->assertStatus(410);
-        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_GONE);
-        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_GONE);
-    }
-
-    public function testInternalServerError()
-    {
         $this->get('/')->assertStatus(500);
-        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_INTERNAL_SERVER_ERROR);
-        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_INTERNAL_SERVER_ERROR);
-    }
-
-    public function testServiceUnavailable()
-    {
         $this->get('/')->assertStatus(503);
-        $this->get('/')->assertStatus(\Illuminate\Http\Response::HTTP_SERVICE_UNAVAILABLE);
-        $this->get('/')->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_SERVICE_UNAVAILABLE);
     }
 }
 CODE_SAMPLE
@@ -101,73 +45,17 @@ CODE_SAMPLE
                     <<<'CODE_SAMPLE'
 class ExampleTest extends \Illuminate\Foundation\Testing\TestCase
 {
-    public function testOk()
+    public function testFoo()
     {
         $this->get('/')->assertOk();
-        $this->get('/')->assertOk();
-        $this->get('/')->assertOk();
-    }
-
-    public function testNoContent()
-    {
         $this->get('/')->assertNoContent();
-        $this->get('/')->assertNoContent();
-        $this->get('/')->assertNoContent();
-    }
-
-    public function testUnauthorized()
-    {
         $this->get('/')->assertUnauthorized();
-        $this->get('/')->assertUnauthorized();
-        $this->get('/')->assertUnauthorized();
-    }
-
-    public function testForbidden()
-    {
         $this->get('/')->assertForbidden();
-        $this->get('/')->assertForbidden();
-        $this->get('/')->assertForbidden();
-    }
-
-    public function testNotFound()
-    {
         $this->get('/')->assertNotFound();
-        $this->get('/')->assertNotFound();
-        $this->get('/')->assertNotFound();
-    }
-
-    public function testMethodNotAllowed()
-    {
         $this->get('/')->assertMethodNotAllowed();
-        $this->get('/')->assertMethodNotAllowed();
-        $this->get('/')->assertMethodNotAllowed();
-    }
-
-    public function testUnprocessableEntity()
-    {
         $this->get('/')->assertUnprocessable();
-        $this->get('/')->assertUnprocessable();
-        $this->get('/')->assertUnprocessable();
-    }
-
-    public function testGone()
-    {
         $this->get('/')->assertGone();
-        $this->get('/')->assertGone();
-        $this->get('/')->assertGone();
-    }
-
-    public function testInternalServerError()
-    {
         $this->get('/')->assertInternalServerError();
-        $this->get('/')->assertInternalServerError();
-        $this->get('/')->assertInternalServerError();
-    }
-
-    public function testServiceUnavailable()
-    {
-        $this->get('/')->assertServiceUnavailable();
-        $this->get('/')->assertServiceUnavailable();
         $this->get('/')->assertServiceUnavailable();
     }
 }
@@ -210,12 +98,14 @@ CODE_SAMPLE
         $arg = $methodCall->getArgs()[0];
         $argValue = $arg->value;
 
+        // we can check if the arg is an integer even if it comes from a constant
         $type = $this->getType($argValue);
 
         if (! $type->isInteger()->yes()) {
             return null;
         }
 
+        // we want the value of the integer if it's known
         $value = ($type->getConstantScalarValues()[0] ?? null);
 
         if ($value === null) {

--- a/stubs/Illuminate/Http/Response.php
+++ b/stubs/Illuminate/Http/Response.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Http;
+
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+if (class_exists('Illuminate\Http\Response')) {
+    return;
+}
+
+class Response extends SymfonyResponse
+{
+}

--- a/stubs/Symfony/Component/HttpFoundation/Response.php
+++ b/stubs/Symfony/Component/HttpFoundation/Response.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation;
+
+if (class_exists('Symfony\Component\HttpFoundation\Response')) {
+    return;
+}
+
+class Response
+{
+    public const HTTP_CONTINUE = 100;
+
+    public const HTTP_SWITCHING_PROTOCOLS = 101;
+
+    public const HTTP_PROCESSING = 102;            // RFC2518
+
+    public const HTTP_EARLY_HINTS = 103;           // RFC8297
+
+    public const HTTP_OK = 200;
+
+    public const HTTP_CREATED = 201;
+
+    public const HTTP_ACCEPTED = 202;
+
+    public const HTTP_NON_AUTHORITATIVE_INFORMATION = 203;
+
+    public const HTTP_NO_CONTENT = 204;
+
+    public const HTTP_RESET_CONTENT = 205;
+
+    public const HTTP_PARTIAL_CONTENT = 206;
+
+    public const HTTP_MULTI_STATUS = 207;          // RFC4918
+
+    public const HTTP_ALREADY_REPORTED = 208;      // RFC5842
+
+    public const HTTP_IM_USED = 226;               // RFC3229
+
+    public const HTTP_MULTIPLE_CHOICES = 300;
+
+    public const HTTP_MOVED_PERMANENTLY = 301;
+
+    public const HTTP_FOUND = 302;
+
+    public const HTTP_SEE_OTHER = 303;
+
+    public const HTTP_NOT_MODIFIED = 304;
+
+    public const HTTP_USE_PROXY = 305;
+
+    public const HTTP_RESERVED = 306;
+
+    public const HTTP_TEMPORARY_REDIRECT = 307;
+
+    public const HTTP_PERMANENTLY_REDIRECT = 308;  // RFC7238
+
+    public const HTTP_BAD_REQUEST = 400;
+
+    public const HTTP_UNAUTHORIZED = 401;
+
+    public const HTTP_PAYMENT_REQUIRED = 402;
+
+    public const HTTP_FORBIDDEN = 403;
+
+    public const HTTP_NOT_FOUND = 404;
+
+    public const HTTP_METHOD_NOT_ALLOWED = 405;
+
+    public const HTTP_NOT_ACCEPTABLE = 406;
+
+    public const HTTP_PROXY_AUTHENTICATION_REQUIRED = 407;
+
+    public const HTTP_REQUEST_TIMEOUT = 408;
+
+    public const HTTP_CONFLICT = 409;
+
+    public const HTTP_GONE = 410;
+
+    public const HTTP_LENGTH_REQUIRED = 411;
+
+    public const HTTP_PRECONDITION_FAILED = 412;
+
+    public const HTTP_REQUEST_ENTITY_TOO_LARGE = 413;
+
+    public const HTTP_REQUEST_URI_TOO_LONG = 414;
+
+    public const HTTP_UNSUPPORTED_MEDIA_TYPE = 415;
+
+    public const HTTP_REQUESTED_RANGE_NOT_SATISFIABLE = 416;
+
+    public const HTTP_EXPECTATION_FAILED = 417;
+
+    public const HTTP_I_AM_A_TEAPOT = 418;                                               // RFC2324
+
+    public const HTTP_MISDIRECTED_REQUEST = 421;                                         // RFC7540
+
+    public const HTTP_UNPROCESSABLE_ENTITY = 422;                                        // RFC4918
+
+    public const HTTP_LOCKED = 423;                                                      // RFC4918
+
+    public const HTTP_FAILED_DEPENDENCY = 424;                                           // RFC4918
+
+    public const HTTP_TOO_EARLY = 425;                                                   // RFC-ietf-httpbis-replay-04
+
+    public const HTTP_UPGRADE_REQUIRED = 426;                                            // RFC2817
+
+    public const HTTP_PRECONDITION_REQUIRED = 428;                                       // RFC6585
+
+    public const HTTP_TOO_MANY_REQUESTS = 429;                                           // RFC6585
+
+    public const HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE = 431;                             // RFC6585
+
+    public const HTTP_UNAVAILABLE_FOR_LEGAL_REASONS = 451;                               // RFC7725
+
+    public const HTTP_INTERNAL_SERVER_ERROR = 500;
+
+    public const HTTP_NOT_IMPLEMENTED = 501;
+
+    public const HTTP_BAD_GATEWAY = 502;
+
+    public const HTTP_SERVICE_UNAVAILABLE = 503;
+
+    public const HTTP_GATEWAY_TIMEOUT = 504;
+
+    public const HTTP_VERSION_NOT_SUPPORTED = 505;
+
+    public const HTTP_VARIANT_ALSO_NEGOTIATES_EXPERIMENTAL = 506;                        // RFC2295
+
+    public const HTTP_INSUFFICIENT_STORAGE = 507;                                        // RFC4918
+
+    public const HTTP_LOOP_DETECTED = 508;                                               // RFC5842
+
+    public const HTTP_NOT_EXTENDED = 510;                                                // RFC2774
+
+    public const HTTP_NETWORK_AUTHENTICATION_REQUIRED = 511;
+}

--- a/tests/Rector/MethodCall/AssertStatusToAssertMethodRector/Fixture/fixture_with_illuminate_response_constants.php.inc
+++ b/tests/Rector/MethodCall/AssertStatusToAssertMethodRector/Fixture/fixture_with_illuminate_response_constants.php.inc
@@ -6,52 +6,52 @@ class FixtureWithIlluminateTest
 {
     public function testOk(\Illuminate\Testing\TestResponse $response)
     {
-        $response->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_OK);
+        $response->assertStatus(\Illuminate\Http\Response::HTTP_OK);
     }
 
     public function testNoContent(\Illuminate\Testing\TestResponse $response)
     {
-        $response->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_NO_CONTENT);
+        $response->assertStatus(\Illuminate\Http\Response::HTTP_NO_CONTENT);
     }
 
     public function testForbidden(\Illuminate\Testing\TestResponse $response)
     {
-        $response->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_FORBIDDEN);
+        $response->assertStatus(\Illuminate\Http\Response::HTTP_FORBIDDEN);
     }
 
     public function testNotFound(\Illuminate\Testing\TestResponse $response)
     {
-        $response->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND);
+        $response->assertStatus(\Illuminate\Http\Response::HTTP_NOT_FOUND);
     }
 
     public function testMethodNotAllowed(\Illuminate\Testing\TestResponse $response)
     {
-        $response->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_METHOD_NOT_ALLOWED);
+        $response->assertStatus(\Illuminate\Http\Response::HTTP_METHOD_NOT_ALLOWED);
     }
 
     public function testUnauthorized(\Illuminate\Testing\TestResponse $response)
     {
-        $response->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_UNAUTHORIZED);
+        $response->assertStatus(\Illuminate\Http\Response::HTTP_UNAUTHORIZED);
     }
 
     public function testUnprocessableEntity(\Illuminate\Testing\TestResponse $response)
     {
-        $response->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY);
+        $response->assertStatus(\Illuminate\Http\Response::HTTP_UNPROCESSABLE_ENTITY);
     }
 
     public function testGone(\Illuminate\Testing\TestResponse $response)
     {
-        $response->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_GONE);
+        $response->assertStatus(\Illuminate\Http\Response::HTTP_GONE);
     }
 
     public function testInternalServerError(\Illuminate\Testing\TestResponse $response)
     {
-        $response->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_INTERNAL_SERVER_ERROR);
+        $response->assertStatus(\Illuminate\Http\Response::HTTP_INTERNAL_SERVER_ERROR);
     }
 
     public function testServiceUnavailable(\Illuminate\Testing\TestResponse $response)
     {
-        $response->assertStatus(\Symfony\Component\HttpFoundation\Response::HTTP_SERVICE_UNAVAILABLE);
+        $response->assertStatus(\Illuminate\Http\Response::HTTP_SERVICE_UNAVAILABLE);
     }
 }
 


### PR DESCRIPTION
# Changes

- Uses PHPStan to a better effect instead of looking at what constants might be used
- Corrects a previously incorrect test
- Adds stubs for Laravel and Symfony responses
- Simplify the docs a little for the rule

# Why

I wrote this rule over a year or so ago now and learnt a lot since then. This should now allow for any integer value PHPStan can detect. For example:

```diff
-$this->get('/')->assertStatus(400 + 4);
+$this->get('/')->assertNotFound();
```

Before this the rule would only detect specific constants or the scalar integer using only what the PHP Parser had found.