### PR TITLE
feat: add ConvertEnumerableToArrayToAllRector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "phpunit/phpunit": "^10.5",
         "symplify/rule-doc-generator": "^12.2",
         "tightenco/duster": "^3.1",
-        "nette/utils": "^4.0"
+        "nette/utils": "^4.0",
+        "tracy/tracy": "^2.10"
     },
     "autoload": {
         "psr-4": {
@@ -31,7 +32,8 @@
             "RectorLaravel\\Tests\\": "tests",
             "RectorLaravel\\Commands\\": "commands"
         },
-        "classmap": ["stubs"]
+        "classmap": ["stubs"],
+        "files": ["tests/debug_functions.php"]
     },
     "scripts": {
         "phpstan": "vendor/bin/phpstan analyse --ansi",

--- a/config/sets/laravel-collection.php
+++ b/config/sets/laravel-collection.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use RectorLaravel\Rector\BooleanNot\AvoidNegatedCollectionContainsOrDoesntContainRector;
 use RectorLaravel\Rector\MethodCall\AvoidNegatedCollectionFilterOrRejectRector;
+use RectorLaravel\Rector\MethodCall\ConvertEnumerableToArrayToAllRector;
 use RectorLaravel\Rector\MethodCall\UnaliasCollectionMethodsRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../config.php');
     $rectorConfig->rule(AvoidNegatedCollectionContainsOrDoesntContainRector::class);
     $rectorConfig->rule(AvoidNegatedCollectionFilterOrRejectRector::class);
+    $rectorConfig->rule(ConvertEnumerableToArrayToAllRector::class);
     $rectorConfig->rule(UnaliasCollectionMethodsRector::class);
 };

--- a/src/Rector/MethodCall/ConvertEnumerableToArrayToAllRector.php
+++ b/src/Rector/MethodCall/ConvertEnumerableToArrayToAllRector.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\TypeCombinator;
+use RectorLaravel\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\MethodCall\ConvertEnumerableToArrayToAllRector\ConvertEnumerableToArrayToAllRectorTest
+ */
+final class ConvertEnumerableToArrayToAllRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Convert `toArray()` to `all()` when the collection does not contain any Arrayable objects.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use Illuminate\Support\Collection;
+
+new Collection([0, 1, -1])->toArray();
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use Illuminate\Support\Collection;
+
+new Collection([0, 1, -1])->all();
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class, NullsafeMethodCall::class];
+    }
+
+    /**
+     * @param  MethodCall|NullsafeMethodCall  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isName($node->name, 'toArray')) {
+            return null;
+        }
+
+        if (! $this->isObjectType($node->var, new ObjectType('Illuminate\Support\Enumerable'))) {
+            return null;
+        }
+
+        $type = TypeCombinator::removeNull($this->getType($node->var));
+        $valueType = $type->getTemplateType('Illuminate\Support\Enumerable', 'TValue');
+
+        if (! (new ObjectType('Illuminate\Contracts\Support\Arrayable'))->isSuperTypeOf($valueType)->no()) {
+            return null;
+        }
+
+        $node->name = new Identifier('all');
+
+        return $node;
+    }
+}

--- a/stubs/Illuminate/Contracts/Support/Arrayable.php
+++ b/stubs/Illuminate/Contracts/Support/Arrayable.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Contracts\Support;
+
+if (interface_exists('Illuminate\Contracts\Support\Arrayable')) {
+    return;
+}
+
+/**
+ * @template TKey of array-key
+ * @template TValue
+ */
+interface Arrayable
+{
+    /**
+     * Get the instance as an array.
+     *
+     * @return array<TKey, TValue>
+     */
+    public function toArray();
+}

--- a/stubs/Illuminate/Support/Enumerable.php
+++ b/stubs/Illuminate/Support/Enumerable.php
@@ -101,4 +101,18 @@ interface Enumerable
      * @return $this|TUnlessNotEmptyReturnType
      */
     public function unlessNotEmpty();
+
+    /**
+     * Get the collection of items as a plain array.
+     *
+     * @return array<TKey, mixed>
+     */
+    public function toArray();
+
+    /**
+     * Get all items in the enumerable.
+     *
+     * @return array<TKey, TValue>
+     */
+    public function all();
 }

--- a/tests/Rector/MethodCall/ConvertEnumerableToArrayToAllRector/ConvertEnumerableToArrayToAllRectorTest.php
+++ b/tests/Rector/MethodCall/ConvertEnumerableToArrayToAllRector/ConvertEnumerableToArrayToAllRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ConvertEnumerableToArrayToAllRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ConvertEnumerableToArrayToAllRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/ConvertEnumerableToArrayToAllRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/ConvertEnumerableToArrayToAllRector/Fixture/fixture.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ConvertEnumerableToArrayToAllRector\Fixture;
+
+use Illuminate\Support\Collection;
+
+/** @var Collection<int, int> $collection */
+$collection->toArray();
+/** @var Collection<int, int>|null $nullableCollection */
+$nullableCollection->toArray();
+$nullableCollection?->toArray();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ConvertEnumerableToArrayToAllRector\Fixture;
+
+use Illuminate\Support\Collection;
+
+/** @var Collection<int, int> $collection */
+$collection->all();
+/** @var Collection<int, int>|null $nullableCollection */
+$nullableCollection->all();
+$nullableCollection?->all();
+
+?>

--- a/tests/Rector/MethodCall/ConvertEnumerableToArrayToAllRector/Fixture/skip_arrayble.php.inc
+++ b/tests/Rector/MethodCall/ConvertEnumerableToArrayToAllRector/Fixture/skip_arrayble.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ConvertEnumerableToArrayToAllRector\Fixture;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Collection;
+
+/** @var Collection<int, Arrayable> $collection */
+$collection->toArray();
+
+?>

--- a/tests/Rector/MethodCall/ConvertEnumerableToArrayToAllRector/Fixture/skip_arrayble_union.php.inc
+++ b/tests/Rector/MethodCall/ConvertEnumerableToArrayToAllRector/Fixture/skip_arrayble_union.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ConvertEnumerableToArrayToAllRector\Fixture;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Collection;
+
+/** @var Collection<int, Arrayable|int> $collection */
+$collection->toArray();
+
+?>

--- a/tests/Rector/MethodCall/ConvertEnumerableToArrayToAllRector/Fixture/skip_mixed.php.inc
+++ b/tests/Rector/MethodCall/ConvertEnumerableToArrayToAllRector/Fixture/skip_mixed.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ConvertEnumerableToArrayToAllRector\Fixture;
+
+use Illuminate\Support\Collection;
+
+/** @var Collection<int, mixed> $collection */
+$collection->toArray();
+
+?>

--- a/tests/Rector/MethodCall/ConvertEnumerableToArrayToAllRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/ConvertEnumerableToArrayToAllRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\MethodCall\ConvertEnumerableToArrayToAllRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+    $rectorConfig->rule(ConvertEnumerableToArrayToAllRector::class);
+};

--- a/tests/debug_functions.php
+++ b/tests/debug_functions.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Tracy\Dumper;
+
+// helpful functions to create new rector rules
+
+if (! function_exists('dd')) {
+    function dd(mixed $value, int $depth = 2): never
+    {
+        d($value, $depth);
+        exit;
+    }
+}
+
+if (! function_exists('d')) {
+    function d(mixed $value, int $depth = 2): void
+    {
+        Dumper::dump($value, [
+            Dumper::DEPTH => $depth,
+        ]);
+    }
+}


### PR DESCRIPTION
Hello!

This is a companion PR to https://github.com/larastan/larastan/pull/2311

The `toArray()` method on an Enumerable maps over all the items and recursively calls the `toArray()` method on each item if it is an Arrayable object. For collections that do not contain any Arrayable items, this is an unnecessary map operation and the method can be replaced with `all()` which simply returns the underlying array.


I also added the upstream `d` and `dd` functions to help when writing tests since those did not exist because they are rector dev dependencies.

Thanks!