### PR TITLE
Stop overriding previous tags

### DIFF
--- a/src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php
+++ b/src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php
@@ -390,6 +390,7 @@ CODE_SAMPLE
 
         if (
             $this->typeComparator->areTypesEqual($phpDocTypes[0], new ObjectType($relatedClass))
+            && count($phpDocTypes) > 1
             && $phpDocTypes[1] instanceof ThisType
             && ! $relationUsesPivots
         ) {

--- a/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Fixture/NewGenerics/skip-already-set-generic.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Fixture/NewGenerics/skip-already-set-generic.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Fixture\NewGenerics;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use RectorLaravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Source\SomeModel;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class SkipAlreadySetGeneric extends Model
+{
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<SomeModel, $this>
+     */
+    public function account(): BelongsTo
+    {
+        return $this->belongsTo(SomeModel::class);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<SomeModel, $this>
+     */
+    public function posts(): HasMany
+    {
+        return $this->hasMany(SomeModel::class);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<SomeModel, $this, Pivot>
+     */
+    public function comments(): BelongsToMany
+    {
+        return $this->belongsToMany(SomeModel::class);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany<SomeModel, $this, Pivot>
+     */
+    public function photos(): MorphToMany
+    {
+        return $this->morphToMany(SomeModel::class);
+    }
+}
+?>


### PR DESCRIPTION
# Changes

- AddGenericReturnTypeToRelationsRector updates
- additional test scenario for AddGenericReturnTypeToRelationsRector

# Why

Reported by @brunogaspar  that the rule was working okay but would overwrite tags with a fully qualified name even when the tag was already correct.

This PR seeks to change the situation so if the tag exists, then it will not apply any changes.

Looking at this rule. There's a few changes that might be required when it comes to the pivot changes that were added in #316. I have a feeling relationships like MorphToMany haven't been considered and it should probably assign the Pivot class if the relationship uses one.