### PR TITLE
feat: improve AppEnvironmentComparisonToParameterRector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "symplify/rule-doc-generator-contracts": "^11.2"
     },
     "require-dev": {
-        "nikic/php-parser": "^5.3",
+        "nikic/php-parser": "^5.6",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-deprecation-rules": "^2.0",

--- a/config/sets/laravel-code-quality.php
+++ b/config/sets/laravel-code-quality.php
@@ -6,6 +6,7 @@ use Rector\Config\RectorConfig;
 use RectorLaravel\Rector\Assign\CallOnAppArrayAccessToStandaloneAssignRector;
 use RectorLaravel\Rector\ClassMethod\MakeModelAttributesAndScopesProtectedRector;
 use RectorLaravel\Rector\Coalesce\ApplyDefaultInsteadOfNullCoalesceRector;
+use RectorLaravel\Rector\Expr\AppEnvironmentComparisonToParameterRector;
 use RectorLaravel\Rector\MethodCall\ReverseConditionableMethodCallRector;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -14,4 +15,5 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(ReverseConditionableMethodCallRector::class);
     $rectorConfig->rule(ApplyDefaultInsteadOfNullCoalesceRector::class);
     $rectorConfig->rule(MakeModelAttributesAndScopesProtectedRector::class);
+    $rectorConfig->rule(AppEnvironmentComparisonToParameterRector::class);
 };

--- a/src/Rector/Expr/AppEnvironmentComparisonToParameterRector.php
+++ b/src/Rector/Expr/AppEnvironmentComparisonToParameterRector.php
@@ -7,10 +7,16 @@ namespace RectorLaravel\Rector\Expr;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\BinaryOp\Equal;
 use PhpParser\Node\Expr\BinaryOp\Identical;
+use PhpParser\Node\Expr\BinaryOp\NotEqual;
+use PhpParser\Node\Expr\BinaryOp\NotIdentical;
+use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\ObjectType;
 use RectorLaravel\AbstractRector;
@@ -25,82 +31,145 @@ class AppEnvironmentComparisonToParameterRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Replace `$app->environment() === \'local\'` with `$app->environment(\'local\')`',
+            'Replace app environment comparison with parameter or method call',
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'
-$app->environment() === 'production';
+$app->environment() === 'local';
+$app->environment() !== 'production';
+$app->environment() === 'testing';
+in_array($app->environment(), ['local', 'testing']);
 CODE_SAMPLE
                     ,
                     <<<'CODE_SAMPLE'
-$app->environment('production');
+$app->isLocal();
+! $app->isProduction();
+$app->environment('testing');
+$app->environment(['local', 'testing']);
 CODE_SAMPLE
                 ),
             ]
         );
     }
 
+    /** @return list<class-string<Node>> */
     public function getNodeTypes(): array
     {
-        return [Expr::class];
+        return [FuncCall::class, Identical::class, Equal::class, NotIdentical::class, NotEqual::class];
     }
 
-    public function refactor(Node $node): MethodCall|StaticCall|null
+    /** @param FuncCall|Identical|Equal|NotIdentical|NotEqual $node */
+    public function refactor(Node $node): ?Expr
     {
-        if (! $node instanceof Identical && ! $node instanceof Equal) {
+        if ($node instanceof FuncCall) {
+            [$methodCall, $otherNode] = $this->handleFuncCall($node);
+        } else {
+            [$methodCall, $otherNode] = $this->handleBinaryOp($node);
+        }
+
+        if ($methodCall === null || $otherNode === null) {
             return null;
         }
 
-        /** @var MethodCall|StaticCall|null $methodCall */
-        $methodCall = array_values(
-            array_filter(
-                [$node->left, $node->right],
-                fn ($node) => ($node instanceof MethodCall || $node instanceof StaticCall) && $this->isName(
-                    $node->name,
-                    'environment'
-                )
-            )
-        )[0] ?? null;
+        $methodName = null;
 
-        if ($methodCall === null || ! $this->validMethodCall($methodCall)) {
-            return null;
+        if ($otherNode instanceof String_) {
+            $methodName = $this->getMethodName($methodCall, $otherNode->value);
         }
 
-        /** @var Expr $otherNode */
-        $otherNode = array_values(
-            array_filter([$node->left, $node->right], static fn ($node) => $node !== $methodCall)
-        )[0] ?? null;
-
-        if (! $otherNode instanceof String_) {
-            return null;
+        if ($methodName === null) {
+            $methodCall->args[] = new Arg($otherNode);
+        } else {
+            $methodCall->name = new Identifier($methodName);
         }
 
-        // make sure the method call has no arguments
-        if ($methodCall->getArgs() !== []) {
-            return null;
+        if ($node instanceof NotIdentical || $node instanceof NotEqual) {
+            return new BooleanNot($methodCall);
         }
-
-        $methodCall->args[] = new Arg($otherNode);
 
         return $methodCall;
     }
 
-    private function validMethodCall(MethodCall|StaticCall $methodCall): bool
+    /** @return array{0: MethodCall|StaticCall|null, 1: Expr|null} */
+    private function handleFuncCall(FuncCall $funcCall): array
     {
+        if (! $this->isName($funcCall->name, 'in_array')) {
+            return [null, null];
+        }
+
+        $methodCall = $funcCall->getArg('needle', 0);
+        $haystack = $funcCall->getArg('haystack', 1);
+
+        if (! $haystack instanceof Arg || ! $methodCall instanceof Arg || ! $this->validMethodCall($methodCall->value)) {
+            return [null, null];
+        }
+
+        return [$methodCall->value, $haystack->value];
+    }
+
+    /** @return array{0: MethodCall|StaticCall|null, 1: Expr|null} */
+    private function handleBinaryOp(BinaryOp $binaryOp): array
+    {
+        $methodCall = array_values(
+            array_filter(
+                [$binaryOp->left, $binaryOp->right],
+                fn ($node) => $this->validMethodCall($node),
+            )
+        )[0] ?? null;
+
+        $otherNode = array_values(
+            array_filter([$binaryOp->left, $binaryOp->right], static fn ($node) => $node !== $methodCall)
+        )[0] ?? null;
+
+        return [$methodCall, $otherNode];
+    }
+
+    /** @phpstan-assert-if-true MethodCall|StaticCall $node */
+    private function validMethodCall(Node $node): bool
+    {
+        if (! $node instanceof MethodCall && ! $node instanceof StaticCall) {
+            return false;
+        }
+
+        if (! $this->isName($node->name, 'environment')) {
+            return false;
+        }
+
+        // make sure the method call has no arguments
+        if ($node->getArgs() !== []) {
+            return false;
+        }
+
         return match (true) {
-            $methodCall instanceof MethodCall && $this->isObjectType(
-                $methodCall->var,
+            $node instanceof MethodCall && $this->isObjectType(
+                $node->var,
                 new ObjectType('Illuminate\Contracts\Foundation\Application')
             ) => true,
-            $methodCall instanceof StaticCall && $this->isObjectType(
-                $methodCall->class,
+            $node instanceof StaticCall && $this->isObjectType(
+                $node->class,
                 new ObjectType('Illuminate\Support\Facades\App')
             ) => true,
-            $methodCall instanceof StaticCall && $this->isObjectType(
-                $methodCall->class,
+            $node instanceof StaticCall && $this->isObjectType(
+                $node->class,
                 new ObjectType('App')
             ) => true,
             default => false,
+        };
+    }
+
+    private function getMethodName(MethodCall|StaticCall $methodCall, string $environment): ?string
+    {
+        if (
+            $methodCall instanceof MethodCall
+            && ! $this->isObjectType($methodCall->var, new ObjectType('Illuminate\Foundation\Application'))
+        ) {
+            return null;
+        }
+
+        return match ($environment) {
+            'local' => 'isLocal',
+            'production' => 'isProduction',
+            default => null,
         };
     }
 }

--- a/tests/Rector/Expr/AppEnvironmentComparisonToParameterRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Expr/AppEnvironmentComparisonToParameterRector/Fixture/fixture.php.inc
@@ -2,14 +2,25 @@
 
 namespace RectorLaravel\Tests\Rector\Expr\AppEnvironmentComparisonToParameterRector\Fixture;
 
-/** @var \Illuminate\Contracts\Foundation\Application $app */
+/** @var \Illuminate\Foundation\Application $app */
+/** @var \Illuminate\Contracts\Foundation\Application $appContract */
+$app->environment() === 'local';
+$app->environment() === 'staging';
 $app->environment() === 'production';
+$appContract->environment() === 'local';
+$appContract->environment() === 'staging';
+$appContract->environment() === 'production';
 'staging' == $app->environment();
+'testing' != $app->environment();
 
-if ($app->environment() === 'production') {
+if ($app->environment() !== 'production') {
 }
 
+\Illuminate\Support\Facades\App::environment() === 'local';
+\Illuminate\Support\Facades\App::environment() === 'staging';
 \Illuminate\Support\Facades\App::environment() === 'production';
+\App::environment() === 'local';
+\App::environment() === 'staging';
 \App::environment() === 'production';
 
 ?>
@@ -18,14 +29,25 @@ if ($app->environment() === 'production') {
 
 namespace RectorLaravel\Tests\Rector\Expr\AppEnvironmentComparisonToParameterRector\Fixture;
 
-/** @var \Illuminate\Contracts\Foundation\Application $app */
-$app->environment('production');
+/** @var \Illuminate\Foundation\Application $app */
+/** @var \Illuminate\Contracts\Foundation\Application $appContract */
+$app->isLocal();
 $app->environment('staging');
+$app->isProduction();
+$appContract->environment('local');
+$appContract->environment('staging');
+$appContract->environment('production');
+$app->environment('staging');
+!$app->environment('testing');
 
-if ($app->environment('production')) {
+if (!$app->isProduction()) {
 }
 
-\Illuminate\Support\Facades\App::environment('production');
-\App::environment('production');
+\Illuminate\Support\Facades\App::isLocal();
+\Illuminate\Support\Facades\App::environment('staging');
+\Illuminate\Support\Facades\App::isProduction();
+\App::isLocal();
+\App::environment('staging');
+\App::isProduction();
 
 ?>

--- a/tests/Rector/Expr/AppEnvironmentComparisonToParameterRector/Fixture/in_array.php.inc
+++ b/tests/Rector/Expr/AppEnvironmentComparisonToParameterRector/Fixture/in_array.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Expr\AppEnvironmentComparisonToParameterRector\Fixture;
+
+/** @var \Illuminate\Foundation\Application $app */
+/** @var \Illuminate\Contracts\Foundation\Application $appContract */
+in_array($app->environment(), ['local']);
+in_array($appContract->environment(), ['testing'], true);
+
+if (! in_array($app->environment(), ['local', 'testing'], true)) {
+}
+
+in_array(\Illuminate\Support\Facades\App::environment(), ['local', 'testing']);
+in_array(\App::environment(), ['local', 'testing']);
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Expr\AppEnvironmentComparisonToParameterRector\Fixture;
+
+/** @var \Illuminate\Foundation\Application $app */
+/** @var \Illuminate\Contracts\Foundation\Application $appContract */
+$app->environment(['local']);
+$appContract->environment(['testing']);
+
+if (! $app->environment(['local', 'testing'])) {
+}
+
+\Illuminate\Support\Facades\App::environment(['local', 'testing']);
+\App::environment(['local', 'testing']);
+
+?>


### PR DESCRIPTION
Hello!

This adds several improvements:
- support for the `in_array` function
- support for `!=` and `!==` operators
- support for the cleaner `isLocal` and `isProduction` methods

I also saw that this rule was not in any set, so I created a code style set (similar to the upstream rector one) for this and others (I figured this was more stylistic than code quality)


Thanks!