### PR TITLE
fix: ContainerBindConcreteWithClosureOnlyRector Rule when the abstract is a variable

### DIFF
--- a/src/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector.php
+++ b/src/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector.php
@@ -3,6 +3,7 @@
 namespace RectorLaravel\Rector\MethodCall;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Const_;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\MethodCall;
@@ -73,6 +74,10 @@ CODE_SAMPLE
         $type = $this->getType($node->getArgs()[0]->value);
         $classString = $node->getArgs()[0]->value;
         $concreteNode = $node->getArgs()[1]->value;
+
+        if ($classString instanceof Node\Expr\Variable) {
+            return null;
+        }
 
         if (! $concreteNode instanceof Closure) {
             return null;

--- a/src/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector.php
+++ b/src/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector.php
@@ -3,10 +3,10 @@
 namespace RectorLaravel\Rector\MethodCall;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Const_;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
@@ -75,7 +75,7 @@ CODE_SAMPLE
         $classString = $node->getArgs()[0]->value;
         $concreteNode = $node->getArgs()[1]->value;
 
-        if ($classString instanceof Node\Expr\Variable) {
+        if ($classString instanceof Variable) {
             return null;
         }
 

--- a/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/fixture.php.inc
@@ -19,6 +19,12 @@ $app->singleton(SomeInterface::class, function () {
     return new SomeClass();
 });
 
+foreach ([SomeClass::class] as $item) {
+    $app->singleton($item, function () use ($item) {
+        return new $item();
+    });
+}
+
 ?>
 -----
 <?php
@@ -41,5 +47,11 @@ $app->bind(function (): \RectorLaravel\Tests\Rector\MethodCall\ContainerBindConc
 $app->singleton(function (): \RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface {
     return new SomeClass();
 });
+
+foreach ([SomeClass::class] as $item) {
+    $app->singleton($item, function () use ($item) {
+        return new $item();
+    });
+}
 
 ?>


### PR DESCRIPTION
Hi,

This is a proposed solution to solve the following issue when using `LARAVEL_120` set (`ContainerBindConcreteWithClosureOnlyRector` Rule):

The following piece of code
```php
foreach ([SomeClass::class, SomeOtherClass::class] as $item) {
    $app->singleton($item, function () use ($item) {
        return new $item();
    });
}
```

Currently gets updated wrongly into
```php
foreach ([SomeClass::class, SomeOtherClass::class] as $item) {
    $app->singleton($item, function () use ($item): SomeClass::class|SomeOtherClass::class {
        return new $item();
    });
}
```

[EDIT: The above is a made-up example to explain simply the issue, see my comment bellow]

I believe we should prevent any modification when the first argument is a variable. The above code should remain unchanged.


This PR is a proposed approach to do that and will fix this bug.

---

Thank you very much for creating this wonderful package ;) 

Hope this helps,
Jeff