### PR TITLE
Refactor Carbon static calls to Date Facade

### DIFF
--- a/config/sets/laravel-code-quality.php
+++ b/config/sets/laravel-code-quality.php
@@ -25,6 +25,7 @@ use RectorLaravel\Rector\MethodCall\RedirectRouteToToRouteHelperRector;
 use RectorLaravel\Rector\MethodCall\ReverseConditionableMethodCallRector;
 use RectorLaravel\Rector\MethodCall\ValidationRuleArrayStringValueToArrayRector;
 use RectorLaravel\Rector\PropertyFetch\OptionalToNullsafeOperatorRector;
+use RectorLaravel\Rector\StaticCall\CarbonToDateFacadeRector;
 use RectorLaravel\Rector\StaticCall\DispatchToHelperFunctionsRector;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -49,6 +50,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(RedirectRouteToToRouteHelperRector::class);
     $rectorConfig->rule(AnonymousMigrationsRector::class);
     $rectorConfig->rule(SleepFuncToSleepStaticCallRector::class);
+    $rectorConfig->rule(CarbonToDateFacadeRector::class);
     $rectorConfig->rule(DispatchToHelperFunctionsRector::class);
     $rectorConfig->rule(NotFilledBlankFuncCallToBlankFilledFuncCallRector::class);
     $rectorConfig->rule(EloquentOrderByToLatestOrOldestRector::class);

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 86 Rules Overview
+# 87 Rules Overview
 
 ## AbortIfRector
 
@@ -475,6 +475,36 @@ Use the `$this->travelTo()` method in Laravel's `TestCase` class instead of the 
 +        $this->travelTo('2024-08-11');
      }
  }
+```
+
+<br>
+
+## CarbonToDateFacadeRector
+
+Refactor Carbon static method calls to use the Date facade instead.
+
+- class: [`RectorLaravel\Rector\StaticCall\CarbonToDateFacadeRector`](../src/Rector/StaticCall/CarbonToDateFacadeRector.php)
+
+```diff
+-use Carbon\Carbon;
++use Illuminate\Support\Facades\Date;
+
+-Carbon::now();
+-Carbon::parse('2024-01-01');
++Date::now();
++Date::parse('2024-01-01');
+```
+
+<br>
+
+```diff
+-use Illuminate\Support\Carbon;
++use Illuminate\Support\Facades\Date;
+
+-Carbon::now();
+-Carbon::today();
++Date::now();
++Date::today();
 ```
 
 <br>

--- a/src/Rector/StaticCall/CarbonToDateFacadeRector.php
+++ b/src/Rector/StaticCall/CarbonToDateFacadeRector.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace RectorLaravel\Rector\StaticCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name\FullyQualified;
+use PHPStan\Type\ObjectType;
+use RectorLaravel\AbstractRector;
+use Symplify\RuleDocGenerator\Exception\PoorDocumentationException;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\StaticCall\CarbonToDateFacadeRector\CarbonToDateFacadeRectorTest
+ */
+final class CarbonToDateFacadeRector extends AbstractRector
+{
+    /**
+     * @throws PoorDocumentationException
+     */
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Refactor Carbon static method calls to use the Date facade instead.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use Carbon\Carbon;
+
+Carbon::now();
+Carbon::parse('2024-01-01');
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use Illuminate\Support\Facades\Date;
+
+Date::now();
+Date::parse('2024-01-01');
+CODE_SAMPLE
+                ),
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use Illuminate\Support\Carbon;
+
+Carbon::now();
+Carbon::today();
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use Illuminate\Support\Facades\Date;
+
+Date::now();
+Date::today();
+CODE_SAMPLE
+                ),
+            ],
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [StaticCall::class];
+    }
+
+    public function refactor(Node $node): ?StaticCall
+    {
+        if (! $node instanceof StaticCall) {
+            return null;
+        }
+
+        if (! $this->isCarbon($node->class)) {
+            return null;
+        }
+
+        return new StaticCall(
+            new FullyQualified('Illuminate\Support\Facades\Date'),
+            $node->name,
+            $node->args,
+            $node->getAttributes()
+        );
+    }
+
+    private function isCarbon(Node $node): bool
+    {
+        return $this->isObjectType($node, new ObjectType('Carbon\Carbon')) ||
+            $this->isObjectType($node, new ObjectType('Illuminate\Support\Carbon'));
+    }
+}

--- a/tests/Rector/StaticCall/CarbonToDateFacadeRector/CarbonToDateFacadeRectorTest.php
+++ b/tests/Rector/StaticCall/CarbonToDateFacadeRector/CarbonToDateFacadeRectorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\StaticCall\CarbonToDateFacadeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Exception\ShouldNotHappenException;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class CarbonToDateFacadeRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     *
+     * @throws ShouldNotHappenException
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/StaticCall/CarbonToDateFacadeRector/Fixture/carbon_carbon.php.inc
+++ b/tests/Rector/StaticCall/CarbonToDateFacadeRector/Fixture/carbon_carbon.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\CarbonToDateFacadeRector\Fixture;
+
+use Carbon\Carbon;
+
+class CarbonCarbon
+{
+    public function run()
+    {
+        $now = Carbon::now();
+        $today = Carbon::today();
+        $yesterday = Carbon::yesterday();
+        $tomorrow = Carbon::tomorrow();
+        $parsed = Carbon::parse('2024-01-01');
+        $created = Carbon::create(2024, 1, 1);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\CarbonToDateFacadeRector\Fixture;
+
+use Carbon\Carbon;
+
+class CarbonCarbon
+{
+    public function run()
+    {
+        $now = \Illuminate\Support\Facades\Date::now();
+        $today = \Illuminate\Support\Facades\Date::today();
+        $yesterday = \Illuminate\Support\Facades\Date::yesterday();
+        $tomorrow = \Illuminate\Support\Facades\Date::tomorrow();
+        $parsed = \Illuminate\Support\Facades\Date::parse('2024-01-01');
+        $created = \Illuminate\Support\Facades\Date::create(2024, 1, 1);
+    }
+}
+
+?>

--- a/tests/Rector/StaticCall/CarbonToDateFacadeRector/Fixture/illuminate_support_carbon.php.inc
+++ b/tests/Rector/StaticCall/CarbonToDateFacadeRector/Fixture/illuminate_support_carbon.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\CarbonToDateFacadeRector\Fixture;
+
+use Illuminate\Support\Carbon;
+
+class IlluminateSupportCarbon
+{
+    public function run()
+    {
+        $now = Carbon::now();
+        $today = Carbon::today();
+        $parsed = Carbon::parse('2024-01-01');
+        $created = Carbon::createFromFormat('Y-m-d', '2024-01-01');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\CarbonToDateFacadeRector\Fixture;
+
+use Illuminate\Support\Carbon;
+
+class IlluminateSupportCarbon
+{
+    public function run()
+    {
+        $now = \Illuminate\Support\Facades\Date::now();
+        $today = \Illuminate\Support\Facades\Date::today();
+        $parsed = \Illuminate\Support\Facades\Date::parse('2024-01-01');
+        $created = \Illuminate\Support\Facades\Date::createFromFormat('Y-m-d', '2024-01-01');
+    }
+}
+
+?>

--- a/tests/Rector/StaticCall/CarbonToDateFacadeRector/Fixture/skip_already_using_date_facade.php.inc
+++ b/tests/Rector/StaticCall/CarbonToDateFacadeRector/Fixture/skip_already_using_date_facade.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\CarbonToDateFacadeRector\Fixture;
+
+use Illuminate\Support\Facades\Date;
+
+class SkipAlreadyUsingDateFacade
+{
+    public function run()
+    {
+        // Should not be changed - already using Date facade
+        $now = Date::now();
+    }
+}

--- a/tests/Rector/StaticCall/CarbonToDateFacadeRector/Fixture/skip_non_carbon_class.php.inc
+++ b/tests/Rector/StaticCall/CarbonToDateFacadeRector/Fixture/skip_non_carbon_class.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\CarbonToDateFacadeRector\Fixture;
+
+use SomeOther\Carbon;
+
+class SkipNonCarbonClass
+{
+    public function run()
+    {
+        // Should not be changed - different Carbon class
+        $now = Carbon::now();
+    }
+}

--- a/tests/Rector/StaticCall/CarbonToDateFacadeRector/Fixture/with_fully_qualified_names.php.inc
+++ b/tests/Rector/StaticCall/CarbonToDateFacadeRector/Fixture/with_fully_qualified_names.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\CarbonToDateFacadeRector\Fixture;
+
+use Carbon\Carbon;
+
+class WithFullyQualifiedNames
+{
+    public function run()
+    {
+        $now = \Carbon\Carbon::now();
+        $today = \Illuminate\Support\Carbon::today();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\CarbonToDateFacadeRector\Fixture;
+
+use Carbon\Carbon;
+
+class WithFullyQualifiedNames
+{
+    public function run()
+    {
+        $now = \Illuminate\Support\Facades\Date::now();
+        $today = \Illuminate\Support\Facades\Date::today();
+    }
+}
+
+?>

--- a/tests/Rector/StaticCall/CarbonToDateFacadeRector/config/configured_rule.php
+++ b/tests/Rector/StaticCall/CarbonToDateFacadeRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\StaticCall\CarbonToDateFacadeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+    $rectorConfig->rule(CarbonToDateFacadeRector::class);
+};


### PR DESCRIPTION
Laravel's Date facade has some benefits; notably that it adheres to whatever handler is configured (so if you call `Date::use(CarbonImmutable::class)` in a service provider, all your dates will be immutable).

```diff
- Carbon::now();
+ Date::now();
```