### PR TITLE
Update docs

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 68 Rules Overview
+# 69 Rules Overview
 
 ## AbortIfRector
 
@@ -1184,6 +1184,19 @@ Change static `validate()` method to `$request->validate()`
 
 <br>
 
+## ResponseHelperCallToJsonResponseRector
+
+Use new JsonResponse instead of `response()->json()`
+
+- class: [`RectorLaravel\Rector\MethodCall\ResponseHelperCallToJsonResponseRector`](../src/Rector/MethodCall/ResponseHelperCallToJsonResponseRector.php)
+
+```diff
+-response()->json(['key' => 'value']);
++return new JsonResponse(['key' => 'value']);
+```
+
+<br>
+
 ## ReverseConditionableMethodCallRector
 
 Reverse conditionable method calls
@@ -1359,19 +1372,6 @@ Convert string validation rules into arrays for Laravel's Validator.
 -    'field' => 'required|nullable|string|max:255',
 +    'field' => ['required', 'nullable', 'string', 'max:255'],
  ]);
-```
-
-<br>
-
-## ResponseHelperCallToJsonResponseRector
-
-Change `response()->json()` to `new JsonResponse()`
-
-- class: [`RectorLaravel\Rector\MethodCall\ResponseHelperCallToJsonResponseRector`](../src/Rector/MethodCall/ResponseHelperCallToJsonResponseRector.php)
-
-```diff
--    return response()->json(['message' => 'Hello World']);
-+    return new \Illuminate\Http\JsonResponse(['message' => 'Hello World']);
 ```
 
 <br>

--- a/src/Rector/FuncCall/RemoveDumpDataDeadCodeRector.php
+++ b/src/Rector/FuncCall/RemoveDumpDataDeadCodeRector.php
@@ -10,7 +10,7 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\NodeTraverser;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
-use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
 
@@ -29,7 +29,7 @@ final class RemoveDumpDataDeadCodeRector extends AbstractRector implements Confi
         return new RuleDefinition(
             'It will removes the dump data just like dd or dump functions from the code.`',
             [
-                new CodeSample(
+                new ConfiguredCodeSample(
                     <<<'CODE_SAMPLE'
 class MyController
 {
@@ -61,6 +61,8 @@ class MyController
     }
 }
 CODE_SAMPLE
+                    ,
+                    ['dd', 'dump'],
                 ),
             ]
         );


### PR DESCRIPTION
The rule definition of `RemoveDumpDataDeadCodeRector` is incorrect and prevents docs from being generated.