### PR TITLE
Fixup expected jobs and events rule

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1137,7 +1137,7 @@ Replace expectJobs and expectEvents methods in tests
 -        $this->expectsEvents(\App\Events\SomeEvent::class);
 -        $this->doesntExpectEvents(\App\Events\SomeOtherEvent::class);
 +        \Illuminate\Support\Facades\Bus::fake([\App\Jobs\SomeJob::class, \App\Jobs\SomeOtherJob::class]);
-+        \Illuminate\Support\Facades\Event::fake([\App\Events\SomeEvent::class]);
++        \Illuminate\Support\Facades\Event::fake([\App\Events\SomeEvent::class, \App\Events\SomeOtherEvent::class]);
 
          $this->get('/');
 +

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1135,6 +1135,7 @@ Replace expectJobs and expectEvents methods in tests
      {
 -        $this->expectsJobs([\App\Jobs\SomeJob::class, \App\Jobs\SomeOtherJob::class]);
 -        $this->expectsEvents(\App\Events\SomeEvent::class);
+-        $this->doesntExpectEvents(\App\Events\SomeOtherEvent::class);
 +        \Illuminate\Support\Facades\Bus::fake([\App\Jobs\SomeJob::class, \App\Jobs\SomeOtherJob::class]);
 +        \Illuminate\Support\Facades\Event::fake([\App\Events\SomeEvent::class]);
 
@@ -1143,6 +1144,7 @@ Replace expectJobs and expectEvents methods in tests
 +        \Illuminate\Support\Facades\Bus::assertDispatched(\App\Jobs\SomeJob::class);
 +        \Illuminate\Support\Facades\Bus::assertDispatched(\App\Jobs\SomeOtherJob::class);
 +        \Illuminate\Support\Facades\Event::assertDispatched(\App\Events\SomeEvent::class);
++        \Illuminate\Support\Facades\Event::assertNotDispatched(\App\Events\SomeOtherEvent::class);
      }
  }
 ```

--- a/src/NodeAnalyzer/ExpectedClassMethodAnalyzer.php
+++ b/src/NodeAnalyzer/ExpectedClassMethodAnalyzer.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace RectorLaravel\NodeAnalyzer;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
+use RectorLaravel\ValueObject\ExpectedClassMethodMethodCalls;
+
+class ExpectedClassMethodAnalyzer
+{
+    public function __construct(
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
+        private NodeNameResolver $nodeNameResolver,
+    )
+    {
+    }
+
+    public function findExpectedJobCallsWithClassMethod(ClassMethod $classMethod): ?ExpectedClassMethodMethodCalls
+    {
+        /** @var MethodCall[] $expectedMethodCalls */
+        $expectedMethodCalls = [];
+        /** @var MethodCall[] $notExpectedMethodCalls */
+        $notExpectedMethodCalls = [];
+        $reasonsToNotContinue = false;
+
+        $this->simpleCallableNodeTraverser->traverseNodesWithCallable($classMethod, function (Node $node) use (
+            &$expectedMethodCalls,
+            &$notExpectedMethodCalls,
+            &$reasonsToNotContinue,
+        ): void {
+            if (! $node instanceof MethodCall) {
+                return;
+            }
+
+            if ($this->nodeNameResolver->isName($node->name, 'expectsJobs')) {
+                $expectedMethodCalls[] = $node;
+                return;
+            }
+
+            if ($this->nodeNameResolver->isName($node->name, 'doesntExpectJobs')) {
+                $notExpectedMethodCalls[] = $node;
+            }
+
+            if ($node->isFirstClassCallable()) {
+                $reasonsToNotContinue = true;
+            }
+        });
+
+        if ($reasonsToNotContinue) {
+            return null;
+        }
+
+        $expectedItems = $this->findClasses($expectedMethodCalls);
+        $notExpectedItems = $this->findClasses($expectedMethodCalls);
+
+        return new ExpectedClassMethodMethodCalls(
+            $expectedMethodCalls,
+            $expectedItems,
+            $notExpectedMethodCalls,
+            $notExpectedItems
+        );
+    }
+
+    public function findExpectedEventCallsWithClassMethod(ClassMethod $classMethod): ?ExpectedClassMethodMethodCalls
+    {
+        /** @var MethodCall[] $expectedMethodCalls */
+        $expectedMethodCalls = [];
+        /** @var MethodCall[] $notExpectedMethodCalls */
+        $notExpectedMethodCalls = [];
+        $reasonsToNotContinue = false;
+
+        $this->simpleCallableNodeTraverser->traverseNodesWithCallable($classMethod, function (Node $node) use (
+            &$expectedMethodCalls,
+            &$notExpectedMethodCalls,
+            &$reasonsToNotContinue,
+        ): void {
+            var_dump('here');
+            if (! $node instanceof MethodCall) {
+                return;
+            }
+
+            if ($this->nodeNameResolver->isName($node, 'expectsEvents')) {
+                $expectedMethodCalls[] = $node;
+                return;
+            }
+
+            if ($this->nodeNameResolver->isName($node, 'doesntExpectEvents')) {
+                $notExpectedMethodCalls[] = $node;
+            }
+
+            if ($node->isFirstClassCallable()) {
+                $reasonsToNotContinue = true;
+            }
+        });
+
+        if ($reasonsToNotContinue) {
+            return null;
+        }
+
+        $expectedItems = $this->findClasses($expectedMethodCalls);
+        $notExpectedItems = $this->findClasses($expectedMethodCalls);
+
+        return new ExpectedClassMethodMethodCalls(
+            $expectedMethodCalls,
+            $expectedItems,
+            $notExpectedMethodCalls,
+            $notExpectedItems
+        );
+    }
+
+    private function findClasses(array $methodCalls): array
+    {
+        $items = [];
+        foreach ($methodCalls as $methodCall) {
+            $value = $methodCall->args[0]->value;
+            if ($value instanceof Node\Scalar\String_) {
+                $items[] = $value->value;
+                continue;
+            }
+            if ($value instanceof Node\Expr\ClassConstFetch && $this->nodeNameResolver->isName($value->name, 'class')) {
+                $items[] = $value->class->name;
+                continue;
+            }
+            if ($value instanceof Node\Expr\Array_) {
+                foreach ($value->items as $arrayItem) {
+                    if ($arrayItem->value instanceof Node\Expr\ClassConstFetch && $this->nodeNameResolver->isName($arrayItem->value->name, 'class')) {
+                        $items[] = $arrayItem->value->class->name;
+                        continue;
+                    }
+                    if ($arrayItem->value instanceof Node\Scalar\String_) {
+                        $items[] = $arrayItem->value->value;
+                    }
+                }
+            }
+        }
+
+        return $items;
+    }
+}

--- a/src/NodeAnalyzer/ExpectedClassMethodAnalyzer.php
+++ b/src/NodeAnalyzer/ExpectedClassMethodAnalyzer.php
@@ -34,22 +34,22 @@ final readonly class ExpectedClassMethodAnalyzer
             &$expectedMethodCalls,
             &$notExpectedMethodCalls,
             &$reasonsToNotContinue,
-        ): void {
+        ): array|int|\PhpParser\Node|null {
             if (! $node instanceof MethodCall) {
-                return;
+                return null;
             }
 
             if (! $this->nodeTypeResolver->isObjectType(
                 $node->var,
                 new ObjectType('Illuminate\Foundation\Testing\TestCase')
             )) {
-                return;
+                return null;
             }
 
             if ($this->nodeNameResolver->isName($node->name, 'expectsJobs')) {
                 $expectedMethodCalls[] = $node;
 
-                return;
+                return null;
             }
 
             if ($this->nodeNameResolver->isName($node->name, 'doesntExpectJobs')) {
@@ -59,6 +59,8 @@ final readonly class ExpectedClassMethodAnalyzer
             if ($node->isFirstClassCallable()) {
                 $reasonsToNotContinue = true;
             }
+
+            return null;
         });
 
         if ($reasonsToNotContinue) {
@@ -88,22 +90,22 @@ final readonly class ExpectedClassMethodAnalyzer
             &$expectedMethodCalls,
             &$notExpectedMethodCalls,
             &$reasonsToNotContinue,
-        ): void {
+        ): array|int|\PhpParser\Node|null {
             if (! $node instanceof MethodCall) {
-                return;
+                return null;
             }
 
             if (! $this->nodeTypeResolver->isObjectType(
                 $node->var,
                 new ObjectType('Illuminate\Foundation\Testing\TestCase')
             )) {
-                return;
+                return null;
             }
 
             if ($this->nodeNameResolver->isName($node->name, 'expectsEvents')) {
                 $expectedMethodCalls[] = $node;
 
-                return;
+                return null;
             }
 
             if ($this->nodeNameResolver->isName($node->name, 'doesntExpectEvents')) {
@@ -113,6 +115,8 @@ final readonly class ExpectedClassMethodAnalyzer
             if ($node->isFirstClassCallable()) {
                 $reasonsToNotContinue = true;
             }
+
+            return null;
         });
 
         if ($reasonsToNotContinue) {
@@ -138,6 +142,9 @@ final readonly class ExpectedClassMethodAnalyzer
     {
         $items = [];
         foreach ($methodCalls as $methodCall) {
+            if (! $methodCall->args[0] instanceof Node\Arg) {
+                continue;
+            }
             $value = $methodCall->args[0]->value;
             if ($value instanceof String_) {
                 $items[] = $value;

--- a/src/NodeAnalyzer/ExpectedClassMethodAnalyzer.php
+++ b/src/NodeAnalyzer/ExpectedClassMethodAnalyzer.php
@@ -3,6 +3,7 @@
 namespace RectorLaravel\NodeAnalyzer;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
@@ -34,7 +35,7 @@ final readonly class ExpectedClassMethodAnalyzer
             &$expectedMethodCalls,
             &$notExpectedMethodCalls,
             &$reasonsToNotContinue,
-        ): array|int|\PhpParser\Node|null {
+        ): array|int|Node|null {
             if (! $node instanceof MethodCall) {
                 return null;
             }
@@ -90,7 +91,7 @@ final readonly class ExpectedClassMethodAnalyzer
             &$expectedMethodCalls,
             &$notExpectedMethodCalls,
             &$reasonsToNotContinue,
-        ): array|int|\PhpParser\Node|null {
+        ): array|int|Node|null {
             if (! $node instanceof MethodCall) {
                 return null;
             }
@@ -142,7 +143,7 @@ final readonly class ExpectedClassMethodAnalyzer
     {
         $items = [];
         foreach ($methodCalls as $methodCall) {
-            if (! $methodCall->args[0] instanceof Node\Arg) {
+            if (! $methodCall->args[0] instanceof Arg) {
                 continue;
             }
             $value = $methodCall->args[0]->value;

--- a/src/NodeAnalyzer/ExpectedClassMethodAnalyzer.php
+++ b/src/NodeAnalyzer/ExpectedClassMethodAnalyzer.php
@@ -54,7 +54,7 @@ class ExpectedClassMethodAnalyzer
         }
 
         $expectedItems = $this->findClasses($expectedMethodCalls);
-        $notExpectedItems = $this->findClasses($expectedMethodCalls);
+        $notExpectedItems = $this->findClasses($notExpectedMethodCalls);
 
         return new ExpectedClassMethodMethodCalls(
             $expectedMethodCalls,
@@ -77,17 +77,16 @@ class ExpectedClassMethodAnalyzer
             &$notExpectedMethodCalls,
             &$reasonsToNotContinue,
         ): void {
-            var_dump('here');
             if (! $node instanceof MethodCall) {
                 return;
             }
 
-            if ($this->nodeNameResolver->isName($node, 'expectsEvents')) {
+            if ($this->nodeNameResolver->isName($node->name, 'expectsEvents')) {
                 $expectedMethodCalls[] = $node;
                 return;
             }
 
-            if ($this->nodeNameResolver->isName($node, 'doesntExpectEvents')) {
+            if ($this->nodeNameResolver->isName($node->name, 'doesntExpectEvents')) {
                 $notExpectedMethodCalls[] = $node;
             }
 
@@ -101,7 +100,7 @@ class ExpectedClassMethodAnalyzer
         }
 
         $expectedItems = $this->findClasses($expectedMethodCalls);
-        $notExpectedItems = $this->findClasses($expectedMethodCalls);
+        $notExpectedItems = $this->findClasses($notExpectedMethodCalls);
 
         return new ExpectedClassMethodMethodCalls(
             $expectedMethodCalls,

--- a/src/NodeFactory/DispatchableTestsMethodsFactory.php
+++ b/src/NodeFactory/DispatchableTestsMethodsFactory.php
@@ -14,7 +14,7 @@ use PhpParser\Node\Stmt\Expression;
 class DispatchableTestsMethodsFactory
 {
     /**
-     * @param  array<int<0, max>, \PhpParser\Node\Expr\ClassConstFetch|\PhpParser\Node\Scalar\String_>  $items
+     * @param  array<int<0, max>, ClassConstFetch|String_>  $items
      */
     public function makeFacadeFakeCall(array $items, string $facade): StaticCall
     {
@@ -26,7 +26,7 @@ class DispatchableTestsMethodsFactory
     }
 
     /**
-     * @param  array<int<0, max>, \PhpParser\Node\Expr\ClassConstFetch|\PhpParser\Node\Scalar\String_>  $items
+     * @param  array<int<0, max>, ClassConstFetch|String_>  $items
      * @return Expression[]
      */
     public function assertStatements(array $items, string $facade): array
@@ -39,7 +39,7 @@ class DispatchableTestsMethodsFactory
     }
 
     /**
-     * @param  array<int<0, max>, \PhpParser\Node\Expr\ClassConstFetch|\PhpParser\Node\Scalar\String_>  $items
+     * @param  array<int<0, max>, ClassConstFetch|String_>  $items
      * @return Expression[]
      */
     public function assertNotStatements(array $items, string $facade): array

--- a/src/NodeFactory/DispatchableTestsMethodsFactory.php
+++ b/src/NodeFactory/DispatchableTestsMethodsFactory.php
@@ -8,48 +8,47 @@ use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Expression;
 
 class DispatchableTestsMethodsFactory
 {
-    public function makeFacadeFakeCall(array $classes, string $facade): StaticCall
+    /**
+     * @param  list<String_|ClassConstFetch>  $items
+     * @param  class-string  $facade
+     */
+    public function makeFacadeFakeCall(array $items, string $facade): StaticCall
     {
         return new StaticCall(
             new FullyQualified($facade),
             'fake',
-            [new Arg (new Array_(array_map(function (string $class): ArrayItem {
-                return new ArrayItem(new ClassConstFetch(new FullyQualified($class), 'class'));
-            }, $classes)))]
+            [new Arg(new Array_(array_map(fn (String_|ClassConstFetch $item): ArrayItem => new ArrayItem($item), $items)))]
         );
     }
 
     /**
-     * @param class-string[] $classes
+     * @param  list<String_|ClassConstFetch>  $items
      * @return StaticCall[]
      */
-    public function assertStatements(array $classes, string $facade): array
+    public function assertStatements(array $items, string $facade): array
     {
-        return array_map(function (string $class) use ($facade): Expression {
-            return new Expression(new StaticCall(
-                new FullyQualified($facade),
-                'assertDispatched',
-                [new Arg(new ClassConstFetch(new FullyQualified($class), 'class'))],
-            ));
-        }, $classes);
+        return array_map(fn (String_|ClassConstFetch $item): Expression => new Expression(new StaticCall(
+            new FullyQualified($facade),
+            'assertDispatched',
+            [new Arg($item)],
+        )), $items);
     }
 
     /**
-     * @param class-string[] $classes
+     * @param  list<String_|ClassConstFetch>  $items
      * @return StaticCall[]
      */
-    public function assertNotStatements(array $classes, string $facade): array
+    public function assertNotStatements(array $items, string $facade): array
     {
-        return array_map(function (string $class) use ($facade): Expression {
-            return new Expression(new StaticCall(
-                new FullyQualified($facade),
-                'assertNotDispatched',
-                [new Arg(new ClassConstFetch(new FullyQualified($class), 'class'))],
-            ));
-        }, $classes);
+        return array_map(fn (String_|ClassConstFetch $item): Expression => new Expression(new StaticCall(
+            new FullyQualified($facade),
+            'assertNotDispatched',
+            [new Arg($item)],
+        )), $items);
     }
 }

--- a/src/NodeFactory/DispatchableTestsMethodsFactory.php
+++ b/src/NodeFactory/DispatchableTestsMethodsFactory.php
@@ -14,8 +14,7 @@ use PhpParser\Node\Stmt\Expression;
 class DispatchableTestsMethodsFactory
 {
     /**
-     * @param  list<String_|ClassConstFetch>  $items
-     * @param  class-string  $facade
+     * @param  array<int<0, max>, \PhpParser\Node\Expr\ClassConstFetch|\PhpParser\Node\Scalar\String_>  $items
      */
     public function makeFacadeFakeCall(array $items, string $facade): StaticCall
     {
@@ -27,8 +26,8 @@ class DispatchableTestsMethodsFactory
     }
 
     /**
-     * @param  list<String_|ClassConstFetch>  $items
-     * @return StaticCall[]
+     * @param  array<int<0, max>, \PhpParser\Node\Expr\ClassConstFetch|\PhpParser\Node\Scalar\String_>  $items
+     * @return Expression[]
      */
     public function assertStatements(array $items, string $facade): array
     {
@@ -40,8 +39,8 @@ class DispatchableTestsMethodsFactory
     }
 
     /**
-     * @param  list<String_|ClassConstFetch>  $items
-     * @return StaticCall[]
+     * @param  array<int<0, max>, \PhpParser\Node\Expr\ClassConstFetch|\PhpParser\Node\Scalar\String_>  $items
+     * @return Expression[]
      */
     public function assertNotStatements(array $items, string $facade): array
     {

--- a/src/NodeFactory/DispatchableTestsMethodsFactory.php
+++ b/src/NodeFactory/DispatchableTestsMethodsFactory.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace RectorLaravel\NodeFactory;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\ArrayItem;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\Expression;
+
+class DispatchableTestsMethodsFactory
+{
+    public function makeFacadeFakeCall(array $classes, string $facade): StaticCall
+    {
+        return new StaticCall(
+            new FullyQualified($facade),
+            'fake',
+            [new Arg (new Array_(array_map(function (string $class): ArrayItem {
+                return new ArrayItem(new ClassConstFetch(new FullyQualified($class), 'class'));
+            }, $classes)))]
+        );
+    }
+
+    /**
+     * @param class-string[] $classes
+     * @return StaticCall[]
+     */
+    public function assertStatements(array $classes, string $facade): array
+    {
+        return array_map(function (string $class) use ($facade): Expression {
+            return new Expression(new StaticCall(
+                new FullyQualified($facade),
+                'assertDispatched',
+                [new Arg(new ClassConstFetch(new FullyQualified($class), 'class'))],
+            ));
+        }, $classes);
+    }
+
+    /**
+     * @param class-string[] $classes
+     * @return StaticCall[]
+     */
+    public function assertNotStatements(array $classes, string $facade): array
+    {
+        return array_map(function (string $class) use ($facade): Expression {
+            return new Expression(new StaticCall(
+                new FullyQualified($facade),
+                'assertNotDispatched',
+                [new Arg(new ClassConstFetch(new FullyQualified($class), 'class'))],
+            ));
+        }, $classes);
+    }
+}

--- a/src/Rector/Class_/ReplaceExpectsMethodsInTestsRector.php
+++ b/src/Rector/Class_/ReplaceExpectsMethodsInTestsRector.php
@@ -40,6 +40,7 @@ class SomethingTest extends TestCase
     {
         $this->expectsJobs([\App\Jobs\SomeJob::class, \App\Jobs\SomeOtherJob::class]);
         $this->expectsEvents(\App\Events\SomeEvent::class);
+        $this->doesntExpectEvents(\App\Events\SomeOtherEvent::class);
 
         $this->get('/');
     }
@@ -61,6 +62,7 @@ class SomethingTest extends TestCase
         \Illuminate\Support\Facades\Bus::assertDispatched(\App\Jobs\SomeJob::class);
         \Illuminate\Support\Facades\Bus::assertDispatched(\App\Jobs\SomeOtherJob::class);
         \Illuminate\Support\Facades\Event::assertDispatched(\App\Events\SomeEvent::class);
+        \Illuminate\Support\Facades\Event::assertNotDispatched(\App\Events\SomeOtherEvent::class);
     }
 }
 CODE_SAMPLE

--- a/src/Rector/Class_/ReplaceExpectsMethodsInTestsRector.php
+++ b/src/Rector/Class_/ReplaceExpectsMethodsInTestsRector.php
@@ -141,10 +141,14 @@ CODE_SAMPLE
     private function removeAndReplaceMethodCalls(ClassMethod $node, array $expectedMethodCalls, array $classes, string $facade): ClassMethod
     {
         $first = true;
-        $this->traverseNodesWithCallable($node, function (Node $node) use (&$first, $expectedMethodCalls, $classes, $facade): StaticCall|int|null {
+        $this->traverseNodesWithCallable($node, function (Node $node) use (&$first, $expectedMethodCalls, $classes, $facade): Expression|int|null {
             $match = false;
+            if (! $node instanceof Expression) {
+                return null;
+            }
+
             foreach ($expectedMethodCalls as $methodCall) {
-                if ($this->nodeComparator->areNodesEqual($node, $methodCall)) {
+                if ($this->nodeComparator->areNodesEqual($node->expr, $methodCall)) {
                     $match = true;
                     break;
                 }
@@ -156,7 +160,7 @@ CODE_SAMPLE
 
             if ($first) {
                 $first = false;
-                return $this->dispatchableTestsMethodsFactory->makeFacadeFakeCall($classes, $facade);
+                return new Expression($this->dispatchableTestsMethodsFactory->makeFacadeFakeCall($classes, $facade));
             }
 
             return NodeVisitor::REMOVE_NODE;

--- a/src/Rector/Class_/ReplaceExpectsMethodsInTestsRector.php
+++ b/src/Rector/Class_/ReplaceExpectsMethodsInTestsRector.php
@@ -114,8 +114,6 @@ CODE_SAMPLE
                 continue;
             }
 
-            var_dump($result->getExpectedItems());
-
             if ($result->isActionable()) {
                 $this->fixUpClassMethod($classMethod, $result, 'Illuminate\Support\Facades\Event');
             }
@@ -134,7 +132,7 @@ CODE_SAMPLE
         $node->stmts = array_merge(
             $node->stmts,
             $this->dispatchableTestsMethodsFactory->assertStatements($result->getExpectedItems(), $facade),
-            $this->dispatchableTestsMethodsFactory->assertStatements($result->getNotExpectedItems(), $facade)
+            $this->dispatchableTestsMethodsFactory->assertNotStatements($result->getNotExpectedItems(), $facade)
         );
 
         return $node;
@@ -158,16 +156,10 @@ CODE_SAMPLE
 
             if ($first) {
                 $first = false;
-//                \RectorPrefix202502\dump_node($node);
-                $static = $this->dispatchableTestsMethodsFactory->makeFacadeFakeCall($classes, $facade);
-//                \RectorPrefix202502\dump_node($static);
-
-                return $static;
+                return $this->dispatchableTestsMethodsFactory->makeFacadeFakeCall($classes, $facade);
             }
 
-//            \RectorPrefix202502\dump_node($node);
-
-            return null;
+            return NodeVisitor::REMOVE_NODE;
         });
 
         return $node;

--- a/src/Rector/Class_/ReplaceExpectsMethodsInTestsRector.php
+++ b/src/Rector/Class_/ReplaceExpectsMethodsInTestsRector.php
@@ -55,7 +55,7 @@ class SomethingTest extends TestCase
     public function testSomething()
     {
         \Illuminate\Support\Facades\Bus::fake([\App\Jobs\SomeJob::class, \App\Jobs\SomeOtherJob::class]);
-        \Illuminate\Support\Facades\Event::fake([\App\Events\SomeEvent::class]);
+        \Illuminate\Support\Facades\Event::fake([\App\Events\SomeEvent::class, \App\Events\SomeOtherEvent::class]);
 
         $this->get('/');
 

--- a/src/Rector/Class_/ReplaceExpectsMethodsInTestsRector.php
+++ b/src/Rector/Class_/ReplaceExpectsMethodsInTestsRector.php
@@ -111,18 +111,24 @@ CODE_SAMPLE
         ClassMethod $classMethod,
         ExpectedClassMethodMethodCalls $expectedClassMethodMethodCalls,
         string $facade
-    ): ClassMethod {
+    ): void {
         $this->removeAndReplaceMethodCalls($classMethod, $expectedClassMethodMethodCalls->getAllMethodCalls(), $expectedClassMethodMethodCalls->getItemsToFake(), $facade);
-        $classMethod->stmts = array_merge(
-            $classMethod->stmts,
-            $this->dispatchableTestsMethodsFactory->assertStatements($expectedClassMethodMethodCalls->getExpectedItems(), $facade),
-            $this->dispatchableTestsMethodsFactory->assertNotStatements($expectedClassMethodMethodCalls->getNotExpectedItems(), $facade)
-        );
 
-        return $classMethod;
+        $statements = [
+            ...($classMethod->stmts ?? []),
+            ...$this->dispatchableTestsMethodsFactory->assertStatements($expectedClassMethodMethodCalls->getExpectedItems(), $facade),
+            ...$this->dispatchableTestsMethodsFactory->assertNotStatements($expectedClassMethodMethodCalls->getNotExpectedItems(), $facade),
+        ];
+
+        $classMethod->stmts = $statements;
+
     }
 
-    private function removeAndReplaceMethodCalls(ClassMethod $classMethod, array $expectedMethodCalls, array $classes, string $facade): ClassMethod
+    /**
+     * @param  Node\Expr\MethodCall[]  $expectedMethodCalls
+     * @param  array<int<0, max>, \PhpParser\Node\Expr\ClassConstFetch|\PhpParser\Node\Scalar\String_>  $classes
+     */
+    private function removeAndReplaceMethodCalls(ClassMethod $classMethod, array $expectedMethodCalls, array $classes, string $facade): void
     {
         $first = true;
         $this->traverseNodesWithCallable($classMethod, function (Node $node) use (&$first, $expectedMethodCalls, $classes, $facade): Expression|int|null {
@@ -151,6 +157,5 @@ CODE_SAMPLE
             return NodeVisitor::REMOVE_NODE;
         });
 
-        return $classMethod;
     }
 }

--- a/src/Rector/Class_/ReplaceExpectsMethodsInTestsRector.php
+++ b/src/Rector/Class_/ReplaceExpectsMethodsInTestsRector.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace RectorLaravel\Rector\Class_;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
@@ -127,8 +130,8 @@ CODE_SAMPLE
     }
 
     /**
-     * @param  Node\Expr\MethodCall[]  $expectedMethodCalls
-     * @param  array<int<0, max>, \PhpParser\Node\Expr\ClassConstFetch|\PhpParser\Node\Scalar\String_>  $classes
+     * @param  MethodCall[]  $expectedMethodCalls
+     * @param  array<int<0, max>, ClassConstFetch|String_>  $classes
      */
     private function removeAndReplaceMethodCalls(ClassMethod $classMethod, array $expectedMethodCalls, array $classes, string $facade): void
     {

--- a/src/ValueObject/ExpectedClassMethodMethodCalls.php
+++ b/src/ValueObject/ExpectedClassMethodMethodCalls.php
@@ -49,7 +49,7 @@ final readonly class ExpectedClassMethodMethodCalls
     }
 
     /**
-     * @return list<String_|ClassConstFetch>
+     * @return array<int<0, max>, \PhpParser\Node\Expr\ClassConstFetch|\PhpParser\Node\Scalar\String_>
      */
     public function getItemsToFake(): array
     {
@@ -57,7 +57,7 @@ final readonly class ExpectedClassMethodMethodCalls
     }
 
     /**
-     * @return list<String_|ClassConstFetch>
+     * @return array<int<0, max>, \PhpParser\Node\Expr\ClassConstFetch|\PhpParser\Node\Scalar\String_>
      */
     public function getExpectedItems(): array
     {
@@ -65,10 +65,10 @@ final readonly class ExpectedClassMethodMethodCalls
     }
 
     /**
-     * @return list<String_|ClassConstFetch>
+     * @return array<int<0, max>, \PhpParser\Node\Expr\ClassConstFetch|\PhpParser\Node\Scalar\String_>
      */
     public function getNotExpectedItems(): array
     {
-        return array_unique($this->notExpectedItems);
+        return array_unique($this->notExpectedItems, SORT_REGULAR);
     }
 }

--- a/src/ValueObject/ExpectedClassMethodMethodCalls.php
+++ b/src/ValueObject/ExpectedClassMethodMethodCalls.php
@@ -49,7 +49,7 @@ final readonly class ExpectedClassMethodMethodCalls
     }
 
     /**
-     * @return array<int<0, max>, \PhpParser\Node\Expr\ClassConstFetch|\PhpParser\Node\Scalar\String_>
+     * @return array<int<0, max>, ClassConstFetch|String_>
      */
     public function getItemsToFake(): array
     {
@@ -57,7 +57,7 @@ final readonly class ExpectedClassMethodMethodCalls
     }
 
     /**
-     * @return array<int<0, max>, \PhpParser\Node\Expr\ClassConstFetch|\PhpParser\Node\Scalar\String_>
+     * @return array<int<0, max>, ClassConstFetch|String_>
      */
     public function getExpectedItems(): array
     {
@@ -65,7 +65,7 @@ final readonly class ExpectedClassMethodMethodCalls
     }
 
     /**
-     * @return array<int<0, max>, \PhpParser\Node\Expr\ClassConstFetch|\PhpParser\Node\Scalar\String_>
+     * @return array<int<0, max>, ClassConstFetch|String_>
      */
     public function getNotExpectedItems(): array
     {

--- a/src/ValueObject/ExpectedClassMethodMethodCalls.php
+++ b/src/ValueObject/ExpectedClassMethodMethodCalls.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace RectorLaravel\ValueObject;
+
+use PhpParser\Node\Expr\MethodCall;
+use Webmozart\Assert\Assert;
+
+final readonly class ExpectedClassMethodMethodCalls
+{
+    /**
+     * @param MethodCall[] $expectedMethodCalls
+     * @param class-string[] $expectedItems
+     * @param MethodCall[] $notExpectedMethodCalls
+     * @param class-string[] $notExpectedItems
+     */
+    public function __construct(
+        private array $expectedMethodCalls = [],
+        private array $expectedItems = [],
+        private array $notExpectedMethodCalls = [],
+        private array $notExpectedItems = []
+    )
+    {
+        Assert::allIsInstanceOf($this->expectedMethodCalls, MethodCall::class);
+        Assert::allIsInstanceOf($this->notExpectedMethodCalls, MethodCall::class);
+        Assert::allString($this->expectedItems);
+        Assert::allString($this->notExpectedItems);
+    }
+
+    public function isActionable(): bool
+    {
+        return ! ($this->expectedMethodCalls === [] && $this->notExpectedMethodCalls === []);
+    }
+
+    /**
+     * @return MethodCall[]
+     */
+    public function getAllMethodCalls(): array
+    {
+        return array_merge($this->expectedMethodCalls, $this->notExpectedMethodCalls);
+    }
+
+    /**
+     * @return MethodCall[]
+     */
+    public function getNotExpectedMethodCalls(): array
+    {
+        return $this->notExpectedMethodCalls;
+    }
+
+    /**
+     * @return class-string[]
+     */
+    public function getItemsToFake(): array
+    {
+        return array_unique(array_merge($this->expectedItems, $this->notExpectedItems));
+    }
+
+    /**
+     * @return class-string[]
+     */
+    public function getExpectedItems(): array
+    {
+        return array_unique($this->expectedItems);
+    }
+
+    /**
+     * @return class-string[]
+     */
+    public function getNotExpectedItems(): array
+    {
+        return array_unique($this->notExpectedItems);
+    }
+}

--- a/src/ValueObject/ExpectedClassMethodMethodCalls.php
+++ b/src/ValueObject/ExpectedClassMethodMethodCalls.php
@@ -2,28 +2,29 @@
 
 namespace RectorLaravel\ValueObject;
 
+use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Scalar\String_;
 use Webmozart\Assert\Assert;
 
 final readonly class ExpectedClassMethodMethodCalls
 {
     /**
-     * @param MethodCall[] $expectedMethodCalls
-     * @param class-string[] $expectedItems
-     * @param MethodCall[] $notExpectedMethodCalls
-     * @param class-string[] $notExpectedItems
+     * @param  MethodCall[]  $expectedMethodCalls
+     * @param  list<String_|ClassConstFetch>  $expectedItems
+     * @param  MethodCall[]  $notExpectedMethodCalls
+     * @param  list<String_|ClassConstFetch>  $notExpectedItems
      */
     public function __construct(
         private array $expectedMethodCalls = [],
         private array $expectedItems = [],
         private array $notExpectedMethodCalls = [],
         private array $notExpectedItems = []
-    )
-    {
+    ) {
         Assert::allIsInstanceOf($this->expectedMethodCalls, MethodCall::class);
         Assert::allIsInstanceOf($this->notExpectedMethodCalls, MethodCall::class);
-        Assert::allString($this->expectedItems);
-        Assert::allString($this->notExpectedItems);
+        Assert::allIsInstanceOfAny($this->expectedItems, [String_::class, ClassConstFetch::class]);
+        Assert::allIsInstanceOfAny($this->expectedItems, [String_::class, ClassConstFetch::class]);
     }
 
     public function isActionable(): bool
@@ -48,23 +49,23 @@ final readonly class ExpectedClassMethodMethodCalls
     }
 
     /**
-     * @return class-string[]
+     * @return list<String_|ClassConstFetch>
      */
     public function getItemsToFake(): array
     {
-        return array_unique(array_merge($this->expectedItems, $this->notExpectedItems));
+        return array_unique(array_merge($this->expectedItems, $this->notExpectedItems), SORT_REGULAR);
     }
 
     /**
-     * @return class-string[]
+     * @return list<String_|ClassConstFetch>
      */
     public function getExpectedItems(): array
     {
-        return array_unique($this->expectedItems);
+        return array_unique($this->expectedItems, SORT_REGULAR);
     }
 
     /**
-     * @return class-string[]
+     * @return list<String_|ClassConstFetch>
      */
     public function getNotExpectedItems(): array
     {

--- a/tests/Rector/Class_/ReplaceExpectsMethodsInTestsRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/ReplaceExpectsMethodsInTestsRector/Fixture/fixture.php.inc
@@ -4,12 +4,13 @@ namespace RectorLaravel\Tests\Rector\Class_\ReplaceExpectsMethodsInTestsRector\F
 
 use Illuminate\Foundation\Testing\TestCase;
 
-class BaseTest extends TestCase
+class Fixture extends TestCase
 {
     public function testSomething()
     {
         $this->expectsJobs([\App\Jobs\SomeJob::class, \App\Jobs\SomeOtherJob::class]);
         $this->expectsEvents(\App\Events\SomeEvent::class);
+        $this->doesntExpectEvents(\App\Events\SomeOtherEvent::class);
 
         $this->get('/');
     }
@@ -22,17 +23,17 @@ namespace RectorLaravel\Tests\Rector\Class_\ReplaceExpectsMethodsInTestsRector\F
 
 use Illuminate\Foundation\Testing\TestCase;
 
-class BaseTest extends TestCase
+class Fixture extends TestCase
 {
     public function testSomething()
     {
         \Illuminate\Support\Facades\Bus::fake([\App\Jobs\SomeJob::class, \App\Jobs\SomeOtherJob::class]);
-        \Illuminate\Support\Facades\Event::fake([\App\Events\SomeEvent::class]);
-
+        \Illuminate\Support\Facades\Event::fake([\App\Events\SomeEvent::class, \App\Events\SomeOtherEvent::class]);
         $this->get('/');
         \Illuminate\Support\Facades\Bus::assertDispatched(\App\Jobs\SomeJob::class);
         \Illuminate\Support\Facades\Bus::assertDispatched(\App\Jobs\SomeOtherJob::class);
         \Illuminate\Support\Facades\Event::assertDispatched(\App\Events\SomeEvent::class);
+        \Illuminate\Support\Facades\Event::assertNotDispatched(\App\Events\SomeOtherEvent::class);
     }
 }
 ?>


### PR DESCRIPTION
# Changes

* refactors the ReplaceExpectsMethodsInTestsRector rule to handle more scenarios
* adds new tests
* Adds new ExpectedClassMethodMethodCalls value object
* Adds new DispatchableTestsMethodsFactory node factory
* Adds new ExpectedClassMethodAnalyzer analyser

# Why

The original version while working was a bit basic and only covered `expectsJobs` and `expectsEvents`. It never found any uses of `doesntExpectJobs` and `doesntExpectEvents` because it just felt too complex to make happen within a single rule.

The rule now handles it nicely.

```diff
 use Illuminate\Foundation\Testing\TestCase;

 class SomethingTest extends TestCase
 {
     public function testSomething()
     {
-        $this->expectsJobs([\App\Jobs\SomeJob::class, \App\Jobs\SomeOtherJob::class]);
-        $this->expectsEvents(\App\Events\SomeEvent::class);
-        $this->doesntExpectEvents(\App\Events\SomeOtherEvent::class);
+        \Illuminate\Support\Facades\Bus::fake([\App\Jobs\SomeJob::class, \App\Jobs\SomeOtherJob::class]);
+        \Illuminate\Support\Facades\Event::fake([\App\Events\SomeEvent::class, \App\Events\SomeOtherEvent::class]);

         $this->get('/');
+
+        \Illuminate\Support\Facades\Bus::assertDispatched(\App\Jobs\SomeJob::class);
+        \Illuminate\Support\Facades\Bus::assertDispatched(\App\Jobs\SomeOtherJob::class);
+        \Illuminate\Support\Facades\Event::assertDispatched(\App\Events\SomeEvent::class);
+        \Illuminate\Support\Facades\Event::assertNotDispatched(\App\Events\SomeOtherEvent::class);
     }
 }
```