### PR TITLE
Session variable to Session Facade

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 73 Rules Overview
+# 74 Rules Overview
 
 ## AbortIfRector
 
@@ -1288,6 +1288,35 @@ Use PHP callable syntax instead of string syntax for controller route declaratio
 ```diff
 -Route::get('/users', 'UserController@index');
 +Route::get('/users', [\App\Http\Controllers\UserController::class, 'index']);
+```
+
+<br>
+
+## SessionVariableToSessionFacadeRector
+
+Change PHP session usage to Session Facade methods
+
+- class: [`RectorLaravel\Rector\ArrayDimFetch\SessionVariableToSessionFacadeRector`](../src/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector.php)
+
+```diff
+-$_SESSION['key'];
+-$_SESSION['key'] = 'value';
+-$_SESSION;
+-session_regenerate_id();
+-session_unset();
+-session_destroy();
+-session_start();
+-unset($_SESSION['key']);
+-isset($_SESSION['key'])
++\Illuminate\Support\Facades\Session::get('key');
++\Illuminate\Support\Facades\Session::put('key', 'value');
++\Illuminate\Support\Facades\Session::all();
++\Illuminate\Support\Facades\Session::regenerate();
++\Illuminate\Support\Facades\Session::flush();
++\Illuminate\Support\Facades\Session::destroy();
++\Illuminate\Support\Facades\Session::start();
++\Illuminate\Support\Facades\Session::forget('key');
++\Illuminate\Support\Facades\Session::has('key');
 ```
 
 <br>

--- a/src/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector.php
+++ b/src/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace RectorLaravel\Rector\ArrayDimFetch;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\StaticCall;
+use RectorLaravel\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\ArrayDimFetch\SessionVariableToSessionFacadeRector\SessionVariableToSessionFacadeRectorTest
+ */
+class SessionVariableToSessionFacadeRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change PHP session usage to Session Facade methods',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+$_SESSION['VARIABLE'];
+$_SESSION['VARIABLE'] = 'value';
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+\Illuminate\Support\Facades\Session::get('VARIABLE');
+\Illuminate\Support\Facades\Session::put('VARIABLE', 'value');
+CODE_SAMPLE
+            )]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [ArrayDimFetch::class, Assign::class];
+    }
+
+    /**
+     * @param  ArrayDimFetch|Assign  $node
+     */
+    public function refactor(Node $node): ?StaticCall
+    {
+        if ($node instanceof ArrayDimFetch) {
+            return $this->processDimFetch($node);
+        }
+
+        return $this->processAssign($node);
+    }
+
+    public function processDimFetch(ArrayDimFetch $node): ?StaticCall
+    {
+        if (! $this->isName($node->var, '_SESSION')) {
+            return null;
+        }
+
+        if ($node->dim === null) {
+            return null;
+        }
+
+        return $this->nodeFactory->createStaticCall('Illuminate\Support\Facades\Session', 'get', [
+            new Arg($node->dim),
+        ]);
+    }
+
+    private function processAssign(Assign $node): ?StaticCall
+    {
+        $dimFetch = $node->var;
+
+        if (! $dimFetch instanceof ArrayDimFetch || ! $this->isName($dimFetch->var, '_SESSION')) {
+            return null;
+        }
+
+        if ($dimFetch->dim === null) {
+            return null;
+        }
+
+        return $this->nodeFactory->createStaticCall('Illuminate\Support\Facades\Session', 'put', [
+            new Arg($dimFetch->dim),
+            new Arg($node->expr),
+        ]);
+    }
+}

--- a/src/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector.php
+++ b/src/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector.php
@@ -4,9 +4,17 @@ namespace RectorLaravel\Rector\ArrayDimFetch;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Isset_;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Unset_;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 use RectorLaravel\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -22,12 +30,26 @@ class SessionVariableToSessionFacadeRector extends AbstractRector
             'Change PHP session usage to Session Facade methods',
             [new CodeSample(
                 <<<'CODE_SAMPLE'
-$_SESSION['VARIABLE'];
-$_SESSION['VARIABLE'] = 'value';
+$_SESSION['key'];
+$_SESSION['key'] = 'value';
+$_SESSION;
+session_regenerate_id();
+session_unset();
+session_destroy();
+session_start();
+unset($_SESSION['key']);
+isset($_SESSION['key'])
 CODE_SAMPLE,
                 <<<'CODE_SAMPLE'
-\Illuminate\Support\Facades\Session::get('VARIABLE');
-\Illuminate\Support\Facades\Session::put('VARIABLE', 'value');
+\Illuminate\Support\Facades\Session::get('key');
+\Illuminate\Support\Facades\Session::put('key', 'value');
+\Illuminate\Support\Facades\Session::all();
+\Illuminate\Support\Facades\Session::regenerate();
+\Illuminate\Support\Facades\Session::flush();
+\Illuminate\Support\Facades\Session::destroy();
+\Illuminate\Support\Facades\Session::start();
+\Illuminate\Support\Facades\Session::forget('key');
+\Illuminate\Support\Facades\Session::has('key');
 CODE_SAMPLE
             )]
         );
@@ -35,29 +57,57 @@ CODE_SAMPLE
 
     public function getNodeTypes(): array
     {
-        return [ArrayDimFetch::class, Assign::class];
+        return [
+            Isset_::class,
+            Unset_::class,
+            ArrayDimFetch::class,
+            Assign::class,
+            FuncCall::class,
+            Variable::class,
+        ];
     }
 
     /**
-     * @param  ArrayDimFetch|Assign  $node
+     * @param  ArrayDimFetch|Assign|FuncCall|Isset_|Unset_|Variable  $node
      */
-    public function refactor(Node $node): ?StaticCall
+    public function refactor(Node $node): StaticCall|Expression|int|null
     {
         if ($node instanceof ArrayDimFetch) {
             return $this->processDimFetch($node);
         }
 
+        if ($node instanceof FuncCall) {
+            return $this->processFunction($node);
+        }
+
+        if ($node instanceof Isset_) {
+            return $this->processIsset($node);
+        }
+
+        if ($node instanceof Unset_) {
+            $return = $this->processUnset($node);
+            if ($return instanceof StaticCall) {
+                return new Expression($return);
+            }
+
+            return $return;
+        }
+
+        if ($node instanceof Variable) {
+            return $this->processVariable($node);
+        }
+
         return $this->processAssign($node);
     }
 
-    public function processDimFetch(ArrayDimFetch $node): ?StaticCall
+    public function processDimFetch(ArrayDimFetch $node): StaticCall|int|null
     {
         if (! $this->isName($node->var, '_SESSION')) {
             return null;
         }
 
         if ($node->dim === null) {
-            return null;
+            return NodeVisitor::DONT_TRAVERSE_CHILDREN;
         }
 
         return $this->nodeFactory->createStaticCall('Illuminate\Support\Facades\Session', 'get', [
@@ -81,5 +131,91 @@ CODE_SAMPLE
             new Arg($dimFetch->dim),
             new Arg($node->expr),
         ]);
+    }
+
+    private function processFunction(FuncCall $node): ?StaticCall
+    {
+        if (! $this->isNames($node, [
+            'session_regenerate_id',
+            'session_unset',
+            'session_destroy',
+            'session_start',
+        ])) {
+            return null;
+        }
+
+        $method = $this->getName($node);
+        $replacementMethod = match($method) {
+            'session_regenerate_id' => 'regenerate',
+            'session_unset' => 'flush',
+            'session_destroy' => 'destroy',
+            'session_start' => 'start',
+            default => null,
+        };
+
+        if ($replacementMethod === null) {
+            return null;
+        }
+
+        return $this->nodeFactory->createStaticCall('Illuminate\Support\Facades\Session', $replacementMethod);
+    }
+
+    private function processIsset(Isset_ $node): StaticCall|int|null
+    {
+        if (count($node->vars) < 1) {
+            return null;
+        }
+
+        $var = $node->vars[0];
+
+        if (! $var instanceof ArrayDimFetch) {
+            return null;
+        }
+
+        if (! $this->isName($var->var, '_SESSION')) {
+            return null;
+        }
+
+        if ($var->dim === null) {
+            return NodeVisitor::DONT_TRAVERSE_CHILDREN;
+        }
+
+        return $this->nodeFactory->createStaticCall('Illuminate\Support\Facades\Session', 'has', [
+            new Arg($var->dim),
+        ]);
+    }
+
+    private function processUnset(Unset_ $node): StaticCall|int|null
+    {
+        if (count($node->vars) < 1) {
+            return null;
+        }
+
+        $var = $node->vars[0];
+
+        if (! $var instanceof ArrayDimFetch) {
+            return null;
+        }
+
+        if (! $this->isName($var->var, '_SESSION')) {
+            return null;
+        }
+
+        if ($var->dim === null) {
+            return NodeVisitor::DONT_TRAVERSE_CHILDREN;
+        }
+
+        return $this->nodeFactory->createStaticCall('Illuminate\Support\Facades\Session', 'forget', [
+            new Arg($var->dim),
+        ]);
+    }
+
+    private function processVariable(Variable $node): ?StaticCall
+    {
+        if (! $this->isName($node, '_SESSION')) {
+            return null;
+        }
+
+        return $this->nodeFactory->createStaticCall('Illuminate\Support\Facades\Session', 'all');
     }
 }

--- a/tests/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector/Fixture/fixture.php.inc
@@ -2,8 +2,15 @@
 
 namespace RectorLaravel\Tests\Rector\ArrayDimFetch\SessionVariableToSessionFacadeRector\Fixture;
 
-$_SESSION['VARIABLE'];
-$_SESSION['VARIABLE'] = 'value';
+$_SESSION['key'];
+$_SESSION['key'] = 'value';
+$_SESSION;
+session_regenerate_id();
+session_unset();
+session_destroy();
+session_start();
+unset($_SESSION['key']);
+isset($_SESSION['key']);
 
 ?>
 -----
@@ -11,7 +18,14 @@ $_SESSION['VARIABLE'] = 'value';
 
 namespace RectorLaravel\Tests\Rector\ArrayDimFetch\SessionVariableToSessionFacadeRector\Fixture;
 
-\Illuminate\Support\Facades\Session::get('VARIABLE');
-\Illuminate\Support\Facades\Session::put('VARIABLE', 'value');
+\Illuminate\Support\Facades\Session::get('key');
+\Illuminate\Support\Facades\Session::put('key', 'value');
+\Illuminate\Support\Facades\Session::all();
+\Illuminate\Support\Facades\Session::regenerate();
+\Illuminate\Support\Facades\Session::flush();
+\Illuminate\Support\Facades\Session::destroy();
+\Illuminate\Support\Facades\Session::start();
+\Illuminate\Support\Facades\Session::forget('key');
+\Illuminate\Support\Facades\Session::has('key');
 
 ?>

--- a/tests/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector/Fixture/fixture.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\SessionVariableToSessionFacadeRector\Fixture;
+
+$_SESSION['VARIABLE'];
+$_SESSION['VARIABLE'] = 'value';
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\SessionVariableToSessionFacadeRector\Fixture;
+
+\Illuminate\Support\Facades\Session::get('VARIABLE');
+\Illuminate\Support\Facades\Session::put('VARIABLE', 'value');
+
+?>

--- a/tests/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector/Fixture/skip_dim_fetch_without_dim.php.inc
+++ b/tests/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector/Fixture/skip_dim_fetch_without_dim.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\SessionVariableToSessionFacadeRector\Fixture;
+
+$_SESSION[];
+
+?>

--- a/tests/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector/Fixture/skip_non_env_variable.php.inc
+++ b/tests/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector/Fixture/skip_non_env_variable.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\SessionVariableToSessionFacadeRector\Fixture;
+
+$_SESSIONA['VARIABLE'];
+$_SESSIONA['VARIABLE'] = 'value';
+
+?>

--- a/tests/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector/Fixture/skip_non_session_functions.php.inc
+++ b/tests/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector/Fixture/skip_non_session_functions.php.inc
@@ -2,7 +2,6 @@
 
 namespace RectorLaravel\Tests\Rector\ArrayDimFetch\SessionVariableToSessionFacadeRector\Fixture;
 
-$_SESSIONA['VARIABLE'];
-$_SESSIONA['VARIABLE'] = 'value';
+some_session_function();
 
 ?>

--- a/tests/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector/Fixture/skip_non_session_variable.php.inc
+++ b/tests/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector/Fixture/skip_non_session_variable.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\SessionVariableToSessionFacadeRector\Fixture;
+
+$_SESSIONA['VARIABLE'];
+$_SESSIONA['VARIABLE'] = 'value';
+unset($_SESSIONA['VARIABLE']);
+isset($_SESSIONA['VARIABLE']);
+
+?>

--- a/tests/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector/SessionVariableToSessionFacadeRectorTest.php
+++ b/tests/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector/SessionVariableToSessionFacadeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\SessionVariableToSessionFacadeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class SessionVariableToSessionFacadeRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector/config/configured_rule.php
+++ b/tests/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\ArrayDimFetch\SessionVariableToSessionFacadeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(SessionVariableToSessionFacadeRector::class);
+};


### PR DESCRIPTION
# Changes

- Adds a new rule that converts Session variable and some of the Session functions to use the Laravel Session facade.
- Adds a test to cover these calls

# Why

This will make it easier to convert vanilla PHP applications to Laravel.

```diff
-$_SESSION['key'];
-$_SESSION['key'] = 'value';
-$_SESSION;
-session_regenerate_id();
-session_unset();
-session_destroy();
-session_start();
-unset($_SESSION['key']);
-isset($_SESSION['key'])
+\Illuminate\Support\Facades\Session::get('key');
+\Illuminate\Support\Facades\Session::put('key', 'value');
+\Illuminate\Support\Facades\Session::all();
+\Illuminate\Support\Facades\Session::regenerate();
+\Illuminate\Support\Facades\Session::flush();
+\Illuminate\Support\Facades\Session::destroy();
+\Illuminate\Support\Facades\Session::start();
+\Illuminate\Support\Facades\Session::forget('key');
+\Illuminate\Support\Facades\Session::has('key');
```