### PR TITLE
Fix test warnings

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,6 +6,7 @@
     colors="true"
     executionOrder="defects"
     cacheDirectory=".phpunit.cache"
+    displayDetailsOnTestsThatTriggerWarnings="true"
 >
     <testsuites>
         <testsuite name="main">

--- a/src/Rector/ClassMethod/MigrateToSimplifiedAttributeRector.php
+++ b/src/Rector/ClassMethod/MigrateToSimplifiedAttributeRector.php
@@ -55,6 +55,8 @@ final class MigrateToSimplifiedAttributeRector extends AbstractRector
 
         $classMethods = $node->getMethods();
 
+        $hasChanged = false;
+
         foreach ($node->stmts as $key => $stmt) {
             if (! $stmt instanceof ClassMethod) {
                 continue;
@@ -68,12 +70,17 @@ final class MigrateToSimplifiedAttributeRector extends AbstractRector
 
             if ($newNode instanceof ClassMethod) {
                 $node->stmts[$key] = $newNode;
+                $hasChanged = true;
             } elseif ($newNode === NodeVisitor::REMOVE_NODE) {
                 unset($node->stmts[$key]);
+                $hasChanged = true;
             }
         }
 
-        return $node;
+        return $hasChanged
+            ? $node
+            : null;
+
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/src/Rector/Class_/ReplaceExpectsMethodsInTestsRector.php
+++ b/src/Rector/Class_/ReplaceExpectsMethodsInTestsRector.php
@@ -87,6 +87,8 @@ CODE_SAMPLE
             return null;
         }
 
+        $hasChanged = false;
+
         foreach ($node->getMethods() as $classMethod) {
             $result = $this->expectedClassMethodAnalyzer->findExpectedJobCallsWithClassMethod($classMethod);
 
@@ -96,6 +98,7 @@ CODE_SAMPLE
 
             if ($result->isActionable()) {
                 $this->fixUpClassMethod($classMethod, $result, 'Illuminate\Support\Facades\Bus');
+                $hasChanged = true;
             }
 
             $result = $this->expectedClassMethodAnalyzer->findExpectedEventCallsWithClassMethod($classMethod);
@@ -106,10 +109,14 @@ CODE_SAMPLE
 
             if ($result->isActionable()) {
                 $this->fixUpClassMethod($classMethod, $result, 'Illuminate\Support\Facades\Event');
+                $hasChanged = true;
             }
         }
 
-        return $node;
+        return $hasChanged
+            ? $node
+            : null;
+
     }
 
     private function fixUpClassMethod(

--- a/src/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector.php
+++ b/src/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector.php
@@ -112,7 +112,9 @@ CODE_SAMPLE
 
     private function isAllowedPattern(MethodCall $methodCall): bool
     {
-        $columnArg = $methodCall->args[0] instanceof Arg ? $methodCall->args[0]->value : null;
+        $columnArg = $methodCall->args !== [] && $methodCall->args[0] instanceof Arg
+            ? $methodCall->args[0]->value
+            : null;
 
         // If no patterns are specified, consider all column names as matching
         if ($this->allowedPatterns === []) {

--- a/src/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector.php
+++ b/src/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector.php
@@ -142,19 +142,19 @@ CODE_SAMPLE
         return false;
     }
 
-    private function convertOrderByToLatest(MethodCall $methodCall): MethodCall
+    private function convertOrderByToLatest(MethodCall $methodCall): ?MethodCall
     {
         if (! isset($methodCall->args[0]) && ! $methodCall->args[0] instanceof VariadicPlaceholder) {
-            return $methodCall;
+            return null;
         }
 
         $columnVar = $methodCall->args[0] instanceof Arg ? $methodCall->args[0]->value : null;
         if (! $columnVar instanceof Expr) {
-            return $methodCall;
+            return null;
         }
 
         if (isset($methodCall->args[1]) && (! $methodCall->args[1] instanceof Arg || ! $methodCall->args[1]->value instanceof String_)) {
-            return $methodCall;
+            return null;
         }
 
         if (isset($methodCall->args[1]) && $methodCall->args[1] instanceof Arg && $methodCall->args[1]->value instanceof String_) {

--- a/src/Rector/MethodCall/UseComponentPropertyWithinCommandsRector.php
+++ b/src/Rector/MethodCall/UseComponentPropertyWithinCommandsRector.php
@@ -78,22 +78,35 @@ CODE_SAMPLE
             return null;
         }
 
+        $hasChanged = false;
+
         foreach ($node->stmts as $key => $stmt) {
             if (! $stmt instanceof ClassMethod) {
                 continue;
             }
 
-            $node->stmts[$key] = $this->refactorClassMethod($stmt);
+            $changedClassMethod = $this->refactorClassMethod($stmt);
+
+            if ($changedClassMethod instanceof ClassMethod) {
+                $node->stmts[$key] = $changedClassMethod;
+
+                $hasChanged = true;
+            }
         }
 
-        return $node;
+        return $hasChanged
+            ? $node
+            : null;
+
     }
 
-    private function refactorClassMethod(ClassMethod $classMethod): ClassMethod
+    private function refactorClassMethod(ClassMethod $classMethod): ?ClassMethod
     {
         if ($classMethod->stmts === null) {
-            return $classMethod;
+            return null;
         }
+
+        $hasChanged = false;
 
         foreach ($classMethod->stmts as $stmt) {
             if (! $stmt instanceof Expression) {
@@ -123,8 +136,12 @@ CODE_SAMPLE
 
             $stmt->expr->var =
                 new PropertyFetch(new Variable('this'), 'components');
+
+            $hasChanged = true;
         }
 
-        return $classMethod;
+        return $hasChanged
+            ? $classMethod
+            : null;
     }
 }


### PR DESCRIPTION
New warnings coming from core Rector because of a new check for unchanged nodes that are still returned from the `refactor()` method. This causes an unnecessary performance hit, however small.