### PR TITLE
Laravel 11 new generic types

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 70 Rules Overview
+# 71 Rules Overview
 
 ## AbortIfRector
 
@@ -62,8 +62,6 @@ Adds the `@extends` annotation to Factories.
 ## AddGenericReturnTypeToRelationsRector
 
 Add generic return type to relations in child of `Illuminate\Database\Eloquent\Model`
-
-:wrench: **configure it!**
 
 - class: [`RectorLaravel\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector`](../src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php)
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -29,3 +29,6 @@ parameters:
         - '#Parameter \#1 \$node (.*?) of method RectorLaravel\\(.*?)\:\:(refactor|refactorWithScope)\(\) should be contravariant with parameter \$node \(PhpParser\\Node\) of method Rector\\Contract\\Rector\\RectorInterface\:\:refactor\(\)#'
 
         - '#Parameter \#1 \$className of method Rector\\Reflection\\ReflectionResolver\:\:resolveMethodReflection\(\) expects class\-string, string given#'
+
+        # Laravel Container not being recognized properly in some of the tests
+        - '#Call to method needs\(\) on an unknown class Illuminate\\Contracts\\Container\\ContextualBindingBuilder#'

--- a/src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php
+++ b/src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php
@@ -22,20 +22,19 @@ use PHPStan\Type\ThisType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\ValueObject\Type\FullyQualifiedIdentifierTypeNode;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
-use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Rector\AbstractScopeAwareRector;
 use Rector\StaticTypeMapper\StaticTypeMapper;
-use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use ReflectionClassConstant;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
-use Webmozart\Assert\Assert;
 
 /**
  * @see \RectorLaravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\AddGenericReturnTypeToRelationsRectorNewGenericsTest
  * @see \RectorLaravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\AddGenericReturnTypeToRelationsRectorOldGenericsTest
  */
-class AddGenericReturnTypeToRelationsRector extends AbstractScopeAwareRector implements ConfigurableRectorInterface
+class AddGenericReturnTypeToRelationsRector extends AbstractScopeAwareRector
 {
     // Relation methods which are supported by this Rector.
     private const RELATION_METHODS = [
@@ -59,6 +58,7 @@ class AddGenericReturnTypeToRelationsRector extends AbstractScopeAwareRector imp
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly string $applicationClass = 'Illuminate\Foundation\Application',
     ) {
     }
 
@@ -67,7 +67,7 @@ class AddGenericReturnTypeToRelationsRector extends AbstractScopeAwareRector imp
         return new RuleDefinition(
             'Add generic return type to relations in child of Illuminate\Database\Eloquent\Model',
             [
-                new ConfiguredCodeSample(
+                new CodeSample(
                     <<<'CODE_SAMPLE'
 use App\Account;
 use Illuminate\Database\Eloquent\Model;
@@ -96,9 +96,9 @@ class User extends Model
         return $this->hasMany(Account::class);
     }
 }
-CODE_SAMPLE,
-                    ['shouldUseNewGenerics' => false]),
-                new ConfiguredCodeSample(
+CODE_SAMPLE
+                ),
+                new CodeSample(
                     <<<'CODE_SAMPLE'
 use App\Account;
 use Illuminate\Database\Eloquent\Model;
@@ -127,8 +127,8 @@ class User extends Model
         return $this->hasMany(Account::class);
     }
 }
-CODE_SAMPLE,
-                    ['shouldUseNewGenerics' => true]),
+CODE_SAMPLE
+                ),
             ]
         );
     }
@@ -196,6 +196,9 @@ CODE_SAMPLE,
             return null;
         }
 
+        // Put here to make the check as late as possible
+        $this->setShouldUseNewGenerics();
+
         $classForChildGeneric = $this->getClassForChildGeneric($scope, $relationMethodCall);
         $classForIntermediateGeneric = $this->getClassForIntermediateGeneric($relationMethodCall);
 
@@ -230,24 +233,6 @@ CODE_SAMPLE,
         $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
 
         return $node;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function configure(array $configuration): void
-    {
-        if ($configuration === []) {
-            $this->shouldUseNewGenerics = false;
-
-            return;
-        }
-
-        Assert::count($configuration, 1);
-        Assert::keyExists($configuration, 'shouldUseNewGenerics');
-        Assert::boolean($configuration['shouldUseNewGenerics']);
-
-        $this->shouldUseNewGenerics = $configuration['shouldUseNewGenerics'];
     }
 
     private function getRelatedModelClassFromMethodCall(MethodCall $methodCall): ?string
@@ -488,5 +473,14 @@ CODE_SAMPLE,
         }
 
         return $generics;
+    }
+
+    private function setShouldUseNewGenerics(): void
+    {
+        $laravelVersion = new ReflectionClassConstant($this->applicationClass, 'VERSION');
+
+        if (is_string($laravelVersion->getValue())) {
+            $this->shouldUseNewGenerics = version_compare($laravelVersion->getValue(), '11.15.0', '>=');
+        }
     }
 }

--- a/src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php
+++ b/src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php
@@ -477,10 +477,10 @@ CODE_SAMPLE
 
     private function setShouldUseNewGenerics(): void
     {
-        $laravelVersion = new ReflectionClassConstant($this->applicationClass, 'VERSION');
+        $reflectionClassConstant = new ReflectionClassConstant($this->applicationClass, 'VERSION');
 
-        if (is_string($laravelVersion->getValue())) {
-            $this->shouldUseNewGenerics = version_compare($laravelVersion->getValue(), '11.15.0', '>=');
+        if (is_string($reflectionClassConstant->getValue())) {
+            $this->shouldUseNewGenerics = version_compare($reflectionClassConstant->getValue(), '11.15.0', '>=');
         }
     }
 }

--- a/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/AddGenericReturnTypeToRelationsRectorNewGenericsTest.php
+++ b/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/AddGenericReturnTypeToRelationsRectorNewGenericsTest.php
@@ -12,7 +12,6 @@ final class AddGenericReturnTypeToRelationsRectorNewGenericsTest extends Abstrac
 {
     public static function provideData(): Iterator
     {
-        //        yield [__DIR__ . '/Fixture/NewGenerics/has-one-through.php.inc'];
         return self::yieldFilesFromDirectory(__DIR__ . '/Fixture/NewGenerics');
     }
 

--- a/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Source/NewApplication.php
+++ b/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Source/NewApplication.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Source;
+
+use Illuminate\Foundation\Application;
+
+class NewApplication extends Application
+{
+    const VERSION = '11.15.0';
+}

--- a/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Source/OldApplication.php
+++ b/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Source/OldApplication.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Source;
+
+use Illuminate\Foundation\Application;
+
+class OldApplication extends Application
+{
+    const VERSION = '11.14.0';
+}

--- a/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/config/use_new_generics_configured_rule.php
+++ b/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/config/use_new_generics_configured_rule.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use RectorLaravel\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector;
+use RectorLaravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Source\NewApplication;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
 
-    $rectorConfig->ruleWithConfiguration(AddGenericReturnTypeToRelationsRector::class, [
-        'shouldUseNewGenerics' => true,
-    ]);
+    $rectorConfig->when(AddGenericReturnTypeToRelationsRector::class)
+        ->needs('$applicationClass')
+        ->give(NewApplication::class);
+
+    $rectorConfig->rule(AddGenericReturnTypeToRelationsRector::class);
 };

--- a/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/config/use_old_generics_configured_rule.php
+++ b/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/config/use_old_generics_configured_rule.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use RectorLaravel\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector;
+use RectorLaravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Source\OldApplication;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
 
-    $rectorConfig->ruleWithConfiguration(AddGenericReturnTypeToRelationsRector::class, []);
+    $rectorConfig->when(AddGenericReturnTypeToRelationsRector::class)
+        ->needs('$applicationClass')
+        ->give(OldApplication::class);
+
+    $rectorConfig->rule(AddGenericReturnTypeToRelationsRector::class);
 };


### PR DESCRIPTION
Relates to https://github.com/driftingly/rector-laravel/pull/263.

- Makes the rule as non-configurable, as before, so users won't need to change their configurations.
- The check for the Laravel version is done within the rule, using Reflection, and checking the `VERSION` const of the Laravel `Application` class. Should we refactor this functionality into a class of its own, or wait for when we reach for it on future rules?
- I've used the Laravel Container's when-needs-give capabilities to provide an optional `Application` class for testing the two versions.
- I'm not sure if there is any performance penalty for doing that check on every model relationship. I don't think there is any significant penalty, but it's still something to remember.

Is there a better way to do this @peterfox?