### PR TITLE
Fix `UseForwardCallsTraitRector`

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1592,16 +1592,16 @@ Use `$this->components` property within commands
 
 <br>
 
-## UseForwardCallsTraitRector
+## UseForwardsCallsTraitRector
 
 Replaces the use of `call_user_func` and `call_user_func_array` method with the CallForwarding trait
 
-- class: [`RectorLaravel\Rector\Class_\UseForwardCallsTraitRector`](../src/Rector/Class_/UseForwardCallsTraitRector.php)
+- class: [`RectorLaravel\Rector\Class_\UseForwardsCallsTraitRector`](../src/Rector/Class_/UseForwardsCallsTraitRector.php)
 
 ```diff
  class SomeClass
  {
-+    use ForwardCalls;
++    use ForwardsCalls;
 +
      public function __call($method, $parameters)
      {

--- a/src/Rector/Class_/UseForwardsCallsTraitRector.php
+++ b/src/Rector/Class_/UseForwardsCallsTraitRector.php
@@ -20,11 +20,11 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @see \RectorLaravel\Tests\Rector\Class_\UseForwardCallsTraitRector\UseForwardCallsTraitRectorTest
+ * @see \RectorLaravel\Tests\Rector\Class_\UseForwardsCallsTraitRector\UseForwardsCallsTraitRectorTest
  */
-final class UseForwardCallsTraitRector extends AbstractRector
+final class UseForwardsCallsTraitRector extends AbstractRector
 {
-    private const string FORWARD_CALLS_TRAIT = 'Illuminate\Support\Traits\ForwardCalls';
+    private const string FORWARD_CALLS_TRAIT = 'Illuminate\Support\Traits\ForwardsCalls';
 
     public function __construct(private readonly CallUserFuncAnalyzer $callUserFuncAnalyzer) {}
 
@@ -45,7 +45,7 @@ CODE_SAMPLE,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {
-    use ForwardCalls;
+    use ForwardsCalls;
 
     public function __call($method, $parameters)
     {

--- a/tests/Rector/Class_/UseForwardsCallsTraitRector/Fixture/dont_duplicate_trait.php.inc
+++ b/tests/Rector/Class_/UseForwardsCallsTraitRector/Fixture/dont_duplicate_trait.php.inc
@@ -1,10 +1,10 @@
 <?php
 
-namespace RectorLaravel\Tests\Rector\Class_\UseForwardCallsTraitRector\Fixture;
+namespace RectorLaravel\Tests\Rector\Class_\UseForwardsCallsTraitRector\Fixture;
 
 class DontDuplicateTrait
 {
-    use \Illuminate\Support\Traits\ForwardCalls;
+    use \Illuminate\Support\Traits\ForwardsCalls;
     private SomeCall $foo;
 
     public function __call($method, $args)
@@ -17,11 +17,11 @@ class DontDuplicateTrait
 -----
 <?php
 
-namespace RectorLaravel\Tests\Rector\Class_\UseForwardCallsTraitRector\Fixture;
+namespace RectorLaravel\Tests\Rector\Class_\UseForwardsCallsTraitRector\Fixture;
 
 class DontDuplicateTrait
 {
-    use \Illuminate\Support\Traits\ForwardCalls;
+    use \Illuminate\Support\Traits\ForwardsCalls;
     private SomeCall $foo;
 
     public function __call($method, $args)

--- a/tests/Rector/Class_/UseForwardsCallsTraitRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/UseForwardsCallsTraitRector/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace RectorLaravel\Tests\Rector\Class_\UseForwardCallsTraitRector\Fixture;
+namespace RectorLaravel\Tests\Rector\Class_\UseForwardsCallsTraitRector\Fixture;
 
 class Fixture
 {
@@ -26,11 +26,11 @@ class Fixture
 -----
 <?php
 
-namespace RectorLaravel\Tests\Rector\Class_\UseForwardCallsTraitRector\Fixture;
+namespace RectorLaravel\Tests\Rector\Class_\UseForwardsCallsTraitRector\Fixture;
 
 class Fixture
 {
-    use \Illuminate\Support\Traits\ForwardCalls;
+    use \Illuminate\Support\Traits\ForwardsCalls;
     private SomeCall $foo;
 
     public function __call($method, $args)

--- a/tests/Rector/Class_/UseForwardsCallsTraitRector/Fixture/skip_complex_func_call.php.inc
+++ b/tests/Rector/Class_/UseForwardsCallsTraitRector/Fixture/skip_complex_func_call.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace RectorLaravel\Tests\Rector\Class_\UseForwardCallsTraitRector\Fixture;
+namespace RectorLaravel\Tests\Rector\Class_\UseForwardsCallsTraitRector\Fixture;
 
 class SkipComplexFuncCall
 {

--- a/tests/Rector/Class_/UseForwardsCallsTraitRector/Fixture/skip_first_class_callable_use.php.inc
+++ b/tests/Rector/Class_/UseForwardsCallsTraitRector/Fixture/skip_first_class_callable_use.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace RectorLaravel\Tests\Rector\Class_\UseForwardCallsTraitRector\Fixture;
+namespace RectorLaravel\Tests\Rector\Class_\UseForwardsCallsTraitRector\Fixture;
 
 class SkipFirstClassCallableUse
 {

--- a/tests/Rector/Class_/UseForwardsCallsTraitRector/Fixture/works_with_first_class_callable_callable.php.inc
+++ b/tests/Rector/Class_/UseForwardsCallsTraitRector/Fixture/works_with_first_class_callable_callable.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace RectorLaravel\Tests\Rector\Class_\UseForwardCallsTraitRector\Fixture;
+namespace RectorLaravel\Tests\Rector\Class_\UseForwardsCallsTraitRector\Fixture;
 
 class WorksWithFirstClassCallableCallable
 {
@@ -18,11 +18,11 @@ class WorksWithFirstClassCallableCallable
 -----
 <?php
 
-namespace RectorLaravel\Tests\Rector\Class_\UseForwardCallsTraitRector\Fixture;
+namespace RectorLaravel\Tests\Rector\Class_\UseForwardsCallsTraitRector\Fixture;
 
 class WorksWithFirstClassCallableCallable
 {
-    use \Illuminate\Support\Traits\ForwardCalls;
+    use \Illuminate\Support\Traits\ForwardsCalls;
     public function __call($method, $args)
     {
         return $this->forwardCallTo($this, 'foo', $args);

--- a/tests/Rector/Class_/UseForwardsCallsTraitRector/UseForwardsCallsTraitRectorTest.php
+++ b/tests/Rector/Class_/UseForwardsCallsTraitRector/UseForwardsCallsTraitRectorTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace RectorLaravel\Tests\Rector\Class_\UseForwardCallsTraitRector;
+namespace RectorLaravel\Tests\Rector\Class_\UseForwardsCallsTraitRector;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
-final class UseForwardCallsTraitRectorTest extends AbstractRectorTestCase
+final class UseForwardsCallsTraitRectorTest extends AbstractRectorTestCase
 {
     public static function provideData(): Iterator
     {

--- a/tests/Rector/Class_/UseForwardsCallsTraitRector/config/configured_rule.php
+++ b/tests/Rector/Class_/UseForwardsCallsTraitRector/config/configured_rule.php
@@ -3,8 +3,8 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use RectorLaravel\Rector\Class_\UseForwardCallsTraitRector;
+use RectorLaravel\Rector\Class_\UseForwardsCallsTraitRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rule(UseForwardCallsTraitRector::class);
+    $rectorConfig->rule(UseForwardsCallsTraitRector::class);
 };


### PR DESCRIPTION
> Correct `ForwardCalls` to `ForwardsCalls`.

## Related links

* [https://github.com/laravel/framework/blob/12.x/src/Illuminate/Support/Traits/ForwardsCalls.php#L8C7-L8C20](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Support/Traits/ForwardsCalls.php#L8C7-L8C20)
* [https://github.com/driftingly/rector-laravel/blob/main/src/Rector/Class_/UseForwardCallsTraitRector.php#L27C75-L27C87](https://github.com/driftingly/rector-laravel/blob/main/src/Rector/Class_/UseForwardCallsTraitRector.php#L27C75-L27C87)

## CI

* [Tests](https://github.com/guanguans/rector-laravel/actions/runs/16898445203)
* [Code Analysis](https://github.com/guanguans/rector-laravel/actions/runs/16898445208)
