### PR TITLE
Assert class to type hinted closure

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 78 Rules Overview
+# 79 Rules Overview
 
 ## AbortIfRector
 
@@ -329,6 +329,21 @@ Replace `(new \Illuminate\Testing\TestResponse)->assertStatus(200)` with `(new \
 +        $this->get('/')->assertServiceUnavailable();
      }
  }
+```
+
+<br>
+
+## AssertWithClassStringToTypeHintedClosureRector
+
+Changes assert calls to use a type hinted closure.
+
+- class: [`RectorLaravel\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector`](../src/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector.php)
+
+```diff
+-Bus::assertDispatched(OrderCreated::class, function ($job) {
++Bus::assertDispatched(function (OrderCreated $job) {
+     return true;
+ });
 ```
 
 <br>

--- a/src/NodeAnalyzer/FacadeAssertionAnalyzer.php
+++ b/src/NodeAnalyzer/FacadeAssertionAnalyzer.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace RectorLaravel\NodeAnalyzer;
+
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Type\ObjectType;
+use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\NodeTypeResolver\NodeTypeResolver;
+
+final readonly class FacadeAssertionAnalyzer
+{
+    public function __construct(
+        private NodeTypeResolver $nodeTypeResolver,
+        private NodeNameResolver $nodeNameResolver,
+    ) {}
+
+    public function isFacadeAssertion(StaticCall $staticCall): bool
+    {
+        return match (true) {
+            $this->nodeTypeResolver->isObjectType($staticCall->class, new ObjectType('Illuminate\Support\Facades\Bus'))
+            && $this->nodeNameResolver->isName($staticCall->name, 'assertDispatched') => true,
+            $this->nodeTypeResolver->isObjectType($staticCall->class, new ObjectType('Illuminate\Support\Facades\Event'))
+            && $this->nodeNameResolver->isName($staticCall->name, 'assertDispatched') => true,
+            default => false,
+        };
+    }
+}

--- a/src/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector.php
+++ b/src/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\StaticCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name\FullyQualified;
+use RectorLaravel\AbstractRector;
+use RectorLaravel\NodeAnalyzer\FacadeAssertionAnalyzer;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector\AssertWithClassStringToTypeHintedClosureRectorTest
+ */
+final class AssertWithClassStringToTypeHintedClosureRector extends AbstractRector
+{
+    public function __construct(
+        private readonly FacadeAssertionAnalyzer $facadeAssertionAnalyzer
+    ) {}
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes assert calls to use a type hinted closure.',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+Bus::assertDispatched(OrderCreated::class, function ($job) {
+    return true;
+});
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+Bus::assertDispatched(function (OrderCreated $job) {
+    return true;
+});
+CODE_SAMPLE
+            )]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [StaticCall::class];
+    }
+
+    /**
+     * @param  StaticCall  $node
+     */
+    public function refactor(Node $node): ?StaticCall
+    {
+        if (! $this->facadeAssertionAnalyzer->isFacadeAssertion($node)) {
+            return null;
+        }
+
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
+        if (count($node->getArgs()) !== 2) {
+            return null;
+        }
+
+        if (
+            (! $node->args[1]->value instanceof Closure
+            && ! $node->args[1]->value instanceof ArrowFunction)
+            || ! isset($node->args[1]->value->params[0])
+        ) {
+            return null;
+        }
+
+        $type = $this->getType($node->args[0]->value);
+
+        $classString = match (true) {
+            $type->isClassString()->yes() => $type->getClassStringObjectType()->getClassName(),
+            $type->isString()->yes()
+                && $type->getClassStringObjectType()->isObject()->yes() => $type->getClassStringObjectType()->getClassName(),
+            default => null,
+        };
+
+        if (! is_string($classString)) {
+            return null;
+        }
+
+        return $this->refactorClosure($node, $classString);
+    }
+
+    public function refactorClosure(StaticCall $staticCall, string $class): StaticCall
+    {
+        $closure = $staticCall->args[1]->value;
+
+        $closure->params[0]->type = new FullyQualified($class);
+
+        $staticCall->args = [
+            new Arg($closure),
+        ];
+
+        return $staticCall;
+    }
+}

--- a/tests/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector/AssertWithClassStringToTypeHintedClosureRectorTest.php
+++ b/tests/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector/AssertWithClassStringToTypeHintedClosureRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AssertWithClassStringToTypeHintedClosureRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector/Fixture/fixture.php.inc
+++ b/tests/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector/Fixture/fixture.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector\Fixture;
+
+use RectorLaravel\Tests\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector\Source\SomeClass;
+
+\Illuminate\Support\Facades\Bus::assertDispatched(
+    SomeClass::class,
+    function ($job) {
+        return true;
+    }
+);
+
+\Illuminate\Support\Facades\Bus::assertDispatched(
+    'RectorLaravel\Tests\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector\Source\SomeClass',
+    function ($job) {
+        return true;
+    }
+);
+
+\Illuminate\Support\Facades\Bus::assertDispatched(
+    SomeClass::class,
+    fn ($job) => true,
+);
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector\Fixture;
+
+use RectorLaravel\Tests\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector\Source\SomeClass;
+
+\Illuminate\Support\Facades\Bus::assertDispatched(function (\RectorLaravel\Tests\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector\Source\SomeClass $job) {
+    return true;
+});
+
+\Illuminate\Support\Facades\Bus::assertDispatched(function (\RectorLaravel\Tests\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector\Source\SomeClass $job) {
+    return true;
+});
+
+\Illuminate\Support\Facades\Bus::assertDispatched(fn (\RectorLaravel\Tests\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector\Source\SomeClass $job) => true);
+
+?>

--- a/tests/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector/Fixture/skip_first_class_callable.php.inc
+++ b/tests/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector/Fixture/skip_first_class_callable.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector\Fixture;
+
+\Illuminate\Support\Facades\Bus::assertDispatched(...);
+
+?>

--- a/tests/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector/Fixture/skip_missing_closure_param.php.inc
+++ b/tests/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector/Fixture/skip_missing_closure_param.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector\Fixture;
+
+\Illuminate\Support\Facades\Bus::assertDispatched(
+    'RectorLaravel\Tests\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector\Source\SomeClass',
+    function () {}
+);
+
+?>

--- a/tests/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector/Fixture/skip_non_closure_arg.php.inc
+++ b/tests/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector/Fixture/skip_non_closure_arg.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector\Fixture;
+
+\Illuminate\Support\Facades\Bus::assertDispatched(
+    'RectorLaravel\Tests\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector\Source\SomeClass',
+);
+
+?>

--- a/tests/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector/Fixture/skip_non_existing_class.php.inc
+++ b/tests/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector/Fixture/skip_non_existing_class.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector\Fixture;
+
+\Illuminate\Support\Facades\Bus::assertDispatched(
+    'FooBar',
+    function ($job) {
+        return true;
+    }
+);
+
+?>

--- a/tests/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector/Fixture/skip_non_matching_static_method_call.php.inc
+++ b/tests/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector/Fixture/skip_non_matching_static_method_call.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector\Fixture;
+
+\Illuminate\Support\Facades\FooBar::assertDispatched(
+    'RectorLaravel\Tests\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector\Source\SomeClass',
+    function ($job) {
+        return true;
+    }
+);
+
+\Illuminate\Support\Facades\Bus::assertDispatchedFoo(
+    'RectorLaravel\Tests\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector\Source\SomeClass',
+    function ($job) {
+        return true;
+    }
+);
+
+?>

--- a/tests/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector/Source/SomeClass.php
+++ b/tests/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector/Source/SomeClass.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector\Source;
+
+class SomeClass {}

--- a/tests/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector/config/configured_rule.php
+++ b/tests/Rector/StaticCall/AssertWithClassStringToTypeHintedClosureRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\StaticCall\AssertWithClassStringToTypeHintedClosureRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AssertWithClassStringToTypeHintedClosureRector::class);
+};


### PR DESCRIPTION
# Changes

* Adds `AssertWithClassStringToTypeHintedClosureRector` rule.
* Adds a `FacadeAssertionAnalyzer` class.
* Adds tests for the rule.
* Updates the docs.

# Why

Helps remove a redundant argument to the use of assertDispatched.

```diff
-Bus::assertDispatched(OrderCreated::class, function ($job) {
+Bus::assertDispatched(function (OrderCreated $job) {
     return true;
 });
```

# Notes

This can probably be expanded further but I've left it as just Event and Bus assertDispatch calls.