### PR TITLE
Add RemoveMigrationDocBlockRector rector

### DIFF
--- a/src/Rector/RemoveMigrationDocBlockRector.php
+++ b/src/Rector/RemoveMigrationDocBlockRector.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace App\Rector;
+namespace RectorLaravel\Rector;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
-use Rector\Rector\AbstractRector;
+use RectorLaravel\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 


### PR DESCRIPTION
Cleans up useless phpdoc:

```diff
-/**
- * Run the migrations.
- *
- * @return void
- */
public function up()
{
    // ...
}

-/**
- * Reverse the migrations
- *
- * @return void
- */
public function down()
{
    // ...
}
```
