### PR TITLE
Update Duster and use latest Pint configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^10.5",
         "symplify/rule-doc-generator": "^12.2",
-        "tightenco/duster": "^2.7"
+        "tightenco/duster": "^3.1"
     },
     "autoload": {
         "psr-4": {

--- a/config/config.php
+++ b/config/config.php
@@ -4,5 +4,4 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 
-return static function (RectorConfig $rectorConfig): void {
-};
+return static function (RectorConfig $rectorConfig): void {};

--- a/pint.json
+++ b/pint.json
@@ -1,6 +1,0 @@
-{
-    "rules": {
-        "single_line_empty_body": false,
-        "concat_space": false
-    }
-}

--- a/src/NodeAnalyzer/LumenRouteRegisteringMethodAnalyzer.php
+++ b/src/NodeAnalyzer/LumenRouteRegisteringMethodAnalyzer.php
@@ -16,8 +16,7 @@ final readonly class LumenRouteRegisteringMethodAnalyzer
     public function __construct(
         private NodeTypeResolver $nodeTypeResolver,
         private NodeNameResolver $nodeNameResolver
-    ) {
-    }
+    ) {}
 
     public function isLumenRoutingClass(MethodCall $methodCall): bool
     {

--- a/src/NodeAnalyzer/StaticCallAnalyzer.php
+++ b/src/NodeAnalyzer/StaticCallAnalyzer.php
@@ -13,8 +13,7 @@ final readonly class StaticCallAnalyzer
 {
     public function __construct(
         private NodeNameResolver $nodeNameResolver
-    ) {
-    }
+    ) {}
 
     public function isParentCallNamed(Node $node, string $desiredMethodName): bool
     {

--- a/src/NodeFactory/AppAssignFactory.php
+++ b/src/NodeFactory/AppAssignFactory.php
@@ -17,8 +17,7 @@ final readonly class AppAssignFactory
 {
     public function __construct(
         private PhpDocInfoFactory $phpDocInfoFactory
-    ) {
-    }
+    ) {}
 
     public function createAssignExpression(
         ServiceNameTypeAndVariableName $serviceNameTypeAndVariableName,

--- a/src/NodeFactory/ModelFactoryNodeFactory.php
+++ b/src/NodeFactory/ModelFactoryNodeFactory.php
@@ -38,8 +38,7 @@ final readonly class ModelFactoryNodeFactory
         private NodeFactory $nodeFactory,
         private ValueResolver $valueResolver,
         private SimpleCallableNodeTraverser $simpleCallableNodeTraverser
-    ) {
-    }
+    ) {}
 
     public function createEmptyFactory(string $name, Expr $expr): Class_
     {

--- a/src/NodeFactory/RouterRegisterNodeAnalyzer.php
+++ b/src/NodeFactory/RouterRegisterNodeAnalyzer.php
@@ -17,8 +17,7 @@ final readonly class RouterRegisterNodeAnalyzer
     public function __construct(
         private NodeNameResolver $nodeNameResolver,
         private NodeTypeResolver $nodeTypeResolver
-    ) {
-    }
+    ) {}
 
     public function isRegisterMethodStaticCall(MethodCall|StaticCall $node): bool
     {

--- a/src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php
+++ b/src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php
@@ -58,8 +58,7 @@ class AddGenericReturnTypeToRelationsRector extends AbstractRector
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly StaticTypeMapper $staticTypeMapper,
         private readonly string $applicationClass = 'Illuminate\Foundation\Application',
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/ClassMethod/AddParentBootToModelClassMethodRector.php
+++ b/src/Rector/ClassMethod/AddParentBootToModelClassMethodRector.php
@@ -29,8 +29,7 @@ final class AddParentBootToModelClassMethodRector extends AbstractRector
     public function __construct(
         private readonly StaticCallAnalyzer $staticCallAnalyzer,
         private readonly ReflectionResolver $reflectionResolver,
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/ClassMethod/AddParentRegisterToEventServiceProviderRector.php
+++ b/src/Rector/ClassMethod/AddParentRegisterToEventServiceProviderRector.php
@@ -29,8 +29,7 @@ final class AddParentRegisterToEventServiceProviderRector extends AbstractRector
     public function __construct(
         private readonly StaticCallAnalyzer $staticCallAnalyzer,
         private readonly ReflectionResolver $reflectionResolver,
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/ClassMethod/MigrateToSimplifiedAttributeRector.php
+++ b/src/Rector/ClassMethod/MigrateToSimplifiedAttributeRector.php
@@ -34,8 +34,7 @@ final class MigrateToSimplifiedAttributeRector extends AbstractRector
 {
     public function __construct(
         private readonly BetterNodeFinder $betterNodeFinder
-    ) {
-    }
+    ) {}
 
     /**
      * @return array<class-string<Node>>

--- a/src/Rector/Class_/AddExtendsAnnotationToModelFactoriesRector.php
+++ b/src/Rector/Class_/AddExtendsAnnotationToModelFactoriesRector.php
@@ -35,8 +35,7 @@ final class AddExtendsAnnotationToModelFactoriesRector extends AbstractRector
     public function __construct(
         private readonly DocBlockUpdater $docBlockUpdater,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/Class_/AddMockConsoleOutputFalseToConsoleTestsRector.php
+++ b/src/Rector/Class_/AddMockConsoleOutputFalseToConsoleTestsRector.php
@@ -39,8 +39,7 @@ final class AddMockConsoleOutputFalseToConsoleTestsRector extends AbstractRector
         private readonly VisibilityManipulator $visibilityManipulator,
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly ValueResolver $valueResolver,
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/Class_/AnonymousMigrationsRector.php
+++ b/src/Rector/Class_/AnonymousMigrationsRector.php
@@ -24,8 +24,7 @@ final class AnonymousMigrationsRector extends AbstractRector
 {
     public function __construct(
         private readonly ClassAnalyzer $classAnalyzer
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/Class_/LivewireComponentComputedMethodToComputedAttributeRector.php
+++ b/src/Rector/Class_/LivewireComponentComputedMethodToComputedAttributeRector.php
@@ -26,10 +26,7 @@ final class LivewireComponentComputedMethodToComputedAttributeRector extends Abs
 
     private const METHOD_PATTERN = '/^get(?\'methodName\'[\w]*)Property$/';
 
-    public function __construct(private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer)
-    {
-
-    }
+    public function __construct(private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/Class_/LivewireComponentQueryStringToUrlAttributeRector.php
+++ b/src/Rector/Class_/LivewireComponentQueryStringToUrlAttributeRector.php
@@ -31,10 +31,7 @@ final class LivewireComponentQueryStringToUrlAttributeRector extends AbstractRec
 
     private const QUERY_STRING_PROPERTY_NAME = 'queryString';
 
-    public function __construct(private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer)
-    {
-
-    }
+    public function __construct(private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/Class_/ModelCastsPropertyToCastsMethodRector.php
+++ b/src/Rector/Class_/ModelCastsPropertyToCastsMethodRector.php
@@ -27,8 +27,7 @@ class ModelCastsPropertyToCastsMethodRector extends AbstractRector
         protected BuilderFactory $builderFactory,
         protected PhpDocInfoFactory $phpDocInfoFactory,
         protected DocBlockUpdater $docBlockUpdater,
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/Class_/PropertyDeferToDeferrableProviderToRector.php
+++ b/src/Rector/Class_/PropertyDeferToDeferrableProviderToRector.php
@@ -24,8 +24,7 @@ final class PropertyDeferToDeferrableProviderToRector extends AbstractRector
 {
     public function __construct(
         private readonly ValueResolver $valueResolver,
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/Class_/UnifyModelDatesWithCastsRector.php
+++ b/src/Rector/Class_/UnifyModelDatesWithCastsRector.php
@@ -31,8 +31,7 @@ final class UnifyModelDatesWithCastsRector extends AbstractRector
         private readonly ClassInsertManipulator $classInsertManipulator,
         private readonly ValueResolver $valueResolver,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/SubStrToStartsWithOrEndsWithStaticMethodCallRector.php
+++ b/src/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/SubStrToStartsWithOrEndsWithStaticMethodCallRector.php
@@ -98,8 +98,7 @@ CODE_SAMPLE
         }
 
         return $this->nodeFactory->createStaticCall('Illuminate\Support\Str', $methodName, [
-            $functionCall->getArgs()[0]
-->value,
+            $functionCall->getArgs()[0]->value,
             $otherNode,
         ]);
     }

--- a/src/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/SubStrToStartsWithOrEndsWithStaticMethodCallRector.php
+++ b/src/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/SubStrToStartsWithOrEndsWithStaticMethodCallRector.php
@@ -22,8 +22,7 @@ class SubStrToStartsWithOrEndsWithStaticMethodCallRector extends AbstractRector
 {
     public function __construct(
         private readonly ValueResolver $valueResolver,
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/FuncCall/ArgumentFuncCallToMethodCallRector.php
+++ b/src/Rector/FuncCall/ArgumentFuncCallToMethodCallRector.php
@@ -36,8 +36,7 @@ final class ArgumentFuncCallToMethodCallRector extends AbstractRector implements
     public function __construct(
         private readonly ArrayTypeAnalyzer $arrayTypeAnalyzer,
         private readonly FuncCallStaticCallToMethodCallAnalyzer $funcCallStaticCallToMethodCallAnalyzer
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/FuncCall/DispatchNonShouldQueueToDispatchSyncRector.php
+++ b/src/Rector/FuncCall/DispatchNonShouldQueueToDispatchSyncRector.php
@@ -33,9 +33,7 @@ class DispatchNonShouldQueueToDispatchSyncRector extends AbstractRector
 
     private const string DISPATCHABLE_TRAIT = 'Illuminate\Foundation\Bus\Dispatchable';
 
-    public function __construct(private readonly ReflectionProvider $reflectionProvider)
-    {
-    }
+    public function __construct(private readonly ReflectionProvider $reflectionProvider) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/FuncCall/TypeHintTappableCallRector.php
+++ b/src/Rector/FuncCall/TypeHintTappableCallRector.php
@@ -25,8 +25,7 @@ class TypeHintTappableCallRector extends AbstractRector
     public function __construct(
         private readonly TypeComparator $typeComparator,
         private readonly StaticTypeMapper $staticTypeMapper
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector.php
+++ b/src/Rector/MethodCall/AssertSeeToAssertSeeHtmlRector.php
@@ -28,8 +28,7 @@ final class AssertSeeToAssertSeeHtmlRector extends AbstractRector
 
     public function __construct(
         private readonly ValueResolver $valueResolver
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/MethodCall/ChangeQueryWhereDateValueWithCarbonRector.php
+++ b/src/Rector/MethodCall/ChangeQueryWhereDateValueWithCarbonRector.php
@@ -29,8 +29,7 @@ final class ChangeQueryWhereDateValueWithCarbonRector extends AbstractRector
 {
     public function __construct(
         private readonly ValueResolver $valueResolver,
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/MethodCall/EloquentWhereRelationTypeHintingParameterRector.php
+++ b/src/Rector/MethodCall/EloquentWhereRelationTypeHintingParameterRector.php
@@ -96,8 +96,7 @@ CODE_SAMPLE
         ) ? 2 : 1;
 
         /** @var ArrowFunction|Closure $closure */
-        $closure = $node->getArgs()[$position]
-->value;
+        $closure = $node->getArgs()[$position]->value;
 
         if (! isset($closure->getParams()[0])) {
             return;

--- a/src/Rector/MethodCall/FactoryApplyingStatesRector.php
+++ b/src/Rector/MethodCall/FactoryApplyingStatesRector.php
@@ -26,8 +26,7 @@ final class FactoryApplyingStatesRector extends AbstractRector
 {
     public function __construct(
         private readonly ValueResolver $valueResolver,
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/MethodCall/LumenRoutesStringActionToUsesArrayRector.php
+++ b/src/Rector/MethodCall/LumenRoutesStringActionToUsesArrayRector.php
@@ -22,8 +22,7 @@ final class LumenRoutesStringActionToUsesArrayRector extends AbstractRector
 {
     public function __construct(
         private readonly LumenRouteRegisteringMethodAnalyzer $lumenRouteRegisteringMethodAnalyzer
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/MethodCall/LumenRoutesStringMiddlewareToArrayRector.php
+++ b/src/Rector/MethodCall/LumenRoutesStringMiddlewareToArrayRector.php
@@ -21,8 +21,7 @@ final class LumenRoutesStringMiddlewareToArrayRector extends AbstractRector
 {
     public function __construct(
         private readonly LumenRouteRegisteringMethodAnalyzer $lumenRouteRegisteringMethodAnalyzer
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/Namespace_/FactoryDefinitionRector.php
+++ b/src/Rector/Namespace_/FactoryDefinitionRector.php
@@ -33,8 +33,7 @@ final class FactoryDefinitionRector extends AbstractRector
 {
     public function __construct(
         private readonly ModelFactoryNodeFactory $modelFactoryNodeFactory
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/PropertyFetch/OptionalToNullsafeOperatorRector.php
+++ b/src/Rector/PropertyFetch/OptionalToNullsafeOperatorRector.php
@@ -51,8 +51,7 @@ final class OptionalToNullsafeOperatorRector extends AbstractRector implements C
 
     public function __construct(
         private readonly ValueResolver $valueResolver,
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/PropertyFetch/ReplaceFakerInstanceWithHelperRector.php
+++ b/src/Rector/PropertyFetch/ReplaceFakerInstanceWithHelperRector.php
@@ -21,8 +21,7 @@ final class ReplaceFakerInstanceWithHelperRector extends AbstractRector
 {
     public function __construct(
         private readonly ReflectionResolver $reflectionResolver
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/StaticCall/DispatchToHelperFunctionsRector.php
+++ b/src/Rector/StaticCall/DispatchToHelperFunctionsRector.php
@@ -24,8 +24,7 @@ final class DispatchToHelperFunctionsRector extends AbstractRector
 {
     public function __construct(
         private readonly ReflectionProvider $reflectionProvider,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws PoorDocumentationException

--- a/src/Rector/StaticCall/RouteActionCallableRector.php
+++ b/src/Rector/StaticCall/RouteActionCallableRector.php
@@ -58,8 +58,7 @@ final class RouteActionCallableRector extends AbstractRector implements Configur
         private readonly ReflectionResolver $reflectionResolver,
         private readonly RouterRegisterNodeAnalyzer $routerRegisterNodeAnalyzer,
         private readonly ValueResolver $valueResolver,
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/ValueObject/AddArgumentDefaultValue.php
+++ b/src/ValueObject/AddArgumentDefaultValue.php
@@ -13,8 +13,7 @@ final readonly class AddArgumentDefaultValue
         private string $method,
         private int $position,
         private mixed $defaultValue
-    ) {
-    }
+    ) {}
 
     public function getObjectType(): ObjectType
     {

--- a/src/ValueObject/ApplyDefaultInsteadOfNullCoalesce.php
+++ b/src/ValueObject/ApplyDefaultInsteadOfNullCoalesce.php
@@ -6,9 +6,7 @@ use PHPStan\Type\ObjectType;
 
 final readonly class ApplyDefaultInsteadOfNullCoalesce
 {
-    public function __construct(private string $methodName, private ?ObjectType $objectType = null, private int $argumentPosition = 1)
-    {
-    }
+    public function __construct(private string $methodName, private ?ObjectType $objectType = null, private int $argumentPosition = 1) {}
 
     public function getObjectType(): ?ObjectType
     {

--- a/src/ValueObject/ReplaceServiceContainerCallArg.php
+++ b/src/ValueObject/ReplaceServiceContainerCallArg.php
@@ -9,8 +9,7 @@ final readonly class ReplaceServiceContainerCallArg
     public function __construct(
         private string|ClassConstFetch $oldService,
         private string|ClassConstFetch $newService
-    ) {
-    }
+    ) {}
 
     public function getOldService(): string|ClassConstFetch
     {

--- a/src/ValueObject/ServiceNameTypeAndVariableName.php
+++ b/src/ValueObject/ServiceNameTypeAndVariableName.php
@@ -10,8 +10,7 @@ final readonly class ServiceNameTypeAndVariableName
         private string $serviceName,
         private string $type,
         private string $variableName
-    ) {
-    }
+    ) {}
 
     public function getServiceName(): string
     {

--- a/src/ValueObject/TypeToTimeMethodAndPosition.php
+++ b/src/ValueObject/TypeToTimeMethodAndPosition.php
@@ -12,8 +12,7 @@ final readonly class TypeToTimeMethodAndPosition
         private string $type,
         private string $methodName,
         private int $position
-    ) {
-    }
+    ) {}
 
     public function getObjectType(): ObjectType
     {

--- a/stubs/Illuminate/Container/Container.php
+++ b/stubs/Illuminate/Container/Container.php
@@ -4,6 +4,4 @@ namespace Illuminate\Container;
 
 use Illuminate\Contracts\Container\Container as ContainerContract;
 
-class Container implements ContainerContract
-{
-}
+class Container implements ContainerContract {}

--- a/stubs/Illuminate/Contracts/Cache/Store.php
+++ b/stubs/Illuminate/Contracts/Cache/Store.php
@@ -8,6 +8,4 @@ if (interface_exists('Illuminate\Contracts\Cache\Store')) {
     return;
 }
 
-interface Store
-{
-}
+interface Store {}

--- a/stubs/Illuminate/Contracts/Container/Container.php
+++ b/stubs/Illuminate/Contracts/Container/Container.php
@@ -2,6 +2,4 @@
 
 namespace Illuminate\Contracts\Container;
 
-interface Container
-{
-}
+interface Container {}

--- a/stubs/Illuminate/Contracts/Events/Dispatcher.php
+++ b/stubs/Illuminate/Contracts/Events/Dispatcher.php
@@ -5,6 +5,4 @@ namespace Illuminate\Contracts\Events;
 if (class_exists('Illuminate\Contracts\Events\Dispatcher')) {
     return;
 }
-class Dispatcher
-{
-}
+class Dispatcher {}

--- a/stubs/Illuminate/Contracts/Queue/ShouldQueue.php
+++ b/stubs/Illuminate/Contracts/Queue/ShouldQueue.php
@@ -6,6 +6,4 @@ if (class_exists('Illuminate\Contracts\Queue\ShouldQueue')) {
     return;
 }
 
-interface ShouldQueue
-{
-}
+interface ShouldQueue {}

--- a/stubs/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/stubs/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -6,6 +6,4 @@ if (class_exists('Illuminate\Contracts\Routing\ResponseFactory')) {
     return;
 }
 
-interface ResponseFactory
-{
-}
+interface ResponseFactory {}

--- a/stubs/Illuminate/Contracts/Support/DeferrableProvider.php
+++ b/stubs/Illuminate/Contracts/Support/DeferrableProvider.php
@@ -8,6 +8,4 @@ if (interface_exists('Illuminate\Contracts\Support\DeferrableProvider')) {
     return;
 }
 
-interface DeferrableProvider
-{
-}
+interface DeferrableProvider {}

--- a/stubs/Illuminate/Database/Eloquent/Builder.php
+++ b/stubs/Illuminate/Database/Eloquent/Builder.php
@@ -10,11 +10,7 @@ if (class_exists('Illuminate\Database\Eloquent\Builder')) {
 
 class Builder extends QueryBuilder
 {
-    public function publicMethodBelongsToEloquentQueryBuilder(): void
-    {
-    }
+    public function publicMethodBelongsToEloquentQueryBuilder(): void {}
 
-    public function excludablePublicMethodBelongsToEloquentQueryBuilder(): void
-    {
-    }
+    public function excludablePublicMethodBelongsToEloquentQueryBuilder(): void {}
 }

--- a/stubs/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/stubs/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -6,6 +6,4 @@ if (class_exists('Illuminate\Database\Eloquent\Factories\Factory')) {
     return;
 }
 
-abstract class Factory
-{
-}
+abstract class Factory {}

--- a/stubs/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/stubs/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -6,6 +6,4 @@ if (class_exists('Illuminate\Database\Eloquent\Relations\BelongsTo')) {
     return;
 }
 
-class BelongsTo extends Relation
-{
-}
+class BelongsTo extends Relation {}

--- a/stubs/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/stubs/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -6,6 +6,4 @@ if (class_exists('Illuminate\Database\Eloquent\Relations\HasMany')) {
     return;
 }
 
-class HasMany extends Relation
-{
-}
+class HasMany extends Relation {}

--- a/stubs/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/stubs/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -6,6 +6,4 @@ if (class_exists('Illuminate\Database\Eloquent\Relations\HasOneThrough')) {
     return;
 }
 
-class HasOneThrough extends Relation
-{
-}
+class HasOneThrough extends Relation {}

--- a/stubs/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/stubs/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -6,6 +6,4 @@ if (class_exists('Illuminate\Database\Eloquent\Relations\MorphTo')) {
     return;
 }
 
-class MorphTo extends BelongsTo
-{
-}
+class MorphTo extends BelongsTo {}

--- a/stubs/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/stubs/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -6,6 +6,4 @@ if (class_exists('Illuminate\Database\Eloquent\Relations\Relation')) {
     return;
 }
 
-abstract class Relation
-{
-}
+abstract class Relation {}

--- a/stubs/Illuminate/Database/Migrations/Migration.php
+++ b/stubs/Illuminate/Database/Migrations/Migration.php
@@ -6,6 +6,4 @@ if (class_exists('Illuminate\Database\Migrations\Migration')) {
     return;
 }
 
-class Migration
-{
-}
+class Migration {}

--- a/stubs/Illuminate/Database/Query/Builder.php
+++ b/stubs/Illuminate/Database/Query/Builder.php
@@ -8,15 +8,9 @@ if (class_exists('Illuminate\Database\Query\Builder')) {
 
 class Builder
 {
-    public function publicMethodBelongsToQueryBuilder(): void
-    {
-    }
+    public function publicMethodBelongsToQueryBuilder(): void {}
 
-    protected function protectedMethodBelongsToQueryBuilder(): void
-    {
-    }
+    protected function protectedMethodBelongsToQueryBuilder(): void {}
 
-    private function privateMethodBelongsToQueryBuilder(): void
-    {
-    }
+    private function privateMethodBelongsToQueryBuilder(): void {}
 }

--- a/stubs/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/stubs/Illuminate/Foundation/Bus/Dispatchable.php
@@ -13,7 +13,5 @@ trait Dispatchable
      * @param  array  $chain
      * @return PendingChain
      */
-    public static function withChain($chain)
-    {
-    }
+    public static function withChain($chain) {}
 }

--- a/stubs/Illuminate/Foundation/Bus/DispatchesJobs.php
+++ b/stubs/Illuminate/Foundation/Bus/DispatchesJobs.php
@@ -6,6 +6,4 @@ if (class_exists('Illuminate\Foundation\Bus\DispatchesJobs')) {
     return;
 }
 
-trait DispatchesJobs
-{
-}
+trait DispatchesJobs {}

--- a/stubs/Illuminate/Foundation/Bus/PendingChain.php
+++ b/stubs/Illuminate/Foundation/Bus/PendingChain.php
@@ -5,6 +5,4 @@ namespace Illuminate\Foundation\Bus;
 if (class_exists('Illuminate\Foundation\Bus\PendingChain')) {
     return;
 }
-class PendingChain
-{
-}
+class PendingChain {}

--- a/stubs/Illuminate/Foundation/Events/Dispatchable.php
+++ b/stubs/Illuminate/Foundation/Events/Dispatchable.php
@@ -7,19 +7,11 @@ if (class_exists('Illuminate\Foundation\Events\Dispatchable')) {
 }
 trait Dispatchable
 {
-    public static function dispatch(...$arguments)
-    {
-    }
+    public static function dispatch(...$arguments) {}
 
-    public static function dispatchIf($boolean, ...$arguments)
-    {
-    }
+    public static function dispatchIf($boolean, ...$arguments) {}
 
-    public static function dispatchUnless($boolean, ...$arguments)
-    {
-    }
+    public static function dispatchUnless($boolean, ...$arguments) {}
 
-    public static function broadcast()
-    {
-    }
+    public static function broadcast() {}
 }

--- a/stubs/Illuminate/Foundation/Exceptions/Handler.php
+++ b/stubs/Illuminate/Foundation/Exceptions/Handler.php
@@ -8,6 +8,4 @@ if (class_exists('Illuminate\Foundation\Exceptions\Handler')) {
     return;
 }
 
-class Handler
-{
-}
+class Handler {}

--- a/stubs/Illuminate/Foundation/Http/FormRequest.php
+++ b/stubs/Illuminate/Foundation/Http/FormRequest.php
@@ -8,6 +8,4 @@ if (class_exists('Illuminate\Foundation\Http\FormRequest')) {
     return;
 }
 
-class FormRequest
-{
-}
+class FormRequest {}

--- a/stubs/Illuminate/Foundation/Http/Kernel.php
+++ b/stubs/Illuminate/Foundation/Http/Kernel.php
@@ -8,6 +8,4 @@ if (class_exists('Illuminate\Foundation\Http\Kernel')) {
     return;
 }
 
-class Kernel
-{
-}
+class Kernel {}

--- a/stubs/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/stubs/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -6,6 +6,4 @@ if (class_exists('Illuminate\Foundation\Support\Providers\EventServiceProvider')
     return;
 }
 
-class EventServiceProvider
-{
-}
+class EventServiceProvider {}

--- a/stubs/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/stubs/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -6,6 +6,4 @@ if (class_exists('Illuminate\Foundation\Testing\Concerns\MakesHttpRequests')) {
     return;
 }
 
-class MakesHttpRequests
-{
-}
+class MakesHttpRequests {}

--- a/stubs/Illuminate/Foundation/Testing/TestCase.php
+++ b/stubs/Illuminate/Foundation/Testing/TestCase.php
@@ -6,6 +6,4 @@ if (class_exists('Illuminate\Foundation\Testing\TestCase')) {
     return;
 }
 
-class TestCase
-{
-}
+class TestCase {}

--- a/stubs/Illuminate/Http/Response.php
+++ b/stubs/Illuminate/Http/Response.php
@@ -8,6 +8,4 @@ if (class_exists('Illuminate\Http\Response')) {
     return;
 }
 
-class Response extends SymfonyResponse
-{
-}
+class Response extends SymfonyResponse {}

--- a/stubs/Illuminate/Mail/MailManager.php
+++ b/stubs/Illuminate/Mail/MailManager.php
@@ -8,6 +8,4 @@ if (class_exists('Illuminate\Mail\MailManager')) {
     return;
 }
 
-class MailManager
-{
-}
+class MailManager {}

--- a/stubs/Illuminate/Mail/Mailable.php
+++ b/stubs/Illuminate/Mail/Mailable.php
@@ -8,6 +8,4 @@ if (class_exists('Illuminate\Mail\Mailable')) {
     return;
 }
 
-class Mailable
-{
-}
+class Mailable {}

--- a/stubs/Illuminate/Mail/Mailer.php
+++ b/stubs/Illuminate/Mail/Mailer.php
@@ -8,6 +8,4 @@ if (class_exists('Illuminate\Mail\Mailer')) {
     return;
 }
 
-class Mailer
-{
-}
+class Mailer {}

--- a/stubs/Illuminate/Mail/Message.php
+++ b/stubs/Illuminate/Mail/Message.php
@@ -8,6 +8,4 @@ if (class_exists('Illuminate\Mail\Message')) {
     return;
 }
 
-class Message
-{
-}
+class Message {}

--- a/stubs/Illuminate/Notifications/Messages/MailMessage.php
+++ b/stubs/Illuminate/Notifications/Messages/MailMessage.php
@@ -8,6 +8,4 @@ if (class_exists('Illuminate\Notifications\Messages\MailMessage')) {
     return;
 }
 
-class MailMessage
-{
-}
+class MailMessage {}

--- a/stubs/Illuminate/Routing/ResponseFactory.php
+++ b/stubs/Illuminate/Routing/ResponseFactory.php
@@ -8,6 +8,4 @@ if (class_exists('Illuminate\Routing\ResponseFactory')) {
     return;
 }
 
-class ResponseFactory implements \Illuminate\Contracts\Routing\ResponseFactory
-{
-}
+class ResponseFactory implements \Illuminate\Contracts\Routing\ResponseFactory {}

--- a/stubs/Illuminate/Support/Collection.php
+++ b/stubs/Illuminate/Support/Collection.php
@@ -15,6 +15,4 @@ if (class_exists('Illuminate\Support\Collection')) {
  *
  * @implements \Illuminate\Support\Enumerable<TKey, TValue>
  */
-class Collection implements Enumerable
-{
-}
+class Collection implements Enumerable {}

--- a/stubs/Illuminate/Support/Facades/Route.php
+++ b/stubs/Illuminate/Support/Facades/Route.php
@@ -11,6 +11,4 @@ if (class_exists('\Illuminate\Support\Facades\Route')) {
 /**
  * @method static \Illuminate\Routing\RouteRegistrar middleware(array|string|null $middleware)
  */
-class Route
-{
-}
+class Route {}

--- a/stubs/Illuminate/Support/ServiceProvider.php
+++ b/stubs/Illuminate/Support/ServiceProvider.php
@@ -8,6 +8,4 @@ if (class_exists('Illuminate\Support\ServiceProvider')) {
     return;
 }
 
-abstract class ServiceProvider
-{
-}
+abstract class ServiceProvider {}

--- a/stubs/Illuminate/Support/Traits/Conditionable.php
+++ b/stubs/Illuminate/Support/Traits/Conditionable.php
@@ -8,11 +8,7 @@ if (trait_exists('Illuminate\Support\Traits\Conditionable')) {
 
 trait Conditionable
 {
-    public function when($value = null, ?callable $callback = null, ?callable $default = null)
-    {
-    }
+    public function when($value = null, ?callable $callback = null, ?callable $default = null) {}
 
-    public function unless($value = null, ?callable $callback = null, ?callable $default = null)
-    {
-    }
+    public function unless($value = null, ?callable $callback = null, ?callable $default = null) {}
 }

--- a/stubs/Illuminate/Support/Traits/Tappable.php
+++ b/stubs/Illuminate/Support/Traits/Tappable.php
@@ -8,7 +8,5 @@ if (trait_exists('Illuminate\Support\Traits\Tappable')) {
 
 trait Tappable
 {
-    public function tap($callback = null)
-    {
-    }
+    public function tap($callback = null) {}
 }

--- a/stubs/Illuminate/Testing/TestResponse.php
+++ b/stubs/Illuminate/Testing/TestResponse.php
@@ -8,6 +8,4 @@ if (class_exists('Illuminate\Testing\TestResponse')) {
     return;
 }
 
-class TestResponse
-{
-}
+class TestResponse {}

--- a/stubs/Laravel/Cashier/Billable.php
+++ b/stubs/Laravel/Cashier/Billable.php
@@ -6,6 +6,4 @@ if (class_exists('Laravel\Cashier\Billable')) {
     return;
 }
 
-trait Billable
-{
-}
+trait Billable {}

--- a/stubs/Livewire/Component.php
+++ b/stubs/Livewire/Component.php
@@ -6,6 +6,4 @@ if (class_exists('Livewire\Component')) {
     return;
 }
 
-class Component
-{
-}
+class Component {}

--- a/tests/Rector/Class_/ReplaceExpectsMethodsInTestsRector/Source/TestCase.php
+++ b/tests/Rector/Class_/ReplaceExpectsMethodsInTestsRector/Source/TestCase.php
@@ -4,6 +4,4 @@ namespace RectorLaravel\Tests\Rector\Class_\ReplaceExpectsMethodsInTestsRector\S
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
-class TestCase extends BaseTestCase
-{
-}
+class TestCase extends BaseTestCase {}

--- a/tests/Rector/FuncCall/DispatchNonShouldQueueToDispatchSyncRector/Source/QueueableJob.php
+++ b/tests/Rector/FuncCall/DispatchNonShouldQueueToDispatchSyncRector/Source/QueueableJob.php
@@ -4,6 +4,4 @@ namespace RectorLaravel\Tests\Rector\FuncCall\DispatchNonShouldQueueToDispatchSy
 
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-class QueueableJob implements ShouldQueue
-{
-}
+class QueueableJob implements ShouldQueue {}

--- a/tests/Rector/FuncCall/DispatchNonShouldQueueToDispatchSyncRector/Source/SomeJob.php
+++ b/tests/Rector/FuncCall/DispatchNonShouldQueueToDispatchSyncRector/Source/SomeJob.php
@@ -2,6 +2,4 @@
 
 namespace RectorLaravel\Tests\Rector\FuncCall\DispatchNonShouldQueueToDispatchSyncRector\Source;
 
-class SomeJob
-{
-}
+class SomeJob {}

--- a/tests/Rector/FuncCall/RemoveRedundantValueCallsRector/Source/HelperObject.php
+++ b/tests/Rector/FuncCall/RemoveRedundantValueCallsRector/Source/HelperObject.php
@@ -4,7 +4,5 @@ namespace RectorLaravel\Tests\Rector\FuncCall\RemoveRedundantValueCallsRector\So
 
 class HelperObject
 {
-    public function store(): void
-    {
-    }
+    public function store(): void {}
 }

--- a/tests/Rector/FuncCall/RemoveRedundantWithCallsRector/Source/HelperObject.php
+++ b/tests/Rector/FuncCall/RemoveRedundantWithCallsRector/Source/HelperObject.php
@@ -4,7 +4,5 @@ namespace RectorLaravel\Tests\Rector\FuncCall\RemoveRedundantWithCallsRector\Sou
 
 class HelperObject
 {
-    public function store(): void
-    {
-    }
+    public function store(): void {}
 }

--- a/tests/Rector/FuncCall/TypeHintTappableCallRector/Source/NonTappableExample.php
+++ b/tests/Rector/FuncCall/TypeHintTappableCallRector/Source/NonTappableExample.php
@@ -2,6 +2,4 @@
 
 namespace RectorLaravel\Tests\Rector\FuncCall\TypeHintTappableCallRector\Source;
 
-class NonTappableExample
-{
-}
+class NonTappableExample {}

--- a/tests/Rector/MethodCall/ResponseHelperCallToJsonResponseRector/ResponseHelperCallToJsonResponseRectorTest.php
+++ b/tests/Rector/MethodCall/ResponseHelperCallToJsonResponseRector/ResponseHelperCallToJsonResponseRectorTest.php
@@ -16,6 +16,9 @@ final class ResponseHelperCallToJsonResponseRectorTest extends AbstractRectorTes
         return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
+    /**
+     * @test
+     */
     #[Test]
     #[DataProvider('provideData')]
     public function test(string $filePath): void

--- a/tests/Rector/Namespace_/FactoryDefinitionRector/Source/Model.php
+++ b/tests/Rector/Namespace_/FactoryDefinitionRector/Source/Model.php
@@ -2,6 +2,4 @@
 
 namespace RectorLaravel\Tests\Rector\Namespace_\FactoryDefinitionRector\Source;
 
-class Model
-{
-}
+class Model {}

--- a/tests/Rector/PropertyFetch/OptionalToNullsafeOperatorRector/Source/SomeClass.php
+++ b/tests/Rector/PropertyFetch/OptionalToNullsafeOperatorRector/Source/SomeClass.php
@@ -6,8 +6,5 @@ class SomeClass
 {
     public int $foo;
 
-    public function something(bool $parameter = false): void
-    {
-
-    }
+    public function something(bool $parameter = false): void {}
 }

--- a/tests/Rector/StaticCall/DispatchToHelperFunctionsRector/Source/OtherDispatchable.php
+++ b/tests/Rector/StaticCall/DispatchToHelperFunctionsRector/Source/OtherDispatchable.php
@@ -11,6 +11,5 @@ class OtherDispatchable
     public function __construct(
         private string $param1,
         private string $param2,
-    ) {
-    }
+    ) {}
 }

--- a/tests/Rector/StaticCall/DispatchToHelperFunctionsRector/Source/TestEvent.php
+++ b/tests/Rector/StaticCall/DispatchToHelperFunctionsRector/Source/TestEvent.php
@@ -11,6 +11,5 @@ class TestEvent
     public function __construct(
         private string $param1,
         private string $param2,
-    ) {
-    }
+    ) {}
 }

--- a/tests/Rector/StaticCall/DispatchToHelperFunctionsRector/Source/TestJob.php
+++ b/tests/Rector/StaticCall/DispatchToHelperFunctionsRector/Source/TestJob.php
@@ -11,6 +11,5 @@ class TestJob
     public function __construct(
         private string $param1,
         private string $param2,
-    ) {
-    }
+    ) {}
 }

--- a/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/EloquentMagicMethodToQueryBuilderRectorTest.php
+++ b/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/EloquentMagicMethodToQueryBuilderRectorTest.php
@@ -9,9 +9,7 @@ use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
-final class User extends Model
-{
-}
+final class User extends Model {}
 
 final class EloquentMagicMethodToQueryBuilderRectorTest extends AbstractRectorTestCase
 {

--- a/tests/Rector/StaticCall/RouteActionCallableRector/Source/SomeController.php
+++ b/tests/Rector/StaticCall/RouteActionCallableRector/Source/SomeController.php
@@ -4,8 +4,5 @@ namespace RectorLaravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source
 
 class SomeController
 {
-    public function index()
-    {
-
-    }
+    public function index() {}
 }

--- a/tests/Sets/LaravelSetProviderTest.php
+++ b/tests/Sets/LaravelSetProviderTest.php
@@ -28,7 +28,10 @@ final class LaravelSetProviderTest extends TestCase
         LaravelSetList::LARAVEL_110,
     ];
 
-    public function test_it_provides_sets(): void
+    /**
+     * @test
+     */
+    public function it_provides_sets(): void
     {
         $laravelSetProvider = new LaravelSetProvider;
 
@@ -38,7 +41,10 @@ final class LaravelSetProviderTest extends TestCase
         );
     }
 
-    public function test_it_returns_unique_sets(): void
+    /**
+     * @test
+     */
+    public function it_returns_unique_sets(): void
     {
         $laravelSetProvider = new LaravelSetProvider;
 
@@ -49,7 +55,10 @@ final class LaravelSetProviderTest extends TestCase
         Assert::assertCount(count($sets), $uniqueSets);
     }
 
-    public function test_it_provides_all_laravel_versions(): void
+    /**
+     * @test
+     */
+    public function it_provides_all_laravel_versions(): void
     {
         $laravelSetProvider = new LaravelSetProvider;
 

--- a/tests/Sets/LaravelSetProviderTest.php
+++ b/tests/Sets/LaravelSetProviderTest.php
@@ -28,9 +28,9 @@ final class LaravelSetProviderTest extends TestCase
         LaravelSetList::LARAVEL_110,
     ];
 
-    public function testItProvidesSets(): void
+    public function test_it_provides_sets(): void
     {
-        $laravelSetProvider = new LaravelSetProvider();
+        $laravelSetProvider = new LaravelSetProvider;
 
         Assert::assertContainsOnlyInstancesOf(
             SetInterface::class,
@@ -38,9 +38,9 @@ final class LaravelSetProviderTest extends TestCase
         );
     }
 
-    public function testItReturnsUniqueSets(): void
+    public function test_it_returns_unique_sets(): void
     {
-        $laravelSetProvider = new LaravelSetProvider();
+        $laravelSetProvider = new LaravelSetProvider;
 
         $sets = $laravelSetProvider->provide();
 
@@ -49,9 +49,9 @@ final class LaravelSetProviderTest extends TestCase
         Assert::assertCount(count($sets), $uniqueSets);
     }
 
-    public function testItProvidesAllLaravelVersions(): void
+    public function test_it_provides_all_laravel_versions(): void
     {
-        $laravelSetProvider = new LaravelSetProvider();
+        $laravelSetProvider = new LaravelSetProvider;
 
         $sets = $laravelSetProvider->provide();
 


### PR DESCRIPTION
Fixes https://github.com/driftingly/rector-laravel/issues/228.

- Updating the Duster dependency to from 2.x to 3.x.
- Removing the `pint.json` config and taking the latest defaults from Pint.