### PR TITLE
fix: add interpolated strings support to ReplaceFakerInstanceWithHelperRector

### DIFF
--- a/tests/Rector/PropertyFetch/ReplaceFakerInstanceWithHelperRector/Fixture/interpolated_strings.php.inc
+++ b/tests/Rector/PropertyFetch/ReplaceFakerInstanceWithHelperRector/Fixture/interpolated_strings.php.inc
@@ -1,0 +1,37 @@
+<?php
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class UserFactory extends Factory
+{
+    public function definition()
+    {
+        $time = time();
+
+        return [
+            'foo_property' => "{$this->faker->uuid}.png",
+            'foo_method' => "{$this->faker->uuid()}.png",
+            'bar' => "{$this->faker->uuid}_{$time}.png",
+            'baz' => "{$time}_{$this->faker->uuid}.png",
+        ];
+    }
+}
+?>
+-----
+<?php
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class UserFactory extends Factory
+{
+    public function definition()
+    {
+        $time = time();
+
+        return [
+            'foo_property' => fake()->uuid . ".png",
+            'foo_method' => fake()->uuid() . ".png",
+            'bar' => fake()->uuid . "_{$time}.png",
+            'baz' => "{$time}_" . fake()->uuid . ".png",
+        ];
+    }
+}
+?>


### PR DESCRIPTION
Hello!

This closes #357 by adding support for interpolated strings to the `ReplaceFakerInstanceWithHelperRector`. PHP does not support function calls inside of strings.


Thanks!