### PR TITLE
Change method visibility to protected for scope methods

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1362,7 +1362,7 @@ Changes model scope methods to use the scope attribute
  {
 -    public function scopeActive($query)
 +    #[\Illuminate\Database\Eloquent\Attributes\Scope]
-+    public function active($query)
++    protected function active($query)
      {
          return $query->where('active', 1);
      }

--- a/src/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector.php
+++ b/src/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace RectorLaravel\Rector\ClassMethod;
 
+use PhpParser\Modifiers;
 use PhpParser\Node;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\AttributeGroup;
@@ -98,6 +99,7 @@ CODE_SAMPLE
                 continue;
             }
 
+            $classMethod->flags = Modifiers::PROTECTED;
             $classMethod->name = new Identifier($newName);
             $classMethod->attrGroups[] = new AttributeGroup([new Attribute(new FullyQualified(self::SCOPE_ATTRIBUTE))]);
             $changes = true;

--- a/tests/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector/Fixture/fixture.php.inc
+++ b/tests/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector/Fixture/fixture.php.inc
@@ -23,7 +23,7 @@ use Illuminate\Database\Eloquent\Model;
 class SomeClass extends Model
 {
     #[\Illuminate\Database\Eloquent\Attributes\Scope]
-    public function someMethod()
+    protected function someMethod()
     {
 
     }

--- a/tests/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector/Fixture/non_duplicate_nodes.php.inc
+++ b/tests/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector/Fixture/non_duplicate_nodes.php.inc
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 class NonDuplicateAttributeNodes extends Model
 {
     #[\Illuminate\Database\Eloquent\Attributes\Scope]
-    public function scopeSomeMethod()
+    protected function scopeSomeMethod()
     {
 
     }


### PR DESCRIPTION
# Changes
- Changed access modifier from public to protected.

# Why
[Laravel Doc](https://laravel.com/docs/12.x/eloquent#local-scopes) suggests to use protected access modifier.
When I was upgrading my project,I noticed that if the scope had the public modifier then the scope wasn't working.

example error message
```php
// if I call like this
$post->published()->get();

ArgumentCountError: Too few arguments to function App\Models\Post::published(), 0 passed in /test-app/tests/Unit/PostTest.php on line 69 and exactly 1 expected


// if I call like this
Post::published()->get();

Error: Non-static method App\Models\Post::published() cannot be called statically
```

scope
```php
#[Scope]
public function published(Builder $query): void
{
    $query->where('status', PostStatusEnum::PUBLISHED);
}
```