### PR TITLE
Make RemoveDumpDataDeadCodeRector rule configurable

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -978,6 +978,8 @@ refactors calls with the pre Laravel 11 methods for blueprint geometry columns
 
 It will removes the dump data just like dd or dump functions from the code.`
 
+:wrench: **configure it!**
+
 - class: [`RectorLaravel\Rector\FuncCall\RemoveDumpDataDeadCodeRector`](../src/Rector/FuncCall/RemoveDumpDataDeadCodeRector.php)
 
 ```diff

--- a/src/Rector/FuncCall/RemoveDumpDataDeadCodeRector.php
+++ b/src/Rector/FuncCall/RemoveDumpDataDeadCodeRector.php
@@ -8,15 +8,22 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\NodeTraverser;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \RectorLaravel\Tests\Rector\FuncCall\RemoveDumpDataDeadCodeRector\RemoveDumpDataDeadCodeRectorTest
  */
-final class RemoveDumpDataDeadCodeRector extends AbstractRector
+final class RemoveDumpDataDeadCodeRector extends AbstractRector implements ConfigurableRectorInterface
 {
+    /**
+     * @var string[]
+     */
+    private array $dumpFunctionNames = ['dd', 'dump'];
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -76,10 +83,20 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $this->isNames($node->expr->name, ['dd', 'dump'])) {
+        if (! $this->isNames($node->expr->name, $this->dumpFunctionNames)) {
             return null;
         }
 
         return NodeTraverser::REMOVE_NODE;
+    }
+
+    /**
+     * @param  mixed[]  $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        Assert::allString($configuration);
+
+        $this->dumpFunctionNames = $configuration;
     }
 }

--- a/tests/Rector/FuncCall/RemoveDumpDataDeadCodeRector/config/configured_rule.php
+++ b/tests/Rector/FuncCall/RemoveDumpDataDeadCodeRector/config/configured_rule.php
@@ -8,5 +8,5 @@ use RectorLaravel\Rector\FuncCall\RemoveDumpDataDeadCodeRector;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
 
-    $rectorConfig->rule(RemoveDumpDataDeadCodeRector::class);
+    $rectorConfig->ruleWithConfiguration(RemoveDumpDataDeadCodeRector::class, ['dd', 'dump']);
 };


### PR DESCRIPTION
This PR makes it possible to configure the `RemoveDumpDataDeadCodeRector` rule with an array of dump functions. `dd()` and `dump()` are removed by default if the rule isn't used with a configuration in order to keep the current behavior.