### PR TITLE
Rule to use Forward calls trait

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 79 Rules Overview
+# 80 Rules Overview
 
 ## AbortIfRector
 
@@ -1560,6 +1560,27 @@ Use `$this->components` property within commands
 +        $this->components->line('A line!');
 +        $this->components->info('Info!');
 +        $this->components->error('Error!');
+     }
+ }
+```
+
+<br>
+
+## UseForwardCallsTraitRector
+
+Replaces the use of `call_user_func` and `call_user_func_array` method with the CallForwarding trait
+
+- class: [`RectorLaravel\Rector\Class_\UseForwardCallsTraitRector`](../src/Rector/Class_/UseForwardCallsTraitRector.php)
+
+```diff
+ class SomeClass
+ {
++    use ForwardCalls;
++
+     public function __call($method, $parameters)
+     {
+-        return call_user_func_array([$this->foo, $method], $parameters);
++        return $this->forwardCallTo($this->foo, $method, $parameters);
      }
  }
 ```

--- a/src/NodeAnalyzer/CallUserFuncAnalyzer.php
+++ b/src/NodeAnalyzer/CallUserFuncAnalyzer.php
@@ -2,13 +2,11 @@
 
 namespace RectorLaravel\NodeAnalyzer;
 
-use PhpParser\Builder\Method;
 use PhpParser\Node\Arg;
 use PhpParser\Node\ArrayItem;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Scalar\String_;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;
@@ -19,10 +17,7 @@ final readonly class CallUserFuncAnalyzer
     public function __construct(
         private NodeNameResolver $nodeNameResolver,
         private NodeTypeResolver $nodeTypeResolver,
-    )
-    {
-
-    }
+    ) {}
 
     public function isCallUserFuncCall(FuncCall $funcCall): bool
     {
@@ -31,7 +26,7 @@ final readonly class CallUserFuncAnalyzer
 
     public function canDetermineMethodFromCallable(FuncCall $funcCall): bool
     {
-        return ($funcCall->args[0] ?? false)
+        return isset($funcCall->args[0]) && $funcCall->args[0] instanceof Arg
             && (
                 $funcCall->args[0]->value instanceof Array_
                 || (
@@ -53,15 +48,16 @@ final readonly class CallUserFuncAnalyzer
             return null;
         }
 
-        $args = $funcCall->args[1]->value ?? new Array_([]);
+        $args = $funcCall->getArgs()[1]->value ?? new Array_([]);
+        $funcArgs = $funcCall->getArgs();
 
         if ($this->nodeNameResolver->isName($funcCall, 'call_user_func')) {
-            $args = $this->argsToArray(array_splice($funcCall->args, 1));
+            $args = $this->argsToArray(array_splice($funcArgs, 1));
         }
 
         if ($firstArg->value instanceof Array_) {
 
-            if (count($firstArg->value->items) <> 2) {
+            if (count($firstArg->value->items) !== 2) {
                 return null;
             }
 
@@ -82,19 +78,24 @@ final readonly class CallUserFuncAnalyzer
             return null;
         }
 
+        if (is_null($this->nodeNameResolver->getName($firstArg->value->name))) {
+            return null;
+        }
+
         return new ForwardingCall(
             $firstArg->value->var,
-            new String_($firstArg->value->name->name),
+            new String_($this->nodeNameResolver->getName($firstArg->value->name)),
             $args
         );
     }
 
     /**
-     * @param Arg[] $args
-     * @return Array_
+     * @param  Arg[]  $args
      */
     private function argsToArray(array $args): Array_
     {
-        return new Array_(array_map(fn(Arg $arg) => new ArrayItem($arg->value), $args));
+        return new Array_(
+            array_map(fn (Arg $arg) => new ArrayItem($arg->value), $args)
+        );
     }
 }

--- a/src/NodeAnalyzer/CallUserFuncAnalyzer.php
+++ b/src/NodeAnalyzer/CallUserFuncAnalyzer.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace RectorLaravel\NodeAnalyzer;
+
+use PhpParser\Builder\Method;
+use PhpParser\Node\Arg;
+use PhpParser\Node\ArrayItem;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Scalar\String_;
+use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\NodeTypeResolver\NodeTypeResolver;
+use RectorLaravel\ValueObject\ForwardingCall;
+
+final readonly class CallUserFuncAnalyzer
+{
+    public function __construct(
+        private NodeNameResolver $nodeNameResolver,
+        private NodeTypeResolver $nodeTypeResolver,
+    )
+    {
+
+    }
+
+    public function isCallUserFuncCall(FuncCall $funcCall): bool
+    {
+        return $this->nodeNameResolver->isNames($funcCall, ['call_user_func', 'call_user_func_array']);
+    }
+
+    public function canDetermineMethodFromCallable(FuncCall $funcCall): bool
+    {
+        return ($funcCall->args[0] ?? false)
+            && (
+                $funcCall->args[0]->value instanceof Array_
+                || (
+                    $funcCall->args[0]->value instanceof MethodCall
+                    && $funcCall->args[0]->value->isFirstClassCallable()
+                )
+            );
+    }
+
+    public function getForwardedMethod(FuncCall $funcCall): ?ForwardingCall
+    {
+        $firstArg = $funcCall->args[0];
+
+        if (! $firstArg instanceof Arg) {
+            return null;
+        }
+
+        if (! $firstArg->value instanceof Array_ && ! $firstArg->value instanceof MethodCall) {
+            return null;
+        }
+
+        $args = $funcCall->args[1]->value ?? new Array_([]);
+
+        if ($this->nodeNameResolver->isName($funcCall, 'call_user_func')) {
+            $args = $this->argsToArray(array_splice($funcCall->args, 1));
+        }
+
+        if ($firstArg->value instanceof Array_) {
+
+            if (count($firstArg->value->items) <> 2) {
+                return null;
+            }
+
+            $type = $this->nodeTypeResolver->getType($firstArg->value->items[0]);
+
+            if ($type->isObject()->no()) {
+                return null;
+            }
+
+            return new ForwardingCall(
+                $firstArg->value->items[0]->value,
+                $firstArg->value->items[1]->value,
+                $args
+            );
+        }
+
+        if (! $firstArg->value->isFirstClassCallable()) {
+            return null;
+        }
+
+        return new ForwardingCall(
+            $firstArg->value->var,
+            new String_($firstArg->value->name->name),
+            $args
+        );
+    }
+
+    /**
+     * @param Arg[] $args
+     * @return Array_
+     */
+    private function argsToArray(array $args): Array_
+    {
+        return new Array_(array_map(fn(Arg $arg) => new ArrayItem($arg->value), $args));
+    }
+}

--- a/src/Rector/Class_/UseForwardCallsTraitRector.php
+++ b/src/Rector/Class_/UseForwardCallsTraitRector.php
@@ -25,14 +25,14 @@ final class UseForwardCallsTraitRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Replaces the use of call_user_function method with the CallForwarding trait',
+            'Replaces the use of `call_user_func` and `call_user_func_array` method with the CallForwarding trait',
             [new CodeSample(
                 <<<'CODE_SAMPLE'
 class SomeClass
 {
     public function __call($method, $parameters)
     {
-        return call_user_function_array([$this->foo, $method], $parameters);
+        return call_user_func_array([$this->foo, $method], $parameters);
     }
 }
 CODE_SAMPLE,

--- a/src/Rector/Class_/UseForwardCallsTraitRector.php
+++ b/src/Rector/Class_/UseForwardCallsTraitRector.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\TraitUse;
+use PhpParser\NodeVisitor;
+use RectorLaravel\AbstractRector;
+use RectorLaravel\NodeAnalyzer\CallUserFuncAnalyzer;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\Class_\UseForwardCallsTraitRector\UseForwardCallsTraitRectorTest
+ */
+final class UseForwardCallsTraitRector extends AbstractRector
+{
+    const FORWARD_CALLS_TRAIT = 'Illuminate\Support\Traits\ForwardCalls';
+
+    public function __construct(private CallUserFuncAnalyzer $callUserFuncAnalyzer)
+    {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replaces the use of call_user_function method with the CallForwarding trait',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function __call($method, $parameters)
+    {
+        return call_user_function_array([$this->foo, $method], $parameters);
+    }
+}
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    use ForwardCalls;
+
+    public function __call($method, $parameters)
+    {
+        return $this->forwardCallTo($this->foo, $method, $parameters);
+    }
+}
+CODE_SAMPLE
+            )]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param  Class_  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->hasCallUserFunctionCalls($node)) {
+            return null;
+        }
+
+        $this->addCallForwardingTrait($node);
+
+        $this->refactorFunctionCalls($node);
+
+        return $node;
+    }
+
+    /**
+     * @param Class_ $class
+     */
+    public function hasCallUserFunctionCalls(Class_ $class): bool
+    {
+        $found = false;
+
+        $this->traverseNodesWithCallable($class->stmts, function (Node $node) use (&$found): ?int {
+            if (! $node instanceof Node\Expr\FuncCall) {
+                return null;
+            }
+
+            if ($node->isFirstClassCallable()) {
+                return null;
+            }
+
+            if (
+                $this->callUserFuncAnalyzer->isCallUserFuncCall($node)
+                && $this->callUserFuncAnalyzer->canDetermineMethodFromCallable($node)
+            ) {
+                $found = true;
+
+                return NodeVisitor::STOP_TRAVERSAL;
+            }
+
+            return null;
+        });
+
+        return $found;
+    }
+
+    private function addCallForwardingTrait(Class_ $node): void
+    {
+        $traitUses = $node->getTraitUses();
+
+        if (count($traitUses) > 0) {
+            foreach ($traitUses as $traitUse) {
+                foreach ($traitUse->traits as $trait) {
+                    if ($this->isName($trait, self::FORWARD_CALLS_TRAIT)) {
+                        return;
+                    }
+                }
+            }
+            $traitUses[0]->traits[] = new Node\Name\FullyQualified(self::FORWARD_CALLS_TRAIT);
+
+            return;
+        }
+
+        $node->stmts = [
+            new TraitUse([new Node\Name\FullyQualified(self::FORWARD_CALLS_TRAIT)]),
+            ...$node->stmts
+        ];
+    }
+
+    private function refactorFunctionCalls(Node|Class_ $node): void
+    {
+        $this->traverseNodesWithCallable($node->stmts, function (Node $node): ?Node {
+            if (! $node instanceof Node\Expr\FuncCall) {
+                return null;
+            }
+
+            if ($this->callUserFuncAnalyzer->isCallUserFuncCall($node)) {
+                $forwardCall = $this->callUserFuncAnalyzer->getForwardedMethod($node);
+
+                if ($forwardCall === null) {
+                    return null;
+                }
+
+                return new Node\Expr\MethodCall(
+                    new Node\Expr\Variable('this'),
+                    'forwardCallTo',
+                    [
+                        new Node\Arg($forwardCall->getObject()),
+                        new Node\Arg($forwardCall->getMethod()),
+                        new Node\Arg($forwardCall->getArgs()),
+                    ]
+                );
+            }
+
+            return null;
+        });
+    }
+}

--- a/src/Rector/Class_/UseForwardCallsTraitRector.php
+++ b/src/Rector/Class_/UseForwardCallsTraitRector.php
@@ -20,9 +20,7 @@ final class UseForwardCallsTraitRector extends AbstractRector
 {
     const FORWARD_CALLS_TRAIT = 'Illuminate\Support\Traits\ForwardCalls';
 
-    public function __construct(private CallUserFuncAnalyzer $callUserFuncAnalyzer)
-    {
-    }
+    public function __construct(private CallUserFuncAnalyzer $callUserFuncAnalyzer) {}
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -77,9 +75,6 @@ CODE_SAMPLE
         return $node;
     }
 
-    /**
-     * @param Class_ $class
-     */
     public function hasCallUserFunctionCalls(Class_ $class): bool
     {
         $found = false;
@@ -127,11 +122,11 @@ CODE_SAMPLE
 
         $node->stmts = [
             new TraitUse([new Node\Name\FullyQualified(self::FORWARD_CALLS_TRAIT)]),
-            ...$node->stmts
+            ...$node->stmts,
         ];
     }
 
-    private function refactorFunctionCalls(Node|Class_ $node): void
+    private function refactorFunctionCalls(Class_ $node): void
     {
         $this->traverseNodesWithCallable($node->stmts, function (Node $node): ?Node {
             if (! $node instanceof Node\Expr\FuncCall) {

--- a/src/ValueObject/ForwardingCall.php
+++ b/src/ValueObject/ForwardingCall.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace RectorLaravel\ValueObject;
+
+use PhpParser\Node\Expr;
+
+final readonly class ForwardingCall
+{
+    public function __construct(
+        private Expr $object,
+        private Expr $method,
+        private Expr $args,
+    )
+    {
+    }
+
+    public function getObject(): Expr
+    {
+        return $this->object;
+    }
+
+
+    public function getMethod(): Expr
+    {
+        return $this->method;
+    }
+
+    public function getArgs(): Expr
+    {
+        return $this->args;
+    }
+}

--- a/src/ValueObject/ForwardingCall.php
+++ b/src/ValueObject/ForwardingCall.php
@@ -10,15 +10,12 @@ final readonly class ForwardingCall
         private Expr $object,
         private Expr $method,
         private Expr $args,
-    )
-    {
-    }
+    ) {}
 
     public function getObject(): Expr
     {
         return $this->object;
     }
-
 
     public function getMethod(): Expr
     {

--- a/tests/Rector/Class_/UseForwardCallsTraitRector/Fixture/dont_duplicate_trait.php.inc
+++ b/tests/Rector/Class_/UseForwardCallsTraitRector/Fixture/dont_duplicate_trait.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\UseForwardCallsTraitRector\Fixture;
+
+class DontDuplicateTrait
+{
+    use \Illuminate\Support\Traits\ForwardCalls;
+    private SomeCall $foo;
+
+    public function __call($method, $args)
+    {
+        return call_user_func_array([$this->foo, $method], $args);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\UseForwardCallsTraitRector\Fixture;
+
+class DontDuplicateTrait
+{
+    use \Illuminate\Support\Traits\ForwardCalls;
+    private SomeCall $foo;
+
+    public function __call($method, $args)
+    {
+        return $this->forwardCallTo($this->foo, $method, $args);
+    }
+}
+
+?>

--- a/tests/Rector/Class_/UseForwardCallsTraitRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/UseForwardCallsTraitRector/Fixture/fixture.php.inc
@@ -1,0 +1,52 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\UseForwardCallsTraitRector\Fixture;
+
+class Fixture
+{
+    private SomeCall $foo;
+
+    public function __call($method, $args)
+    {
+        return call_user_func_array([$this->foo, $method], $args);
+    }
+
+    public function another($arg)
+    {
+        return call_user_func([$this->foo, 'another'], 'a', $arg);
+    }
+
+    public function foobar($arg)
+    {
+        return call_user_func([$this->foo, 'another']);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\UseForwardCallsTraitRector\Fixture;
+
+class Fixture
+{
+    use \Illuminate\Support\Traits\ForwardCalls;
+    private SomeCall $foo;
+
+    public function __call($method, $args)
+    {
+        return $this->forwardCallTo($this->foo, $method, $args);
+    }
+
+    public function another($arg)
+    {
+        return $this->forwardCallTo($this->foo, 'another', ['a', $arg]);
+    }
+
+    public function foobar($arg)
+    {
+        return $this->forwardCallTo($this->foo, 'another', []);
+    }
+}
+
+?>

--- a/tests/Rector/Class_/UseForwardCallsTraitRector/Fixture/skip_complex_func_call.php.inc
+++ b/tests/Rector/Class_/UseForwardCallsTraitRector/Fixture/skip_complex_func_call.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\UseForwardCallsTraitRector\Fixture;
+
+class SkipComplexFuncCall
+{
+    public function __call($method, $args)
+    {
+        return call_user_func($this->foo, $args);
+    }
+}
+
+?>

--- a/tests/Rector/Class_/UseForwardCallsTraitRector/Fixture/skip_first_class_callable_use.php.inc
+++ b/tests/Rector/Class_/UseForwardCallsTraitRector/Fixture/skip_first_class_callable_use.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\UseForwardCallsTraitRector\Fixture;
+
+class SkipFirstClassCallableUse
+{
+    public function __call($method, $args)
+    {
+        return call_user_func(...);
+    }
+}
+
+?>

--- a/tests/Rector/Class_/UseForwardCallsTraitRector/Fixture/works_with_first_class_callable_callable.php.inc
+++ b/tests/Rector/Class_/UseForwardCallsTraitRector/Fixture/works_with_first_class_callable_callable.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\UseForwardCallsTraitRector\Fixture;
+
+class WorksWithFirstClassCallableCallable
+{
+    public function __call($method, $args)
+    {
+        return call_user_func_array($this->foo(...), $args);
+    }
+
+    private function foo()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\UseForwardCallsTraitRector\Fixture;
+
+class WorksWithFirstClassCallableCallable
+{
+    use \Illuminate\Support\Traits\ForwardCalls;
+    public function __call($method, $args)
+    {
+        return $this->forwardCallTo($this, 'foo', $args);
+    }
+
+    private function foo()
+    {
+    }
+}
+
+?>

--- a/tests/Rector/Class_/UseForwardCallsTraitRector/UseForwardCallsTraitRectorTest.php
+++ b/tests/Rector/Class_/UseForwardCallsTraitRector/UseForwardCallsTraitRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\Class_\UseForwardCallsTraitRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class UseForwardCallsTraitRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/UseForwardCallsTraitRector/config/configured_rule.php
+++ b/tests/Rector/Class_/UseForwardCallsTraitRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\UseForwardCallsTraitRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(UseForwardCallsTraitRector::class);
+};


### PR DESCRIPTION
# Changes

- Adds a new `UseForwardCallsTraitRector` to the repo
- Adds a new analyzer and value object to keep the rule a bit smaller

# Why

I've found in a few projects where having the forward calls trait would lead to better debugging.

```diff
 class SomeClass
 {
+    use ForwardCalls;
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->foo, $method], $parameters);
+        return $this->forwardCallTo($this->foo, $method, $parameters);
     }
 }
```