### PR TITLE
Adds ServerVariableToRequestFacadeRector rule

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 74 Rules Overview
+# 75 Rules Overview
 
 ## AbortIfRector
 
@@ -1296,6 +1296,19 @@ Use PHP callable syntax instead of string syntax for controller route declaratio
 ```diff
 -Route::get('/users', 'UserController@index');
 +Route::get('/users', [\App\Http\Controllers\UserController::class, 'index']);
+```
+
+<br>
+
+## ServerVariableToRequestFacadeRector
+
+Change server variable to Request facade's server method
+
+- class: [`RectorLaravel\Rector\ArrayDimFetch\ServerVariableToRequestFacadeRector`](../src/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector.php)
+
+```diff
+-$_SERVER['VARIABLE'];
++\Illuminate\Support\Facade\Request::server('VARIABLE');
 ```
 
 <br>

--- a/src/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector.php
+++ b/src/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace RectorLaravel\Rector\ArrayDimFetch;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\StaticCall;
+use RectorLaravel\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\ArrayDimFetch\ServerVariableToRequestFacadeRector\ServerVariableToRequestFacadeRectorTest
+ */
+class ServerVariableToRequestFacadeRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change server variable to Request facade\'s server method',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+$_SERVER['VARIABLE'];
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+\Illuminate\Support\Facade\Request::server('VARIABLE');
+CODE_SAMPLE
+            )]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [ArrayDimFetch::class];
+    }
+
+    /**
+     * @param  ArrayDimFetch  $node
+     */
+    public function refactor(Node $node): ?StaticCall
+    {
+        if (! $this->isName($node->var, '_SERVER')) {
+            return null;
+        }
+
+        if ($node->dim === null) {
+            return null;
+        }
+
+        return $this->nodeFactory->createStaticCall('Illuminate\Support\Facades\Request', 'server', [
+            new Arg($node->dim),
+        ]);
+    }
+}

--- a/tests/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector/Fixture/fixture.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\ServerVariableToRequestFacadeRector\Fixture;
+
+$_SERVER['VARIABLE'];
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\ServerVariableToRequestFacadeRector\Fixture;
+
+\Illuminate\Support\Facades\Request::server('VARIABLE');
+
+?>

--- a/tests/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector/Fixture/skip_dim_fetch_without_dim.php.inc
+++ b/tests/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector/Fixture/skip_dim_fetch_without_dim.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\ServerVariableToRequestFacadeRector\Fixture;
+
+$_SERVER[];
+
+?>

--- a/tests/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector/Fixture/skip_non_server_variable.php.inc
+++ b/tests/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector/Fixture/skip_non_server_variable.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\ServerVariableToRequestFacadeRector\Fixture;
+
+$_SERVERA['VARIABLE'];
+
+?>

--- a/tests/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector/ServerVariableToRequestFacadeRectorTest.php
+++ b/tests/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector/ServerVariableToRequestFacadeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\ServerVariableToRequestFacadeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ServerVariableToRequestFacadeRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector/config/configured_rule.php
+++ b/tests/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\ArrayDimFetch\ServerVariableToRequestFacadeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(ServerVariableToRequestFacadeRector::class);
+};


### PR DESCRIPTION
# Changes

- new ServerVariableToRequestFacadeRector rule
- adds tests
- updates docs

# Why

This converts a simple use of the `$_SERVER` PHP variable to use the Request facade.

```diff
-$_SERVER['VARIABLE'];
+\Illuminate\Support\Facade\Request::server('VARIABLE');
```

