### PR TITLE
feat: add composer-triggered set for version sets

### DIFF
--- a/src/Set/LaravelSetProvider.php
+++ b/src/Set/LaravelSetProvider.php
@@ -4,6 +4,7 @@ namespace RectorLaravel\Set;
 
 use Rector\Set\Contract\SetInterface;
 use Rector\Set\Contract\SetProviderInterface;
+use Rector\Set\ValueObject\ComposerTriggeredSet;
 use Rector\Set\ValueObject\Set;
 use RectorLaravel\Set\Packages\Livewire\LivewireSetList;
 
@@ -95,9 +96,10 @@ final class LaravelSetProvider implements SetProviderInterface
                 'Upgrade Legacy Factories to Modern Factories',
                 LaravelSetList::LARAVEL_LEGACY_FACTORIES_TO_CLASSES,
             ),
-            new Set(
+            new ComposerTriggeredSet(
                 self::GROUP_NAME,
-                'Livewire 3.0',
+                'livewire/livewire',
+                '3.0',
                 LivewireSetList::LIVEWIRE_30,
             ),
             ...$this->getLaravelVersions(),
@@ -105,7 +107,7 @@ final class LaravelSetProvider implements SetProviderInterface
     }
 
     /**
-     * @return Set[]
+     * @return ComposerTriggeredSet[]
      */
     private function getLaravelVersions(): array
     {
@@ -113,18 +115,20 @@ final class LaravelSetProvider implements SetProviderInterface
 
         $totalPostFive = count(self::LARAVEL_POST_FIVE);
         foreach (self::LARAVEL_POST_FIVE as $index => $version) {
-            $versions[] = new Set(
+            $versions[] = new ComposerTriggeredSet(
                 self::GROUP_NAME,
-                'Laravel Framework ' . ($totalPostFive - $index + 5) . '.0',
+                'laravel/framework',
+                ($totalPostFive - $index + 5) . '.0',
                 $version,
             );
         }
 
         $totalFive = count(self::LARAVEL_FIVE);
         foreach (self::LARAVEL_FIVE as $index => $version) {
-            $versions[] = new Set(
+            $versions[] = new ComposerTriggeredSet(
                 self::GROUP_NAME,
-                'Laravel Framework 5.' . ($totalFive - $index - 1),
+                'laravel/framework',
+                '5.' . ($totalFive - $index - 1),
                 $version,
             );
         }

--- a/tests/Sets/LaravelSetProviderTest.php
+++ b/tests/Sets/LaravelSetProviderTest.php
@@ -11,22 +11,22 @@ use RectorLaravel\Set\LaravelSetProvider;
 final class LaravelSetProviderTest extends TestCase
 {
     private const array LARAVEL_VERSION_SETS = [
-        'Laravel Framework 12.0' => LaravelSetList::LARAVEL_120,
-        'Laravel Framework 11.0' => LaravelSetList::LARAVEL_110,
-        'Laravel Framework 10.0' => LaravelSetList::LARAVEL_100,
-        'Laravel Framework 9.0' => LaravelSetList::LARAVEL_90,
-        'Laravel Framework 8.0' => LaravelSetList::LARAVEL_80,
-        'Laravel Framework 7.0' => LaravelSetList::LARAVEL_70,
-        'Laravel Framework 6.0' => LaravelSetList::LARAVEL_60,
-        'Laravel Framework 5.8' => LaravelSetList::LARAVEL_58,
-        'Laravel Framework 5.7' => LaravelSetList::LARAVEL_57,
-        'Laravel Framework 5.6' => LaravelSetList::LARAVEL_56,
-        'Laravel Framework 5.5' => LaravelSetList::LARAVEL_55,
-        'Laravel Framework 5.4' => LaravelSetList::LARAVEL_54,
-        'Laravel Framework 5.3' => LaravelSetList::LARAVEL_53,
-        'Laravel Framework 5.2' => LaravelSetList::LARAVEL_52,
-        'Laravel Framework 5.1' => LaravelSetList::LARAVEL_51,
-        'Laravel Framework 5.0' => LaravelSetList::LARAVEL_50,
+        LaravelSetList::LARAVEL_120,
+        LaravelSetList::LARAVEL_110,
+        LaravelSetList::LARAVEL_100,
+        LaravelSetList::LARAVEL_90,
+        LaravelSetList::LARAVEL_80,
+        LaravelSetList::LARAVEL_70,
+        LaravelSetList::LARAVEL_60,
+        LaravelSetList::LARAVEL_58,
+        LaravelSetList::LARAVEL_57,
+        LaravelSetList::LARAVEL_56,
+        LaravelSetList::LARAVEL_55,
+        LaravelSetList::LARAVEL_54,
+        LaravelSetList::LARAVEL_53,
+        LaravelSetList::LARAVEL_52,
+        LaravelSetList::LARAVEL_51,
+        LaravelSetList::LARAVEL_50,
     ];
 
     /**
@@ -73,16 +73,6 @@ final class LaravelSetProviderTest extends TestCase
             fn (string $filePath) => in_array($filePath, self::LARAVEL_VERSION_SETS, true),
         );
 
-        Assert::assertSame(array_values(self::LARAVEL_VERSION_SETS), array_values($filePaths));
-
-        $setNames = array_filter(
-            array_map(
-                fn (SetInterface $set) => $set->getName(),
-                $sets
-            ),
-            fn (string $setName) => in_array($setName, array_keys(self::LARAVEL_VERSION_SETS), true),
-        );
-
-        Assert::assertSame(array_keys(self::LARAVEL_VERSION_SETS), array_values($setNames));
+        Assert::assertSame(self::LARAVEL_VERSION_SETS, array_values($filePaths));
     }
 }


### PR DESCRIPTION
Hello!

Please see https://github.com/rectorphp/rector-src/pull/7110 and https://getrector.com/documentation/custom-set-provider#content-2-add-your-composertriggeredset-objects-to-the-provide-method for reference

These changes (with the PR mentioned above) will allow users to simply specify the following in their rector config and automatically have all the rectors up to the package version applied:

```php
    ->withComposerBased(laravel: true)
```

Thanks!