### PR TITLE
Improve request input refactor

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1238,8 +1238,12 @@ Change request variable definition in Facade
 ```diff
 -$_GET['value'];
 -$_POST['value'];
+-$_POST;
+-$_GET;
 +\Illuminate\Support\Facades\Request::input('value');
 +\Illuminate\Support\Facades\Request::input('value');
++\Illuminate\Support\Facades\Request::all();
++\Illuminate\Support\Facades\Request::all();
 ```
 
 <br>

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1238,10 +1238,14 @@ Change request variable definition in Facade
 ```diff
 -$_GET['value'];
 -$_POST['value'];
+-$_REQUEST['value'];
 -$_POST;
 -$_GET;
+-$_REQUEST;
 +\Illuminate\Support\Facades\Request::input('value');
 +\Illuminate\Support\Facades\Request::input('value');
++\Illuminate\Support\Facades\Request::input('value');
++\Illuminate\Support\Facades\Request::all();
 +\Illuminate\Support\Facades\Request::all();
 +\Illuminate\Support\Facades\Request::all();
 ```

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1242,11 +1242,11 @@ Change request variable definition in Facade
 -$_POST;
 -$_GET;
 -$_REQUEST;
++\Illuminate\Support\Facades\Request::query('value');
++\Illuminate\Support\Facades\Request::post('value');
 +\Illuminate\Support\Facades\Request::input('value');
-+\Illuminate\Support\Facades\Request::input('value');
-+\Illuminate\Support\Facades\Request::input('value');
-+\Illuminate\Support\Facades\Request::all();
-+\Illuminate\Support\Facades\Request::all();
++\Illuminate\Support\Facades\Request::query();
++\Illuminate\Support\Facades\Request::post();
 +\Illuminate\Support\Facades\Request::all();
 ```
 

--- a/src/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector.php
+++ b/src/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector.php
@@ -35,11 +35,11 @@ $_GET;
 $_REQUEST;
 CODE_SAMPLE,
                     <<<'CODE_SAMPLE'
+\Illuminate\Support\Facades\Request::query('value');
+\Illuminate\Support\Facades\Request::post('value');
 \Illuminate\Support\Facades\Request::input('value');
-\Illuminate\Support\Facades\Request::input('value');
-\Illuminate\Support\Facades\Request::input('value');
-\Illuminate\Support\Facades\Request::all();
-\Illuminate\Support\Facades\Request::all();
+\Illuminate\Support\Facades\Request::query();
+\Illuminate\Support\Facades\Request::post();
 \Illuminate\Support\Facades\Request::all();
 CODE_SAMPLE
                 ),

--- a/src/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector.php
+++ b/src/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector.php
@@ -28,12 +28,16 @@ class RequestVariablesToRequestFacadeRector extends AbstractRector
                     <<<'CODE_SAMPLE'
 $_GET['value'];
 $_POST['value'];
+$_REQUEST['value'];
 $_POST;
 $_GET;
+$_REQUEST;
 CODE_SAMPLE,
                     <<<'CODE_SAMPLE'
 \Illuminate\Support\Facades\Request::input('value');
 \Illuminate\Support\Facades\Request::input('value');
+\Illuminate\Support\Facades\Request::input('value');
+\Illuminate\Support\Facades\Request::all();
 \Illuminate\Support\Facades\Request::all();
 \Illuminate\Support\Facades\Request::all();
 CODE_SAMPLE
@@ -92,7 +96,7 @@ CODE_SAMPLE
             return implode('.', [$key, $value]);
         }
 
-        if ($this->isNames($arrayDimFetch->var, ['_GET', '_POST'])) {
+        if ($this->isNames($arrayDimFetch->var, ['_GET', '_POST', '_REQUEST'])) {
             return (string) $value;
         }
 
@@ -101,7 +105,7 @@ CODE_SAMPLE
 
     private function processVariable(Variable $variable): ?StaticCall
     {
-        if ($this->isNames($variable, ['_GET', '_POST'])) {
+        if ($this->isNames($variable, ['_GET', '_POST', '_REQUEST'])) {
             return $this->nodeFactory->createStaticCall(
                 'Illuminate\Support\Facades\Request',
                 'all',

--- a/src/ValueObject/ReplaceRequestKeyAndMethodValue.php
+++ b/src/ValueObject/ReplaceRequestKeyAndMethodValue.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace RectorLaravel\ValueObject;
+
+use Webmozart\Assert\Assert;
+
+final readonly class ReplaceRequestKeyAndMethodValue
+{
+    public function __construct(private string $key, private string $method)
+    {
+        Assert::inArray($this->method, ['query', 'post', 'input']);
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+}

--- a/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/Fixture/fixture.php.inc
@@ -7,7 +7,9 @@ $deepVar = $_GET['a']['b'];
 $numberUsed = $_GET['a']['b'][0];
 $postVar = $_POST['a'];
 $requestVar = $_REQUEST['a'];
-$input = $_POST;
+$query = $_GET;
+$post = $_POST;
+$input = $_REQUEST;
 
 ?>
 -----
@@ -15,11 +17,13 @@ $input = $_POST;
 
 namespace RectorLaravel\Tests\Rector\ArrayDimFetch\RequestVariablesToRequestFacadeRector\Fixture;
 
-$var = \Illuminate\Support\Facades\Request::input('a');
-$deepVar = \Illuminate\Support\Facades\Request::input('a.b');
-$numberUsed = \Illuminate\Support\Facades\Request::input('a.b.0');
-$postVar = \Illuminate\Support\Facades\Request::input('a');
+$var = \Illuminate\Support\Facades\Request::query('a');
+$deepVar = \Illuminate\Support\Facades\Request::query('a.b');
+$numberUsed = \Illuminate\Support\Facades\Request::query('a.b.0');
+$postVar = \Illuminate\Support\Facades\Request::post('a');
 $requestVar = \Illuminate\Support\Facades\Request::input('a');
+$query = \Illuminate\Support\Facades\Request::query();
+$post = \Illuminate\Support\Facades\Request::post();
 $input = \Illuminate\Support\Facades\Request::all();
 
 ?>

--- a/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/Fixture/fixture.php.inc
@@ -6,6 +6,7 @@ $var = $_GET['a'];
 $deepVar = $_GET['a']['b'];
 $numberUsed = $_GET['a']['b'][0];
 $postVar = $_POST['a'];
+$input = $_POST;
 
 ?>
 -----
@@ -17,5 +18,6 @@ $var = \Illuminate\Support\Facades\Request::input('a');
 $deepVar = \Illuminate\Support\Facades\Request::input('a.b');
 $numberUsed = \Illuminate\Support\Facades\Request::input('a.b.0');
 $postVar = \Illuminate\Support\Facades\Request::input('a');
+$input = \Illuminate\Support\Facades\Request::all();
 
 ?>

--- a/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/Fixture/fixture.php.inc
@@ -6,6 +6,7 @@ $var = $_GET['a'];
 $deepVar = $_GET['a']['b'];
 $numberUsed = $_GET['a']['b'][0];
 $postVar = $_POST['a'];
+$requestVar = $_REQUEST['a'];
 $input = $_POST;
 
 ?>
@@ -18,6 +19,7 @@ $var = \Illuminate\Support\Facades\Request::input('a');
 $deepVar = \Illuminate\Support\Facades\Request::input('a.b');
 $numberUsed = \Illuminate\Support\Facades\Request::input('a.b.0');
 $postVar = \Illuminate\Support\Facades\Request::input('a');
+$requestVar = \Illuminate\Support\Facades\Request::input('a');
 $input = \Illuminate\Support\Facades\Request::all();
 
 ?>


### PR DESCRIPTION
# Changes

- Improves some of the scenarios with the `RequestVariablesToRequestFacadeRector` rule. Namely it handles the split between get, post and request into the right method calls. Also handles replacing the whole variable.
- Adds tests for the scenario
- Docs update

# Why

It makes this rule far more useful as a better 1:1 conversion of PHP to Laravel method calls on the Request facade.

```diff
-$_GET['value'];
-$_POST['value'];
-$_REQUEST['value'];
-$_POST;
-$_GET;
-$_REQUEST;
+\Illuminate\Support\Facades\Request::query('value');
+\Illuminate\Support\Facades\Request::post('value');
+\Illuminate\Support\Facades\Request::input('value');
+\Illuminate\Support\Facades\Request::query();
+\Illuminate\Support\Facades\Request::post();
+\Illuminate\Support\Facades\Request::all();
```