### PR TITLE
Add a command to generate new rules

### DIFF
--- a/commands/MakeRuleCommand.php
+++ b/commands/MakeRuleCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Commands;
+
+use Nette\Utils\FileSystem;
+use Rector\Console\Command\CustomRuleCommand;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+/**
+ * Modified version of
+ *
+ * @see CustomRuleCommand
+ */
+final class MakeRuleCommand
+{
+    public function execute(string $ruleName): int
+    {
+        $rectorName = $this->getRuleName($ruleName);
+        $rulesNamespace = 'RectorLaravel\\Rector';
+        $testsNamespace = 'RectorLaravel\\Tests\\Rector';
+
+        // find all files in templates directory
+        $finder = Finder::create()
+            ->files()
+            ->in(__DIR__ . '/../templates/new-rule')
+            ->notName('__NAME__Test.php');
+
+        $finder->append([
+            new SplFileInfo(
+                __DIR__ . '/../templates/new-rule/tests/Rector/__NAME__/__NAME__Test.php',
+                'tests/Rector/__NAME__',
+                'tests/Rector/__NAME__/__NAME__Test.php',
+            ),
+        ]);
+
+        $currentDirectory = getcwd();
+
+        $generatedFilePaths = [];
+
+        $fileInfos = iterator_to_array($finder->getIterator());
+
+        foreach ($fileInfos as $fileInfo) {
+            $newContent = $this->replaceNameVariable($rectorName, $fileInfo->getContents());
+            $newContent = $this->replaceNamespaceVariable($rulesNamespace, $newContent);
+            $newContent = $this->replaceTestsNamespaceVariable($testsNamespace, $newContent);
+            $newFilePath = $this->replaceNameVariable($rectorName, $fileInfo->getRelativePathname());
+
+            FileSystem::write($currentDirectory . '/' . $newFilePath, $newContent, null);
+
+            $generatedFilePaths[] = $newFilePath;
+        }
+
+        echo PHP_EOL . 'Generated files:' . PHP_EOL . PHP_EOL . "\t";
+        echo implode(PHP_EOL . "\t", $generatedFilePaths) . PHP_EOL;
+
+        return 0;
+    }
+
+    private function getRuleName(string $ruleName): string
+    {
+        if (! str_ends_with($ruleName, 'Rector')) {
+            $ruleName .= 'Rector';
+        }
+
+        return ucfirst($ruleName);
+    }
+
+    private function replaceNameVariable(string $rectorName, string $contents): string
+    {
+        return str_replace('__NAME__', $rectorName, $contents);
+    }
+
+    private function replaceNamespaceVariable(string $namespace, string $contents): string
+    {
+        return str_replace('__NAMESPACE__', $namespace, $contents);
+    }
+
+    private function replaceTestsNamespaceVariable(string $testsNamespace, string $contents): string
+    {
+        return str_replace('__TESTS_NAMESPACE__', $testsNamespace, $contents);
+    }
+}

--- a/commands/make-rule.php
+++ b/commands/make-rule.php
@@ -1,0 +1,16 @@
+#!/usr/bin/env php
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+// get the first argument, the rule name
+// make sure we have at least one argument
+if ($argc < 2) {
+    echo PHP_EOL . 'Please provide the name of the rule!' . PHP_EOL;
+    exit(1);
+}
+
+$ruleName = $argv[1];
+
+$command = new \RectorLaravel\Commands\MakeRuleCommand;
+exit($command->execute($ruleName));

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,9 @@
         "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^10.5",
         "symplify/rule-doc-generator": "^12.2",
-        "tightenco/duster": "^3.1"
+        "tightenco/duster": "^3.1",
+        "nette/utils": "^4.0",
+        "symfony/finder": "^7.2"
     },
     "autoload": {
         "psr-4": {
@@ -27,7 +29,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "RectorLaravel\\Tests\\": "tests"
+            "RectorLaravel\\Tests\\": "tests",
+            "RectorLaravel\\Commands\\": "commands"
         },
         "classmap": ["stubs"]
     },
@@ -38,7 +41,8 @@
         "fix": "vendor/bin/duster fix",
         "rector-dry-run": "vendor/bin/rector process --dry-run --ansi",
         "rector": "vendor/bin/rector process --ansi",
-        "docs": "vendor/bin/rule-doc-generator generate src --output-file docs/rector_rules_overview.md --ansi"
+        "docs": "vendor/bin/rule-doc-generator generate src --output-file docs/rector_rules_overview.md --ansi",
+        "make:rule": "php commands/make-rule.php"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/duster.json
+++ b/duster.json
@@ -6,6 +6,7 @@
     ],
     "exclude": [
         "tests/Rector/**/**/Fixture",
-        "tests/Sets/**/Fixture"
+        "tests/Sets/**/Fixture",
+        "templates"
     ]
 }

--- a/templates/new-rule/src/Rector/__NAME__.php
+++ b/templates/new-rule/src/Rector/__NAME__.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace __NAMESPACE__;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use RectorLaravel\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \__TESTS_NAMESPACE__\__NAME__\__NAME__Test
+ */
+final class __NAME__ extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes something',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+before
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+after
+CODE_SAMPLE
+            )]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        // @todo select node type
+        return [Class_::class];
+    }
+
+    /**
+     * @param  Class_  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        // @todo change the node
+
+        return $node;
+    }
+}

--- a/templates/new-rule/tests/Rector/__NAME__/Fixture/some_class.php.inc
+++ b/templates/new-rule/tests/Rector/__NAME__/Fixture/some_class.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace __TESTS_NAMESPACE__\__NAME__\Fixture;
+
+// @todo fill code before
+
+?>
+-----
+<?php
+
+namespace __TESTS_NAMESPACE__\__NAME__\Fixture;
+
+// @todo fill code after
+
+?>

--- a/templates/new-rule/tests/Rector/__NAME__/__NAME__Test.php
+++ b/templates/new-rule/tests/Rector/__NAME__/__NAME__Test.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace __TESTS_NAMESPACE__\__NAME__;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class __NAME__Test extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/templates/new-rule/tests/Rector/__NAME__/config/configured_rule.php
+++ b/templates/new-rule/tests/Rector/__NAME__/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use __NAMESPACE__\__NAME__;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(__NAME__::class);
+};


### PR DESCRIPTION
# Why
It's very difficult to add new rules to the repository, every time you have to copy an existing one and change everything.

I think we should implement a way to generate the base scaffolding needed for writing a new rule.

Modifying the `CustomRuleCommand` in the core Rector repository would make it unnecessarily complicated (https://github.com/rectorphp/rector-src/pull/6676).

# Changes
- Ported an implementation of the original command without all the options and dependencies. The reason is I couldn't make `RectorConfig` run user-defined commands. I think they need to be configured in the core Rector implementation somehow.
- Added a new directory called `Commands`, registered in `autoload-dev` so it doesn't make it to the users' vendor.
- Added a new composer script to make it easy to run the command, called `composer make:rule`.
- Added two new dev dependencies to work with the filesystem, but they can be refactored out since the use-case is very limited.
- To Do: cleanup, remove dependencies, generate configurable rules, add to Readme, etc

@peterfox what do you think? Can we use something like this? Is there a better way to generate new rules?