### PR TITLE
Updates tests for ArgumentFuncCallToMethodCallRector

### DIFF
--- a/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/auth.php.inc
+++ b/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/auth.php.inc
@@ -18,7 +18,7 @@ namespace RectorLaravel\Tests\Rector\FuncCall\ArgumentFuncCallToMethodCallRector
 
 class Auth
 {
-    public function __construct(private \Illuminate\Contracts\Auth\Guard $guard)
+    public function __construct(private readonly \Illuminate\Contracts\Auth\Guard $guard)
     {
     }
     public function action()

--- a/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/back.php.inc
+++ b/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/back.php.inc
@@ -23,7 +23,7 @@ namespace RectorLaravel\Tests\Rector\FuncCall\ArgumentFuncCallToMethodCallRector
 
 class Back
 {
-    public function __construct(private \Illuminate\Routing\Redirector $redirector)
+    public function __construct(private readonly \Illuminate\Routing\Redirector $redirector)
     {
     }
     public function action()

--- a/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/broadcast.php.inc
+++ b/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/broadcast.php.inc
@@ -18,7 +18,7 @@ namespace RectorLaravel\Tests\Rector\FuncCall\ArgumentFuncCallToMethodCallRector
 
 class Broadcast
 {
-    public function __construct(private \Illuminate\Contracts\Broadcasting\Factory $broadcastingFactory)
+    public function __construct(private readonly \Illuminate\Contracts\Broadcasting\Factory $broadcastingFactory)
     {
     }
     public function action()

--- a/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/config.php.inc
+++ b/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/config.php.inc
@@ -23,7 +23,7 @@ namespace RectorLaravel\Tests\Rector\FuncCall\ArgumentFuncCallToMethodCallRector
 
 class Config
 {
-    public function __construct(private \Illuminate\Contracts\Config\Repository $configRepository)
+    public function __construct(private readonly \Illuminate\Contracts\Config\Repository $configRepository)
     {
     }
     public function actionGet()

--- a/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/route.php.inc
+++ b/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/route.php.inc
@@ -18,7 +18,7 @@ namespace RectorLaravel\Tests\Rector\FuncCall\ArgumentFuncCallToMethodCallRector
 
 class Route
 {
-    public function __construct(private \Illuminate\Routing\UrlGenerator $urlGenerator)
+    public function __construct(private readonly \Illuminate\Routing\UrlGenerator $urlGenerator)
     {
     }
     public function action()

--- a/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/session.php.inc
+++ b/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/session.php.inc
@@ -20,7 +20,7 @@ namespace RectorLaravel\Tests\Rector\FuncCall\FactoryFuncCallToStaticCallRector\
 
 class Session
 {
-    public function __construct(private \Illuminate\Session\SessionManager $sessionManager)
+    public function __construct(private readonly \Illuminate\Session\SessionManager $sessionManager)
     {
     }
     public function action()

--- a/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/view.php.inc
+++ b/tests/Rector/FuncCall/ArgumentFuncCallToMethodCallRector/Fixture/view.php.inc
@@ -19,7 +19,7 @@ namespace RectorLaravel\Tests\Rector\FuncCall\ArgumentFuncCallToMethodCallRector
 
 class View
 {
-    public function __construct(private \Illuminate\Contracts\View\Factory $viewFactory)
+    public function __construct(private readonly \Illuminate\Contracts\View\Factory $viewFactory)
     {
     }
     public function action()


### PR DESCRIPTION
# Changes

- updates tests for ArgumentFuncCallToMethodCallRector where the constructor is using readonly properties

# Why

Without this, tests break when using the latest version of Rector.

I'm unsure why this has cropped up and what method call is the cause of this. It makes sense in the code examples to be readonly but it's odd that's just happened like this.