### PR TITLE
Adds RequestVariablesToRequestFacadeRector rule

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 69 Rules Overview
+# 70 Rules Overview
 
 ## AbortIfRector
 
@@ -1180,6 +1180,21 @@ Change static `validate()` method to `$request->validate()`
 +        $validatedData = $request->validate(['some_attribute' => 'required']);
      }
  }
+```
+
+<br>
+
+## RequestVariablesToRequestFacadeRector
+
+Change request variable definition in Facade
+
+- class: [`RectorLaravel\Rector\ArrayDimFetch\RequestVariablesToRequestFacadeRector`](../src/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector.php)
+
+```diff
+-$_GET['value'];
+-$_POST['value'];
++\Illuminate\Support\Facades\Request::input('value');
++\Illuminate\Support\Facades\Request::input('value');
 ```
 
 <br>

--- a/src/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector.php
+++ b/src/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace RectorLaravel\Rector\ArrayDimFetch;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Scalar;
+use PhpParser\Node\Scalar\String_;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\ArrayDimFetch\RequestVariablesToRequestFacadeRector\RequestVariablesToRequestFacadeRectorTest
+ */
+class RequestVariablesToRequestFacadeRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change request variable definition in Facade',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+$_GET['value'];
+$_POST['value'];
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+\Illuminate\Support\Facades\Request::input('value');
+\Illuminate\Support\Facades\Request::input('value');
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [ArrayDimFetch::class];
+    }
+
+    /**
+     * @param  ArrayDimFetch  $node
+     */
+    public function refactor(Node $node): ?StaticCall
+    {
+        $key = $this->findAllKeys($node);
+
+        if (! is_string($key)) {
+            return null;
+        }
+
+        return $this->nodeFactory->createStaticCall(
+            'Illuminate\Support\Facades\Request',
+            'input',
+            [new Arg(new String_($key))]
+        );
+    }
+
+    public function findAllKeys(ArrayDimFetch $arrayDimFetch): ?string
+    {
+        if (! $arrayDimFetch->dim instanceof Scalar) {
+            return null;
+        }
+
+        $value = $this->getType($arrayDimFetch->dim)->getConstantScalarValues()[0] ?? null;
+
+        if ($value === null) {
+            return null;
+        }
+
+        if ($arrayDimFetch->var instanceof ArrayDimFetch) {
+            $key = $this->findAllKeys($arrayDimFetch->var);
+
+            if ($key === null) {
+                return null;
+            }
+
+            return implode('.', [$key, $value]);
+        }
+
+        if ($this->isNames($arrayDimFetch->var, ['_GET', '_POST'])) {
+            return (string) $value;
+        }
+
+        return null;
+    }
+}

--- a/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/Fixture/fixture.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\RequestVariablesToRequestFacadeRector\Fixture;
+
+$var = $_GET['a'];
+$deepVar = $_GET['a']['b'];
+$numberUsed = $_GET['a']['b'][0];
+$postVar = $_POST['a'];
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\RequestVariablesToRequestFacadeRector\Fixture;
+
+$var = \Illuminate\Support\Facades\Request::input('a');
+$deepVar = \Illuminate\Support\Facades\Request::input('a.b');
+$numberUsed = \Illuminate\Support\Facades\Request::input('a.b.0');
+$postVar = \Illuminate\Support\Facades\Request::input('a');
+
+?>

--- a/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/Fixture/skip_complex_dim.php.inc
+++ b/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/Fixture/skip_complex_dim.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\RequestVariablesToRequestFacadeRector\Fixture;
+
+$a = 'foobar';
+$var = $_GET[$a];
+
+?>

--- a/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/Fixture/skip_non_matching_variables.php.inc
+++ b/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/Fixture/skip_non_matching_variables.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\RequestVariablesToRequestFacadeRector\Fixture;
+
+$var = $_GETT['a'];
+
+?>

--- a/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/RequestVariablesToRequestFacadeRectorTest.php
+++ b/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/RequestVariablesToRequestFacadeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\RequestVariablesToRequestFacadeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RequestVariablesToRequestFacadeRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/config/configured_rule.php
+++ b/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\ArrayDimFetch\RequestVariablesToRequestFacadeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(RequestVariablesToRequestFacadeRector::class);
+};


### PR DESCRIPTION
# Changes

- Adds RequestVariablesToRequestFacadeRector rule
- Adds tests
- Updates Docs

# Why

Provides a nice transition from vanilla PHP to Laravel code.

```diff
-$_GET['value'];
-$_POST['value'];
-$_GET['value']['sub_value'];
+\Illuminate\Support\Facades\Request::input('value');
+\Illuminate\Support\Facades\Request::input('value');
+\Illuminate\Support\Facades\Request::input('value.sub_value');
```