### PR TITLE
chore: removed migrator from the list as not needed

### DIFF
--- a/config/sets/laravel-container-string-to-fully-qualified-name.php
+++ b/config/sets/laravel-container-string-to-fully-qualified-name.php
@@ -45,7 +45,6 @@ return static function (RectorConfig $rectorConfig): void {
         'queue.listener' => 'Illuminate\Queue\Listener',
         'queue.failer' => 'Illuminate\Queue\Failed\DatabaseUuidFailedJobProvider',
         'migration.repository' => 'Illuminate\Database\Migrations\MigrationRepositoryInterface',
-        'migrator' => 'Illuminate\Database\Migrations\Migrator',
         'migration.creator' => 'Illuminate\Database\Migrations\MigrationCreator',
         'composer' => 'Illuminate\Support\Composer',
         'hash' => 'Illuminate\Hashing\HashManager',


### PR DESCRIPTION
https://github.com/driftingly/rector-laravel/issues/293

The Migrator instance is not bound to the class name in the IoC container, it is bound to the migrator alias. I guess it should not be updated.

https://github.com/laravel/framework/blob/11.x/src/Illuminate/Database/MigrationServiceProvider.php#L80