### PR TITLE
Add migration rules for Laravel 5.3

### DIFF
--- a/config/sets/laravel53.php
+++ b/config/sets/laravel53.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Removing\Rector\Class_\RemoveTraitUseRector;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../config.php');
@@ -11,5 +13,12 @@ return static function (RectorConfig $rectorConfig): void {
         ->ruleWithConfiguration(RemoveTraitUseRector::class, [
             // see https://laravel.com/docs/5.3/upgrade
             'Illuminate\Foundation\Auth\Access\AuthorizesResources',
+        ]);
+
+    $rectorConfig
+        ->ruleWithConfiguration(RenameMethodRector::class, [
+            // https://laravel.com/docs/5.3/upgrade#5.2-deprecations
+            new MethodCallRename('Illuminate\Support\Collection', 'lists', 'pluck'),
+            new MethodCallRename('Illuminate\Database\Query\Builder', 'lists', 'pluck'),
         ]);
 };

--- a/config/sets/laravel53.php
+++ b/config/sets/laravel53.php
@@ -3,22 +3,46 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Removing\Rector\Class_\RemoveInterfacesRector;
 use Rector\Removing\Rector\Class_\RemoveTraitUseRector;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\Transform\Rector\StaticCall\StaticCallToFuncCallRector;
+use Rector\Transform\ValueObject\StaticCallToFuncCall;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../config.php');
+
     $rectorConfig
         ->ruleWithConfiguration(RemoveTraitUseRector::class, [
             // see https://laravel.com/docs/5.3/upgrade
             'Illuminate\Foundation\Auth\Access\AuthorizesResources',
         ]);
 
+    // https://laravel.com/docs/5.3/upgrade#5.2-deprecations
     $rectorConfig
         ->ruleWithConfiguration(RenameMethodRector::class, [
-            // https://laravel.com/docs/5.3/upgrade#5.2-deprecations
             new MethodCallRename('Illuminate\Support\Collection', 'lists', 'pluck'),
             new MethodCallRename('Illuminate\Database\Query\Builder', 'lists', 'pluck'),
+            new MethodCallRename('Illuminate\Database\Eloquent\Collection', 'withHidden', 'makeVisible'),
+            new MethodCallRename('Illuminate\Database\Eloquent\Model', 'withHidden', 'makeVisible'),
+        ]);
+
+    $rectorConfig
+        ->ruleWithConfiguration(RemoveInterfacesRector::class, [
+            'Illuminate\Contracts\Bus\SelfHandling',
+        ]);
+
+    $rectorConfig
+        ->ruleWithConfiguration(RenameClassRector::class, [
+            'Illuminate\Database\Eloquent\ScopeInterface' => 'Illuminate\Database\Eloquent\Scope',
+            'Illuminate\View\Expression' => 'Illuminate\Support\HtmlString',
+        ]);
+
+    $rectorConfig
+        ->ruleWithConfiguration(StaticCallToFuncCallRector::class, [
+            new StaticCallToFuncCall('Illuminate\Support\Str', 'randomBytes', 'random_bytes'),
+            new StaticCallToFuncCall('Illuminate\Support\Str', 'equals', 'hash_equals'),
         ]);
 };

--- a/tests/Sets/Laravel53/Fixture/fixture.php.inc
+++ b/tests/Sets/Laravel53/Fixture/fixture.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel53;
+
+use Illuminate\Support\Collection;
+
+(new Collection())->lists('id');
+(new \Illuminate\Database\Eloquent\Builder())->lists('id');
+(new \Illuminate\Database\Query\Builder())->lists('id');
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel53;
+
+use Illuminate\Support\Collection;
+
+(new Collection())->pluck('id');
+(new \Illuminate\Database\Eloquent\Builder())->pluck('id');
+(new \Illuminate\Database\Query\Builder())->pluck('id');
+
+?>

--- a/tests/Sets/Laravel53/Fixture/fixture.php.inc
+++ b/tests/Sets/Laravel53/Fixture/fixture.php.inc
@@ -2,11 +2,25 @@
 
 namespace RectorLaravel\Tests\Sets\Laravel53;
 
-use Illuminate\Support\Collection;
-
-(new Collection())->lists('id');
+(new \Illuminate\Support\Collection())->lists('id');
 (new \Illuminate\Database\Eloquent\Builder())->lists('id');
 (new \Illuminate\Database\Query\Builder())->lists('id');
+(new \Illuminate\Database\Eloquent\Collection())->withHidden([]);
+(new \Illuminate\Database\Eloquent\Model())->withHidden([]);
+\Illuminate\Support\Str::randomBytes(16);
+\Illuminate\Support\Str::equals('knownString', 'userInput');
+
+class SomeJob implements \Illuminate\Contracts\Bus\SelfHandling
+{
+}
+
+class SomeScope implements \Illuminate\Database\Eloquent\ScopeInterface
+{
+}
+
+class SomeView extends \Illuminate\View\Expression
+{
+}
 
 ?>
 -----
@@ -14,10 +28,24 @@ use Illuminate\Support\Collection;
 
 namespace RectorLaravel\Tests\Sets\Laravel53;
 
-use Illuminate\Support\Collection;
-
-(new Collection())->pluck('id');
+(new \Illuminate\Support\Collection())->pluck('id');
 (new \Illuminate\Database\Eloquent\Builder())->pluck('id');
 (new \Illuminate\Database\Query\Builder())->pluck('id');
+(new \Illuminate\Database\Eloquent\Collection())->makeVisible([]);
+(new \Illuminate\Database\Eloquent\Model())->makeVisible([]);
+\random_bytes(16);
+\hash_equals('knownString', 'userInput');
+
+class SomeJob
+{
+}
+
+class SomeScope implements \Illuminate\Database\Eloquent\Scope
+{
+}
+
+class SomeView extends \Illuminate\Support\HtmlString
+{
+}
 
 ?>

--- a/tests/Sets/Laravel53/Laravel53Test.php
+++ b/tests/Sets/Laravel53/Laravel53Test.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Sets\Laravel53;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class Laravel53Test extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Sets/Laravel53/config/configured_rule.php
+++ b/tests/Sets/Laravel53/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../config/sets/laravel53.php');
+};


### PR DESCRIPTION
Fixes https://github.com/driftingly/rector-laravel/issues/254.

We currently only have one rule for the Laravel 5.3 version, this PR adds some more deprecation/migration rules for that version. There are still some more that can be added for 5.3, but they might require custom rules.