### PR TITLE
fix: skip rule when its overriding the method

### DIFF
--- a/src/Rector/ClassMethod/MakeModelAttributesAndScopesProtectedRector.php
+++ b/src/Rector/ClassMethod/MakeModelAttributesAndScopesProtectedRector.php
@@ -113,6 +113,14 @@ CODE_SAMPLE
             return true;
         }
 
+        if (
+            $classReflection->getParentClass() instanceof ClassReflection &&
+            $classReflection->getParentClass()->hasMethod($this->getName($classMethod)) &&
+            $classReflection->getParentClass()->getMethod($this->getName($classMethod), $scope)->isPublic()
+        ) {
+            return true;
+        }
+
         return ! $classReflection->isTrait()
             && ! $classReflection->is('Illuminate\Database\Eloquent\Model');
     }

--- a/tests/Rector/ClassMethod/MakeModelAttributesAndScopesProtectedRector/Fixture/skip-child-class.php.inc
+++ b/tests/Rector/ClassMethod/MakeModelAttributesAndScopesProtectedRector/Fixture/skip-child-class.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\MakeModelAttributesAndScopesProtectedRector\Fixture;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Builder;
+use RectorLaravel\Tests\Rector\ClassMethod\MakeModelAttributesAndScopesProtectedRector\Source\ParentUser;
+
+class User extends ParentUser
+{
+    protected function firstName(): Attribute
+    {
+        return Attribute::get(fn () => ucfirst($this->first_name));
+    }
+
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('active', true);
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/MakeModelAttributesAndScopesProtectedRector/Source/ParentUser.php
+++ b/tests/Rector/ClassMethod/MakeModelAttributesAndScopesProtectedRector/Source/ParentUser.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\MakeModelAttributesAndScopesProtectedRector\Source;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class ParentUser extends Model
+{
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('active', true);
+    }
+}


### PR DESCRIPTION
This PR skips the `MakeModelAttributesAndScopesProtectedRectorTest` if the method is overriding a public parent method. Narrowing down the type in a child class results in a fatal error.