### PR TITLE
feat: add additional methods to laravel-arrayaccess-to-method-call

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Rector upgrades rules for Laravel Framework",
     "require": {
         "php": ">=8.3",
-        "rector/rector": "^2.0.0",
+        "rector/rector": "^2.1.3",
         "webmozart/assert": "^1.11",
         "symplify/rule-doc-generator-contracts": "^11.2"
     },

--- a/config/sets/laravel-arrayaccess-to-method-call.php
+++ b/config/sets/laravel-arrayaccess-to-method-call.php
@@ -14,28 +14,24 @@ return static function (RectorConfig $rectorConfig): void {
             ArrayDimFetchToMethodCallRector::class,
             [
                 new ArrayDimFetchToMethodCall(
-                    new ObjectType('Illuminate\Foundation\Application'),
-                    'make',
-                ),
-                new ArrayDimFetchToMethodCall(
-                    new ObjectType('Illuminate\Contracts\Foundation\Application'),
-                    'make',
-                ),
-                new ArrayDimFetchToMethodCall(
-                    new ObjectType('Illuminate\Config\Repository'),
-                    'get',
-                ),
-                new ArrayDimFetchToMethodCall(
                     new ObjectType('Illuminate\Contracts\Config\Repository'),
-                    'make',
+                    'get',
+                    'set',
+                    'has',
+                    'set', // intentional
                 ),
                 new ArrayDimFetchToMethodCall(
-                    new ObjectType('Illuminate\Contracts\Container\Container\Application'),
-                    'make',
+                    new ObjectType('Illuminate\Contracts\Cache\Repository'),
+                    'get',
+                    'set',
+                    'has',
+                    'forget',
                 ),
                 new ArrayDimFetchToMethodCall(
                     new ObjectType('Illuminate\Contracts\Container\Container'),
                     'make',
+                    'bind',
+                    'bound',
                 ),
             ],
         );

--- a/stubs/Illuminate/Cache/Repository.php
+++ b/stubs/Illuminate/Cache/Repository.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Cache;
+
+use ArrayAccess;
+use Illuminate\Contracts\Cache\Repository as CacheContract;
+
+if (class_exists('Illuminate\Cache\Repository')) {
+    return;
+}
+
+class Repository implements ArrayAccess, CacheContract {}

--- a/stubs/Illuminate/Config/Repository.php
+++ b/stubs/Illuminate/Config/Repository.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Config;
+
+use ArrayAccess;
+use Illuminate\Contracts\Config\Repository as ConfigContract;
+
+if (class_exists('Illuminate\Config\Repository')) {
+    return;
+}
+
+class Repository implements ArrayAccess, ConfigContract {}

--- a/stubs/Illuminate/Container/Container.php
+++ b/stubs/Illuminate/Container/Container.php
@@ -2,6 +2,11 @@
 
 namespace Illuminate\Container;
 
+use ArrayAccess;
 use Illuminate\Contracts\Container\Container as ContainerContract;
 
-class Container implements ContainerContract {}
+if (class_exists('Illuminate\Container\Container')) {
+    return;
+}
+
+class Container implements ArrayAccess, ContainerContract {}

--- a/stubs/Illuminate/Contracts/Cache/Repository.php
+++ b/stubs/Illuminate/Contracts/Cache/Repository.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Contracts\Cache;
+
+if (interface_exists('Illuminate\Contracts\Cache\Repository')) {
+    return;
+}
+
+interface Repository {}

--- a/stubs/Illuminate/Contracts/Config/Repository.php
+++ b/stubs/Illuminate/Contracts/Config/Repository.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Contracts\Config;
+
+if (interface_exists('Illuminate\Contracts\Config\Repository')) {
+    return;
+}
+
+interface Repository {}

--- a/stubs/Illuminate/Contracts/Container/Container.php
+++ b/stubs/Illuminate/Contracts/Container/Container.php
@@ -2,4 +2,8 @@
 
 namespace Illuminate\Contracts\Container;
 
+if (interface_exists('Illuminate\Contracts\Container\Container')) {
+    return;
+}
+
 interface Container {}

--- a/stubs/Illuminate/Contracts/Foundation/Application.php
+++ b/stubs/Illuminate/Contracts/Foundation/Application.php
@@ -6,7 +6,7 @@ namespace Illuminate\Contracts\Foundation;
 
 use Illuminate\Contracts\Container\Container;
 
-if (class_exists('Illuminate\Contracts\Foundation\Application')) {
+if (interface_exists('Illuminate\Contracts\Foundation\Application')) {
     return;
 }
 

--- a/tests/Sets/ArrayAccessToMethodCall/Fixture/fixture.php.inc
+++ b/tests/Sets/ArrayAccessToMethodCall/Fixture/fixture.php.inc
@@ -3,12 +3,22 @@
 namespace RectorLaravel\Tests\Sets\ArrayAccessToMethodCall;
 
 $app = new \Illuminate\Foundation\Application();
-
-$service = $app[\Illuminate\Contracts\Events\Dispatcher::class];
+$app['foo'];
+$app['foo'] = 'Foo';
+isset($app['foo']);
+unset($app['foo']); // skipped
 
 $config = new \Illuminate\Config\Repository();
+$config['app.name'];
+$config['app.name'] = 'Foo';
+isset($config['app.name']);
+unset($config['app.name']);
 
-$name = $config['app.name'];
+$cache = new \Illuminate\Cache\Repository();
+$cache['app.name'];
+$cache['app.name'] = 'Foo';
+isset($cache['app.name']);
+unset($cache['app.name']);
 
 ?>
 -----
@@ -17,11 +27,21 @@ $name = $config['app.name'];
 namespace RectorLaravel\Tests\Sets\ArrayAccessToMethodCall;
 
 $app = new \Illuminate\Foundation\Application();
-
-$service = $app->make(\Illuminate\Contracts\Events\Dispatcher::class);
+$app->make('foo');
+$app->bind('foo', 'Foo');
+$app->bound('foo');
+unset($app['foo']); // skipped
 
 $config = new \Illuminate\Config\Repository();
+$config->get('app.name');
+$config->set('app.name', 'Foo');
+$config->has('app.name');
+$config->set('app.name');
 
-$name = $config->get('app.name');
+$cache = new \Illuminate\Cache\Repository();
+$cache->get('app.name');
+$cache->set('app.name', 'Foo');
+$cache->has('app.name');
+$cache->forget('app.name');
 
 ?>


### PR DESCRIPTION
Hello!

This adds support for the exists, set, and unset operations that can happen on an ArrayAccess object.

This also adds the Cache contract to the list and cleans up the implementations---they are not needed since the contracts are listed and they all implement the contracts.

Thanks!