### PR TITLE
Scope to use attribute rule

### DIFF
--- a/config/sets/laravel120.php
+++ b/config/sets/laravel120.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\ClassMethod\ScopeNamedClassMethodToScopeAttributedClassMethodRector;
 use RectorLaravel\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector;
 
 // see https://laravel.com/docs/12.x/upgrade
@@ -11,4 +12,6 @@ return static function (RectorConfig $rectorConfig): void {
 
     // https://github.com/laravel/framework/pull/54628
     $rectorConfig->rule(ContainerBindConcreteWithClosureOnlyRector::class);
+
+    $rectorConfig->rule(ScopeNamedClassMethodToScopeAttributedClassMethodRector::class);
 };

--- a/config/sets/laravel120.php
+++ b/config/sets/laravel120.php
@@ -12,6 +12,6 @@ return static function (RectorConfig $rectorConfig): void {
 
     // https://github.com/laravel/framework/pull/54628
     $rectorConfig->rule(ContainerBindConcreteWithClosureOnlyRector::class);
-
+    // https://github.com/laravel/framework/pull/54450
     $rectorConfig->rule(ScopeNamedClassMethodToScopeAttributedClassMethodRector::class);
 };

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 77 Rules Overview
+# 78 Rules Overview
 
 ## AbortIfRector
 
@@ -1325,6 +1325,26 @@ Use PHP callable syntax instead of string syntax for controller route declaratio
 
 <br>
 
+## ScopeNamedClassMethodToScopeAttributedClassMethodRector
+
+Changes model scope methods to use the scope attribute
+
+- class: [`RectorLaravel\Rector\ClassMethod\ScopeNamedClassMethodToScopeAttributedClassMethodRector`](../src/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector.php)
+
+```diff
+ class User extends Model
+ {
+-    public function scopeActive($query)
++    #[\Illuminate\Database\Eloquent\Attributes\Scope]
++    public function active($query)
+     {
+         return $query->where('active', 1);
+     }
+ }
+```
+
+<br>
+
 ## ServerVariableToRequestFacadeRector
 
 Change server variable to Request facade's server method
@@ -1459,12 +1479,8 @@ Use the base collection methods instead of their aliases.
  $collection = new Collection([0, 1, null, -1]);
 -$collection->average();
 -$collection->some(fn (?int $number): bool => is_null($number));
--$collection->unlessEmpty(fn(Collection $collection) => $collection->push('Foo'));
--$collection->unlessNotEmpty(fn(Collection $collection) => $collection->push('Foo'));
 +$collection->avg();
 +$collection->contains(fn (?int $number): bool => is_null($number));
-+$collection->whenNotEmpty(fn(Collection $collection) => $collection->push('Foo'));
-+$collection->whenEmpty(fn(Collection $collection) => $collection->push('Foo'));
 ```
 
 <br>

--- a/src/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector.php
+++ b/src/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ObjectType;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
+use RectorLaravel\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\ClassMethod\ScopeNamedClassMethodToScopeAttributedClassMethodRector\ScopeNamedClassMethodToScopeAttributedClassMethodRectorTest
+ */
+final class ScopeNamedClassMethodToScopeAttributedClassMethodRector extends AbstractRector
+{
+    private const string SCOPE_ATTRIBUTE = 'Illuminate\Database\Eloquent\Attributes\Scope';
+
+    public function __construct(
+        private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {}
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes model scope methods to use the scope attribute',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+class User extends Model
+{
+    public function scopeActive($query)
+    {
+        return $query->where('active', 1);
+    }
+}
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+class User extends Model
+{
+    #[\Illuminate\Database\Eloquent\Attributes\Scope]
+    public function active($query)
+    {
+        return $query->where('active', 1);
+    }
+}
+CODE_SAMPLE
+            )]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param  Class_  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isObjectType($node, new ObjectType('Illuminate\Database\Eloquent\Model'))) {
+            return null;
+        }
+
+        if (! is_string($className = $this->getName($node))) {
+            return null;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+
+        $changes = false;
+        foreach ($node->getMethods() as $classMethod) {
+            $name = $this->getName($classMethod);
+            // make sure it starts with scope and the next character is upper case
+            if (! str_starts_with($name, 'scope') || ! ctype_upper(substr($name, 5, 1))) {
+                continue;
+            }
+
+            $newName = lcfirst(str_replace('scope', '', $name));
+
+            if ($classReflection->hasMethod($newName)) {
+                continue;
+            }
+
+            if ($this->phpAttributeAnalyzer->hasPhpAttribute($classMethod, self::SCOPE_ATTRIBUTE)) {
+                continue;
+            }
+
+            $classMethod->name = new Identifier($newName);
+            $classMethod->attrGroups[] = new AttributeGroup([new Attribute(new FullyQualified(self::SCOPE_ATTRIBUTE))]);
+            $changes = true;
+        }
+
+        if ($changes === false) {
+            return null;
+        }
+
+        return $node;
+    }
+}

--- a/tests/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector/Fixture/fixture.php.inc
+++ b/tests/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector/Fixture/fixture.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ScopeNamedClassMethodToScopeAttributedClassMethodRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SomeClass extends Model
+{
+    public function scopeSomeMethod()
+    {
+
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\ScopeNamedClassMethodToScopeAttributedClassMethodRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SomeClass extends Model
+{
+    #[\Illuminate\Database\Eloquent\Attributes\Scope]
+    public function someMethod()
+    {
+
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector/Fixture/non_duplicate_nodes.php.inc
+++ b/tests/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector/Fixture/non_duplicate_nodes.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ScopeNamedClassMethodToScopeAttributedClassMethodRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class NonDuplicateAttributeNodes extends Model
+{
+    #[\Illuminate\Database\Eloquent\Attributes\Scope]
+    public function scopeSomeMethod()
+    {
+
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector/Fixture/non_matching_methods.php.inc
+++ b/tests/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector/Fixture/non_matching_methods.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ScopeNamedClassMethodToScopeAttributedClassMethodRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class NonMatchingMethods extends Model
+{
+    public function scopefoo()
+    {
+
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector/Fixture/non_method_duplicate.php.inc
+++ b/tests/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector/Fixture/non_method_duplicate.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ScopeNamedClassMethodToScopeAttributedClassMethodRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class NonDuplicateMethod extends Model
+{
+    public function scopeSomeMethod()
+    {
+
+    }
+
+    public function someMethod()
+    {
+
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector/Fixture/non_model_class.php.inc
+++ b/tests/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector/Fixture/non_model_class.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ScopeNamedClassMethodToScopeAttributedClassMethodRector\Fixture;
+
+class NonModelClass
+{
+    public function scopeSomeMethod()
+    {
+
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector/ScopeNamedClassMethodToScopeAttributedClassMethodRectorTest.php
+++ b/tests/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector/ScopeNamedClassMethodToScopeAttributedClassMethodRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\ScopeNamedClassMethodToScopeAttributedClassMethodRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ScopeNamedClassMethodToScopeAttributedClassMethodRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector/config/configured_rule.php
+++ b/tests/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\ClassMethod\ScopeNamedClassMethodToScopeAttributedClassMethodRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ScopeNamedClassMethodToScopeAttributedClassMethodRector::class);
+};


### PR DESCRIPTION
# Changes

* creates the new rule and adds it to the Laravel 12 set.
* adds tests
* updates docs

# Why

Added in Laravel 12 https://github.com/laravel/framework/pull/54450

```diff
 class User extends Model
 {
-    public function scopeActive($query)
+    #[\Illuminate\Database\Eloquent\Attributes\Scope]
+    public function active($query)
     {
         return $query->where('active', 1);
     }
 }
```
