### PR TITLE
Laravel 12 set with Bind Closures without Abstract rule

### DIFF
--- a/config/sets/laravel120.php
+++ b/config/sets/laravel120.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector;
+
+// see https://laravel.com/docs/12.x/upgrade
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../config.php');
+
+    // https://github.com/laravel/framework/pull/54628
+    $rectorConfig->rule(ContainerBindConcreteWithClosureOnlyRector::class);
+};

--- a/config/sets/level/up-to-laravel-120.php
+++ b/config/sets/level/up-to-laravel-120.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Set\LaravelLevelSetList;
+use RectorLaravel\Set\LaravelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([LaravelSetList::LARAVEL_120, LaravelLevelSetList::UP_TO_LARAVEL_110]);
+};

--- a/src/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector.php
+++ b/src/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace RectorLaravel\Rector\MethodCall;
+
+use PhpParser\Node;
+use Rector\Rector\AbstractRector;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Generic\GenericClassStringType;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class ContainerBindConcreteWithClosureOnlyRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Drop the specified abstract class from the bind method and replace it with a closure that returns the abstract class.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+$this->app->bind(SomeClass::class, function (): SomeClass {
+    return new SomeClass();
+});
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+$this->app->bind(function (): SomeClass {
+    return new SomeClass();
+});
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Node\Expr\MethodCall::class];
+    }
+
+    /**
+     * @param Node\Expr\MethodCall $node
+     */
+    public function refactor(Node $node): ?Node\Expr\MethodCall
+    {
+        if (! $this->isNames($node->name, ['bind', 'singleton', 'bindIf', 'singletonIf'])) {
+            return null;
+        }
+
+        if (! $this->isObjectType($node->var, new ObjectType('Illuminate\Contracts\Container\Container'))) {
+            return null;
+        }
+
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
+        if (count($node->getArgs()) < 2) {
+            return null;
+        }
+
+        $abstract = $this->getType($node->getArgs()[0]->value);
+        $concreteNode = $node->getArgs()[1]->value;
+
+        if (! $concreteNode instanceof Node\Expr\Closure) {
+            return null;
+        }
+        $abstractFromConcrete = $this->getType($concreteNode)->getReturnType();
+
+        if (! $abstract instanceof GenericClassStringType) {
+            return null;
+        }
+
+        $abstractObjectType = $abstract->getClassStringObjectType();
+
+        var_dump([
+            $abstractObjectType,
+            $abstractFromConcrete,
+            $abstractObjectType->equals($abstractFromConcrete),
+            $abstractFromConcrete->isSuperTypeOf($abstractObjectType)->no(),
+        ]);
+
+        if (! $abstractObjectType->equals($abstractFromConcrete)
+        && $abstractFromConcrete->isSuperTypeOf($abstractObjectType)->no()) {
+            return null;
+        }
+
+        if ($abstractFromConcrete === null) {
+            return null;
+        }
+
+        $args = $node->getArgs();
+        return $this->nodeFactory->createMethodCall(
+            $node->var,
+            $node->name,
+            array_splice($args, 1),
+        );
+    }
+}

--- a/src/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector.php
+++ b/src/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector.php
@@ -18,8 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class ContainerBindConcreteWithClosureOnlyRector extends AbstractRector
 {
     public function __construct(
-        private readonly ReturnTypeInferer $returnTypeInfer,
-        private readonly StaticTypeMapper  $staticTypeMapper,
+        private readonly ReturnTypeInferer $returnTypeInferer,
+        private readonly StaticTypeMapper $staticTypeMapper,
     ) {}
 
     public function getRuleDefinition(): RuleDefinition
@@ -77,7 +77,7 @@ CODE_SAMPLE
         if (! $concreteNode instanceof Closure) {
             return null;
         }
-        $abstractFromConcrete = $this->returnTypeInfer->inferFunctionLike($concreteNode);
+        $abstractFromConcrete = $this->returnTypeInferer->inferFunctionLike($concreteNode);
 
         if ($classString instanceof Const_
         && $this->isName($classString, 'class')) {

--- a/src/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector.php
+++ b/src/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector.php
@@ -18,8 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class ContainerBindConcreteWithClosureOnlyRector extends AbstractRector
 {
     public function __construct(
-        private readonly ReturnTypeInferer $returnTypeInferer,
-        private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly ReturnTypeInferer $returnTypeInfer,
+        private readonly StaticTypeMapper  $staticTypeMapper,
     ) {}
 
     public function getRuleDefinition(): RuleDefinition
@@ -77,7 +77,7 @@ CODE_SAMPLE
         if (! $concreteNode instanceof Closure) {
             return null;
         }
-        $abstractFromConcrete = $this->returnTypeInferer->inferFunctionLike($concreteNode);
+        $abstractFromConcrete = $this->returnTypeInfer->inferFunctionLike($concreteNode);
 
         if ($classString instanceof Const_
         && $this->isName($classString, 'class')) {

--- a/src/Set/LaravelLevelSetList.php
+++ b/src/Set/LaravelLevelSetList.php
@@ -33,4 +33,6 @@ final class LaravelLevelSetList
     final public const string UP_TO_LARAVEL_100 = __DIR__ . '/../../config/sets/level/up-to-laravel-100.php';
 
     final public const string UP_TO_LARAVEL_110 = __DIR__ . '/../../config/sets/level/up-to-laravel-110.php';
+
+    final public const string UP_TO_LARAVEL_120 = __DIR__ . '/../../config/sets/level/up-to-laravel-120.php';
 }

--- a/src/Set/LaravelSetList.php
+++ b/src/Set/LaravelSetList.php
@@ -38,6 +38,8 @@ final class LaravelSetList
 
     final public const string LARAVEL_110 = __DIR__ . '/../../config/sets/laravel110.php';
 
+    final public const string LARAVEL_120 = __DIR__ . '/../../config/sets/laravel120.php';
+
     final public const string LARAVEL_ARRAYACCESS_TO_METHOD_CALL = __DIR__ . '/../../config/sets/laravel-arrayaccess-to-method-call.php';
 
     final public const string LARAVEL_ARRAY_STR_FUNCTION_TO_STATIC_CALL = __DIR__ . '/../../config/sets/laravel-array-str-functions-to-static-call.php';

--- a/src/Set/LaravelSetProvider.php
+++ b/src/Set/LaravelSetProvider.php
@@ -30,6 +30,7 @@ final class LaravelSetProvider implements SetProviderInterface
      * @var string[]
      */
     private const array LARAVEL_POST_FIVE = [
+        LaravelSetList::LARAVEL_120,
         LaravelSetList::LARAVEL_110,
         LaravelSetList::LARAVEL_100,
         LaravelSetList::LARAVEL_90,

--- a/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/ContainerBindConcreteWithClosureOnlyRectorTest.php
+++ b/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/ContainerBindConcreteWithClosureOnlyRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ContainerBindConcreteWithClosureOnlyRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/fixture.php.inc
@@ -7,9 +7,13 @@ use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRe
 use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface;
 
 /** @var Container $app */
+$app->bind(SomeInterface::class, function () {
+    return new SomeClass();
+});
+
 $app->bind(SomeInterface::class, function (): SomeClass {
     return new SomeClass();
-})
+});
 
 ?>
 -----
@@ -24,6 +28,10 @@ use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRe
 /** @var Container $app */
 $app->bind(function (): \RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface {
     return new SomeClass();
-})
+});
+
+$app->bind(function (): \RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface {
+    return new SomeClass();
+});
 
 ?>

--- a/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/fixture.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Fixture;
+
+use Illuminate\Contracts\Container\Container;
+use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeClass;
+use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface;
+
+/** @var Container $app */
+$app->bind(SomeInterface::class, function (): SomeInterface {
+    return new SomeClass();
+})
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Fixture;
+
+use Illuminate\Contracts\Container\Container;
+use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeClass;
+use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface;
+
+/** @var Container $app */
+$app->bind(function (): SomeInterface {
+    return new SomeClass();
+})
+
+?>

--- a/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/fixture.php.inc
@@ -7,7 +7,7 @@ use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRe
 use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface;
 
 /** @var Container $app */
-$app->bind(SomeInterface::class, function (): SomeInterface {
+$app->bind(SomeInterface::class, function (): SomeClass {
     return new SomeClass();
 })
 
@@ -22,7 +22,7 @@ use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRe
 use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface;
 
 /** @var Container $app */
-$app->bind(function (): SomeInterface {
+$app->bind(function (): \RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface {
     return new SomeClass();
 })
 

--- a/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/fixture.php.inc
@@ -15,6 +15,10 @@ $app->bind(SomeInterface::class, function (): SomeClass {
     return new SomeClass();
 });
 
+$app->singleton(SomeInterface::class, function () {
+    return new SomeClass();
+});
+
 ?>
 -----
 <?php
@@ -31,6 +35,10 @@ $app->bind(function (): \RectorLaravel\Tests\Rector\MethodCall\ContainerBindConc
 });
 
 $app->bind(function (): \RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface {
+    return new SomeClass();
+});
+
+$app->singleton(function (): \RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface {
     return new SomeClass();
 });
 

--- a/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Source/SomeClass.php
+++ b/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Source/SomeClass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source;
+
+class SomeClass implements SomeInterface
+{
+
+}

--- a/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Source/SomeClass.php
+++ b/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Source/SomeClass.php
@@ -2,7 +2,4 @@
 
 namespace RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source;
 
-class SomeClass implements SomeInterface
-{
-
-}
+class SomeClass implements SomeInterface {}

--- a/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Source/SomeInterface.php
+++ b/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Source/SomeInterface.php
@@ -2,7 +2,4 @@
 
 namespace RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source;
 
-interface SomeInterface
-{
-
-}
+interface SomeInterface {}

--- a/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Source/SomeInterface.php
+++ b/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Source/SomeInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source;
+
+interface SomeInterface
+{
+
+}

--- a/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(ContainerBindConcreteWithClosureOnlyRector::class);
+};


### PR DESCRIPTION
# Changes

- Adds the Laravel 12 set
- Adds a ContainerBindConcreteWithClosureOnlyRector rule
- Adds sets for the rule

# Why

Handles upgrades for this PR in Laravel https://github.com/laravel/framework/pull/54628

```diff
-$this->app->bind(SomeInterface::class, function () {
+$this->app->bind(function (): SomeInterface {
    return new SomeClass();
});