### PR TITLE
Fix rule AnonymousMigrationsRector

### DIFF
--- a/src/Rector/Class_/AnonymousMigrationsRector.php
+++ b/src/Rector/Class_/AnonymousMigrationsRector.php
@@ -78,19 +78,8 @@ CODE_SAMPLE
             return null;
         }
 
-        return new Return_(new New_(new Class_(
-            null,
-            [
-                'flags' => $node->flags,
-                'extends' => $node->extends,
-                'implements' => $node->implements,
-                'stmts' => $node->stmts,
-                'attrGroups' => $node->attrGroups,
-            ],
-            [
-                'startLine' => $node->getStartLine(),
-                'endLine' => $node->getEndLine(),
-            ]
-        )));
+        $node->name = null;
+
+        return new Return_(new New_($node));
     }
 }


### PR DESCRIPTION
Somehow the `AnonymousMigrationsRector` rule's tests started hanging.
This happens only from the latest release of [Rector 1.2.7](https://github.com/rectorphp/rector/releases/tag/1.2.7), but it might be because of other dependencies of Rector itself.
