### PR TITLE
Add isset to RequestVariablesToRequestFacade

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1288,12 +1288,18 @@ Change request variable definition in Facade
 -$_POST;
 -$_GET;
 -$_REQUEST;
+-isset($_GET['value']);
+-isset($_POST['value']);
+-isset($_REQUEST['value']);
 +\Illuminate\Support\Facades\Request::query('value');
 +\Illuminate\Support\Facades\Request::post('value');
 +\Illuminate\Support\Facades\Request::input('value');
 +\Illuminate\Support\Facades\Request::query();
 +\Illuminate\Support\Facades\Request::post();
 +\Illuminate\Support\Facades\Request::all();
++\Illuminate\Support\Facades\Request::query('value') !== null;
++\Illuminate\Support\Facades\Request::post('value') !== null;
++\Illuminate\Support\Facades\Request::exists('value');
 ```
 
 <br>

--- a/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/Fixture/fixture_isset.php.inc
+++ b/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/Fixture/fixture_isset.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\RequestVariablesToRequestFacadeRector\Fixture;
+
+if (isset($_GET['a'])) {
+
+}
+
+if (isset($_POST['b'])) {
+
+}
+
+if (isset($_REQUEST['c'])) {
+
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\RequestVariablesToRequestFacadeRector\Fixture;
+
+if (\Illuminate\Support\Facades\Request::query('a') !== null) {
+
+}
+
+if (\Illuminate\Support\Facades\Request::post('b') !== null) {
+
+}
+
+if (\Illuminate\Support\Facades\Request::exists('c')) {
+
+}
+
+?>

--- a/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/Fixture/skip_isset_dim.php.inc
+++ b/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/Fixture/skip_isset_dim.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\RequestVariablesToRequestFacadeRector\Fixture;
+
+$name = "test";
+if (isset($_GET[$name])) {
+
+}
+
+?>


### PR DESCRIPTION
## Changes
- Add isset support to `RequestVariablesToRequestFacade`

## Why
I used this rule on my legacy code base and it broke things because isset can only handle variables. The rule for the session facade works with isset so I added it here as well.

When you look at this you'll see `isset($_REQUEST['a'])` uses `Request::exists('a')` while `$_POST` and `$_GET` use `Request::query('a') !== null` and `Request::post('a') !== null`. The request facade doesn't have a post exists method so I figured it would be better to have it null check.