### PR TITLE
EloquentWhereTypeHintClosureParameterRector refactor

### DIFF
--- a/.github/workflows/downgraded_release.yaml
+++ b/.github/workflows/downgraded_release.yaml
@@ -31,6 +31,9 @@ jobs:
             # copy PHP 7.2 composer
             -   run: cp build/composer-php-72.json composer.json
 
+            # run the tests against the downgraded rules
+            -   run: vendor/bin/phpunit tests
+
             # clear the dev files
             -   run: rm -rf build .github tests stubs phpstan.neon phpunit.xml
 

--- a/src/Rector/MethodCall/EloquentWhereRelationTypeHintingParameterRector.php
+++ b/src/Rector/MethodCall/EloquentWhereRelationTypeHintingParameterRector.php
@@ -113,7 +113,7 @@ CODE_SAMPLE
 
     private function expectedObjectTypeAndMethodCall(MethodCall|StaticCall $node): bool
     {
-        return match (true) {
+        $isMatchingClass = match (true) {
             $node instanceof MethodCall && $this->isObjectType(
                 $node->var,
                 new ObjectType('Illuminate\Contracts\Database\Query\Builder')
@@ -123,7 +123,9 @@ CODE_SAMPLE
                 new ObjectType('Illuminate\Database\Eloquent\Model')
             ) => true,
             default => false,
-        } && $this->isNames(
+        };
+
+        $isMatchingMethod = $this->isNames(
             $node->name,
             [
                 'whereHas',
@@ -136,5 +138,7 @@ CODE_SAMPLE
                 'orWhereDoesntHaveMorph',
             ]
         );
+
+        return $isMatchingClass && $isMatchingMethod;
     }
 }

--- a/src/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector.php
+++ b/src/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector.php
@@ -95,7 +95,7 @@ CODE_SAMPLE
 
     private function expectedObjectTypeAndMethodCall(MethodCall|StaticCall $node): bool
     {
-        return match (true) {
+        $isMatchingClass = match (true) {
             $node instanceof MethodCall && $this->isObjectType(
                 $node->var,
                 new ObjectType('Illuminate\Contracts\Database\Query\Builder')
@@ -105,6 +105,10 @@ CODE_SAMPLE
                 new ObjectType('Illuminate\Database\Eloquent\Model')
             ) => true,
             default => false,
-        } && $this->isNames($node->name, ['where', 'orWhere']);
+        };
+
+        $isMatchingMethod = $this->isNames($node->name, ['where', 'orWhere']);
+
+        return $isMatchingClass && $isMatchingMethod;
     }
 }

--- a/stubs/Illuminate/Database/Eloquent/Model.php
+++ b/stubs/Illuminate/Database/Eloquent/Model.php
@@ -6,6 +6,9 @@ if (class_exists('Illuminate\Database\Eloquent\Model')) {
     return;
 }
 
+/**
+ * @method static creating(\Closure $closure)
+ */
 abstract class Model
 {
     /**

--- a/tests/Rector/MethodCall/EloquentWhereRelationTypeHintingParameterRector/Fixture/fixture3.php.inc
+++ b/tests/Rector/MethodCall/EloquentWhereRelationTypeHintingParameterRector/Fixture/fixture3.php.inc
@@ -2,12 +2,9 @@
 
 namespace RectorLaravel\Tests\Rector\MethodCall\EloquentWhereRelationTypeHintingParameterRector\Fixture;
 
-class User extends \Illuminate\Database\Eloquent\Model
-{
+use RectorLaravel\Tests\Rector\MethodCall\EloquentWhereRelationTypeHintingParameterRector\Source\FooModel;
 
-}
-
-User::whereHas('posts', function ($query) {
+FooModel::whereHas('posts', function ($query) {
     $query->where('is_published', true);
 });
 
@@ -17,12 +14,9 @@ User::whereHas('posts', function ($query) {
 
 namespace RectorLaravel\Tests\Rector\MethodCall\EloquentWhereRelationTypeHintingParameterRector\Fixture;
 
-class User extends \Illuminate\Database\Eloquent\Model
-{
+use RectorLaravel\Tests\Rector\MethodCall\EloquentWhereRelationTypeHintingParameterRector\Source\FooModel;
 
-}
-
-User::whereHas('posts', function (\Illuminate\Contracts\Database\Query\Builder $query) {
+FooModel::whereHas('posts', function (\Illuminate\Contracts\Database\Query\Builder $query) {
     $query->where('is_published', true);
 });
 

--- a/tests/Rector/MethodCall/EloquentWhereRelationTypeHintingParameterRector/Fixture/skip_non_closure_argument.php.inc
+++ b/tests/Rector/MethodCall/EloquentWhereRelationTypeHintingParameterRector/Fixture/skip_non_closure_argument.php.inc
@@ -2,19 +2,16 @@
 
 namespace RectorLaravel\Tests\Rector\MethodCall\EloquentWhereRelationTypeHintingParameterRector\Fixture;
 
+use RectorLaravel\Tests\Rector\MethodCall\EloquentWhereRelationTypeHintingParameterRector\Source\FooModel;
+
 /** @var \Illuminate\Contracts\Database\Query\Builder $query */
 $query->whereHas('posts');
 $query->whereHas('posts', null);
 $query->whereHasMorph('posts', '', null);
 
-class User extends \Illuminate\Database\Eloquent\Model
-{
-
-}
-
-User::whereHas('posts');
-User::whereHas('posts', null);
-User::whereHasMorph('posts', '');
-User::whereHasMorph('posts', '', null);
+FooModel::whereHas('posts');
+FooModel::whereHas('posts', null);
+FooModel::whereHasMorph('posts', '');
+FooModel::whereHasMorph('posts', '', null);
 
 ?>

--- a/tests/Rector/MethodCall/EloquentWhereRelationTypeHintingParameterRector/Fixture/skip_non_where_relation_method.php.inc
+++ b/tests/Rector/MethodCall/EloquentWhereRelationTypeHintingParameterRector/Fixture/skip_non_where_relation_method.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector\Source\FooModel;
+
+FooModel::creating('foo', function ($model) {
+    dump($model);
+});
+
+?>

--- a/tests/Rector/MethodCall/EloquentWhereRelationTypeHintingParameterRector/Source/FooModel.php
+++ b/tests/Rector/MethodCall/EloquentWhereRelationTypeHintingParameterRector/Source/FooModel.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\EloquentWhereRelationTypeHintingParameterRector\Source;
+
+use Illuminate\Database\Eloquent\Model;
+
+class FooModel extends Model {}

--- a/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/Fixture/fixture2.php.inc
+++ b/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/Fixture/fixture2.php.inc
@@ -2,12 +2,9 @@
 
 namespace RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector\Fixture;
 
-class User extends \Illuminate\Database\Eloquent\Model
-{
+use RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector\Source\FooModel;
 
-}
-
-User::where(function ($query) {
+FooModel::where(function ($query) {
     $query->where('id', 1)
         ->orWhere('id', 2);
 });
@@ -18,12 +15,9 @@ User::where(function ($query) {
 
 namespace RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector\Fixture;
 
-class User extends \Illuminate\Database\Eloquent\Model
-{
+use RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector\Source\FooModel;
 
-}
-
-User::where(function (\Illuminate\Contracts\Database\Query\Builder $query) {
+FooModel::where(function (\Illuminate\Contracts\Database\Query\Builder $query) {
     $query->where('id', 1)
         ->orWhere('id', 2);
 });

--- a/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/Fixture/skip_non_closure_argument.php.inc
+++ b/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/Fixture/skip_non_closure_argument.php.inc
@@ -1,13 +1,10 @@
 <?php
 
+use RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector\Source\FooModel;
+
 /** @var \Illuminate\Contracts\Database\Query\Builder $query */
 $query->where('name', 'a');
 
-class User extends \Illuminate\Database\Eloquent\Model
-{
-
-}
-
-User::where('name', 'a');
+FooModel::where('name', 'a');
 
 ?>

--- a/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/Fixture/skip_non_where_method.php.inc
+++ b/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/Fixture/skip_non_where_method.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector\Source\FooModel;
+
+FooModel::creating(function ($model) {
+    dump($model);
+});
+
+?>

--- a/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/Source/FooModel.php
+++ b/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/Source/FooModel.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector\Source;
+
+use Illuminate\Database\Eloquent\Model;
+
+class FooModel extends Model
+{
+
+}

--- a/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/Source/FooModel.php
+++ b/tests/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector/Source/FooModel.php
@@ -4,7 +4,4 @@ namespace RectorLaravel\Tests\Rector\MethodCall\EloquentWhereTypeHintClosurePara
 
 use Illuminate\Database\Eloquent\Model;
 
-class FooModel extends Model
-{
-
-}
+class FooModel extends Model {}


### PR DESCRIPTION
Related to #287 

# Changes

- modifies two rules where a downgrade was causing the rule to break.
- adds additional tests.
- refactor the tests to not define classes in the fixtures and use source objects instead.
- sets up the build mechanism to retest code after a downgrade.

# Why

It looks like the `DowngradeMatchToSwitchRector` rule has an issue there which ended up removing code required to check the method causing the downgraded `EloquentWhereTypeHintClosureParameterRector` to break.

@driftingly @GeniJaho, we should be careful to make sure contributors add skip fixtures to cover conditions that ensure the rules they build don't affect code they're not meant to.