### PR TITLE
Fix set names in LaravelSetProvider

### DIFF
--- a/src/Set/LaravelSetProvider.php
+++ b/src/Set/LaravelSetProvider.php
@@ -111,18 +111,20 @@ final class LaravelSetProvider implements SetProviderInterface
     {
         $versions = [];
 
+        $totalPostFive = count(self::LARAVEL_POST_FIVE);
         foreach (self::LARAVEL_POST_FIVE as $index => $version) {
             $versions[] = new Set(
                 self::GROUP_NAME,
-                'Laravel Framework ' . ($index + 6) . '.0',
+                'Laravel Framework ' . ($totalPostFive - $index + 5) . '.0',
                 $version,
             );
         }
 
+        $totalFive = count(self::LARAVEL_FIVE);
         foreach (self::LARAVEL_FIVE as $index => $version) {
             $versions[] = new Set(
                 self::GROUP_NAME,
-                'Laravel Framework 5.' . $index,
+                'Laravel Framework 5.' . ($totalFive - $index - 1),
                 $version,
             );
         }

--- a/tests/Sets/LaravelSetProviderTest.php
+++ b/tests/Sets/LaravelSetProviderTest.php
@@ -11,21 +11,22 @@ use RectorLaravel\Set\LaravelSetProvider;
 final class LaravelSetProviderTest extends TestCase
 {
     private const array LARAVEL_VERSION_SETS = [
-        LaravelSetList::LARAVEL_50,
-        LaravelSetList::LARAVEL_51,
-        LaravelSetList::LARAVEL_52,
-        LaravelSetList::LARAVEL_53,
-        LaravelSetList::LARAVEL_54,
-        LaravelSetList::LARAVEL_55,
-        LaravelSetList::LARAVEL_56,
-        LaravelSetList::LARAVEL_57,
-        LaravelSetList::LARAVEL_58,
-        LaravelSetList::LARAVEL_60,
-        LaravelSetList::LARAVEL_70,
-        LaravelSetList::LARAVEL_80,
-        LaravelSetList::LARAVEL_90,
-        LaravelSetList::LARAVEL_100,
-        LaravelSetList::LARAVEL_110,
+        'Laravel Framework 12.0' => LaravelSetList::LARAVEL_120,
+        'Laravel Framework 11.0' => LaravelSetList::LARAVEL_110,
+        'Laravel Framework 10.0' => LaravelSetList::LARAVEL_100,
+        'Laravel Framework 9.0' => LaravelSetList::LARAVEL_90,
+        'Laravel Framework 8.0' => LaravelSetList::LARAVEL_80,
+        'Laravel Framework 7.0' => LaravelSetList::LARAVEL_70,
+        'Laravel Framework 6.0' => LaravelSetList::LARAVEL_60,
+        'Laravel Framework 5.8' => LaravelSetList::LARAVEL_58,
+        'Laravel Framework 5.7' => LaravelSetList::LARAVEL_57,
+        'Laravel Framework 5.6' => LaravelSetList::LARAVEL_56,
+        'Laravel Framework 5.5' => LaravelSetList::LARAVEL_55,
+        'Laravel Framework 5.4' => LaravelSetList::LARAVEL_54,
+        'Laravel Framework 5.3' => LaravelSetList::LARAVEL_53,
+        'Laravel Framework 5.2' => LaravelSetList::LARAVEL_52,
+        'Laravel Framework 5.1' => LaravelSetList::LARAVEL_51,
+        'Laravel Framework 5.0' => LaravelSetList::LARAVEL_50,
     ];
 
     /**
@@ -64,7 +65,7 @@ final class LaravelSetProviderTest extends TestCase
 
         $sets = $laravelSetProvider->provide();
 
-        $sets = array_filter(
+        $filePaths = array_filter(
             array_map(
                 fn (SetInterface $set) => $set->getSetFilePath(),
                 $sets
@@ -72,6 +73,16 @@ final class LaravelSetProviderTest extends TestCase
             fn (string $filePath) => in_array($filePath, self::LARAVEL_VERSION_SETS, true),
         );
 
-        Assert::assertCount(count(self::LARAVEL_VERSION_SETS), $sets);
+        Assert::assertSame(array_values(self::LARAVEL_VERSION_SETS), array_values($filePaths));
+
+        $setNames = array_filter(
+            array_map(
+                fn (SetInterface $set) => $set->getName(),
+                $sets
+            ),
+            fn (string $setName) => in_array($setName, array_keys(self::LARAVEL_VERSION_SETS), true),
+        );
+
+        Assert::assertSame(array_keys(self::LARAVEL_VERSION_SETS), array_values($setNames));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/driftingly/rector-laravel/issues/343.

We generate the set names, but we were doing it in the wrong order :sweat_smile:.

This PR does not solve the issue of sets that show they contain some rules, but those rules don't show up if you select the set. It's the configured ones like `RenameClassRector`.

I'm not sure if that should be fixed in this repository or the [getrector-com](https://github.com/rectorphp/getrector-com) repository.