### PR TITLE
Exclude `Request::input` calls from ApplyDefaultInsteadOfNullCoalesceRector

### DIFF
--- a/src/Rector/Coalesce/ApplyDefaultInsteadOfNullCoalesceRector.php
+++ b/src/Rector/Coalesce/ApplyDefaultInsteadOfNullCoalesceRector.php
@@ -41,7 +41,6 @@ final class ApplyDefaultInsteadOfNullCoalesceRector extends AbstractRector imple
             new ApplyDefaultInsteadOfNullCoalesce('config'),
             new ApplyDefaultInsteadOfNullCoalesce('env'),
             new ApplyDefaultInsteadOfNullCoalesce('data_get', argumentPosition: 2),
-            new ApplyDefaultInsteadOfNullCoalesce('input', new ObjectType('Illuminate\Http\Request')),
             new ApplyDefaultInsteadOfNullCoalesce('get', new ObjectType('Illuminate\Support\Env')),
         ];
     }

--- a/tests/Rector/Coalesce/ApplyDefaultInsteadOfNullCoalesceRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Coalesce/ApplyDefaultInsteadOfNullCoalesceRector/Fixture/fixture.php.inc
@@ -5,8 +5,6 @@ namespace RectorLaravel\Tests\Rector\Coalesce\ApplyDefaultInsteadOfNullCoalesceR
 config('app.name') ?? false;
 config('app.name') ?? null;
 
-(new \Illuminate\Http\Request())->input('value') ?? '';
-
 \Illuminate\Support\Env::get('APP_NAME') ?? '';
 
 ?>
@@ -17,8 +15,6 @@ namespace RectorLaravel\Tests\Rector\Coalesce\ApplyDefaultInsteadOfNullCoalesceR
 
 config('app.name', false);
 config('app.name');
-
-(new \Illuminate\Http\Request())->input('value', '');
 
 \Illuminate\Support\Env::get('APP_NAME', '');
 

--- a/tests/Rector/Coalesce/ApplyDefaultInsteadOfNullCoalesceRector/Fixture/skip_request_input.php.inc
+++ b/tests/Rector/Coalesce/ApplyDefaultInsteadOfNullCoalesceRector/Fixture/skip_request_input.php.inc
@@ -1,0 +1,5 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Coalesce\ApplyDefaultInsteadOfNullCoalesceRector\Fixture;
+
+(new \Illuminate\Http\Request())->input('value') ?? '';


### PR DESCRIPTION
Fixes #385 and #308.
Unfortunately, I don't see a solution other than just excluding the Request object from this change, due to the its internal implementation of the `input` method.