### PR TITLE
Remove LogManager from the Static to Injection set

### DIFF
--- a/config/sets/laravel-static-to-injection.php
+++ b/config/sets/laravel-static-to-injection.php
@@ -111,7 +111,6 @@ return static function (RectorConfig $rectorConfig): void {
                 'Illuminate\Translation\Translator',
                 '*'
             ),
-            new StaticCallToMethodCall('Illuminate\Support\Facades\Log', '*', 'Illuminate\Log\LogManager', '*'),
             new StaticCallToMethodCall('Illuminate\Support\Facades\Mail', '*', 'Illuminate\Mail\Mailer', '*'),
             new StaticCallToMethodCall(
                 'Illuminate\Support\Facades\Notification',


### PR DESCRIPTION
Fixes #303.

The LogManager instance required an App instance since at least 5.8. The configuration in the set does not work at all.