### PR TITLE
Add `Context` to facade-aliases-to-full-names

### DIFF
--- a/config/sets/laravel-facade-aliases-to-full-names.php
+++ b/config/sets/laravel-facade-aliases-to-full-names.php
@@ -18,6 +18,7 @@ return static function (RectorConfig $rectorConfig): void {
         'Bus' => 'Illuminate\Support\Facades\Bus',
         'Cache' => 'Illuminate\Support\Facades\Cache',
         'Config' => 'Illuminate\Support\Facades\Config',
+        'Context' => 'Illuminate\Support\Facades\Context',
         'Cookie' => 'Illuminate\Support\Facades\Cookie',
         'Crypt' => 'Illuminate\Support\Facades\Crypt',
         'Date' => 'Illuminate\Support\Facades\Date',


### PR DESCRIPTION
Noticed that Context was missing so I went ahead and added it.