### PR TITLE
Adds the EnvVariableToEnvHelperRector rule

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 69 Rules Overview
+# 70 Rules Overview
 
 ## AbortIfRector
 
@@ -574,6 +574,19 @@ Replace use of the unsafe `empty()` function with Laravel's safer `blank()` & `f
 -!empty([]);
 +blank([]);
 +filled([]);
+```
+
+<br>
+
+## EnvVariableToEnvHelperRector
+
+Change env variable to env static call
+
+- class: [`RectorLaravel\Rector\ArrayDimFetch\EnvVariableToEnvHelperRector`](../src/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector.php)
+
+```diff
+-$_ENV['APP_NAME'];
++\Illuminate\Support\Env::get('APP_NAME');
 ```
 
 <br>

--- a/src/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector.php
+++ b/src/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace RectorLaravel\Rector\ArrayDimFetch;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\StaticCall;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\ArrayDimFetch\EnvVariableToEnvHelperRector\EnvVariableToEnvHelperRectorTest
+ */
+class EnvVariableToEnvHelperRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change env variable to env static call',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+$_ENV['APP_NAME'];
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+\Illuminate\Support\Env::get('APP_NAME');
+CODE_SAMPLE
+            )]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [ArrayDimFetch::class];
+    }
+
+    /**
+     * @param  ArrayDimFetch  $node
+     */
+    public function refactor(Node $node): ?StaticCall
+    {
+        if (! $this->isName($node->var, '_ENV')) {
+            return null;
+        }
+
+        if ($node->dim === null) {
+            return null;
+        }
+
+        return $this->nodeFactory->createStaticCall('Illuminate\Support\Env', 'get', [
+            new Arg($node->dim),
+        ]);
+    }
+}

--- a/tests/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector/EnvVariableToEnvHelperRectorTest.php
+++ b/tests/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector/EnvVariableToEnvHelperRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\EnvVariableToEnvHelperRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class EnvVariableToEnvHelperRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector/Fixture/fixture.php.inc
+++ b/tests/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector/Fixture/fixture.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\EnvVariableToEnvHelperRector\Fixture;
+
+$_ENV['APP_NAME'];
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\EnvVariableToEnvHelperRector\Fixture;
+
+\Illuminate\Support\Env::get('APP_NAME');
+
+?>

--- a/tests/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector/Fixture/skip_dim_fetch_without_dim.php.inc
+++ b/tests/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector/Fixture/skip_dim_fetch_without_dim.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\EnvVariableToEnvHelperRector\Fixture;
+
+$_ENV[];
+
+?>

--- a/tests/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector/Fixture/skip_non_env_variable.php.inc
+++ b/tests/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector/Fixture/skip_non_env_variable.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\EnvVariableToEnvHelperRector\Fixture;
+
+$_ENVV['APP_NAME'];
+
+?>

--- a/tests/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector/config/configured_rule.php
+++ b/tests/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\ArrayDimFetch\EnvVariableToEnvHelperRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(EnvVariableToEnvHelperRector::class);
+};


### PR DESCRIPTION
# Changes

- Adds the EnvVariableToEnvHelperRector rule
- Provides tests
- Updates Docs

# Why

Just a useful rule to help transition PHP use of `$_ENV` to use the dotenv system of Laravel.