### PR TITLE
Refactor attempts to get request data to use type-specific methods when the type is known

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 86 Rules Overview
+# 87 Rules Overview
 
 ## AbortIfRector
 
@@ -1374,6 +1374,25 @@ Change if report to report_if
 -}
 +report_if($condition, new Exception());
 +report_unless($condition, new Exception());
+```
+
+<br>
+
+## RequestInputToTypedMethodRector
+
+Refactor Request input/get/data methods and array access to type-specific methods when the type is known
+
+- class: [`RectorLaravel\Rector\MethodCall\RequestInputToTypedMethodRector`](../src/Rector/MethodCall/RequestInputToTypedMethodRector.php)
+
+```diff
+-$name = $request->input('name');
+-$age = (int) $request->get('age');
+-$price = (float) $request->data('price');
+-$isActive = (bool) $request['is_active'];
++$name = $request->string('name');
++$age = $request->integer('age');
++$price = $request->float('price');
++$isActive = $request->boolean('is_active');
 ```
 
 <br>

--- a/src/Rector/MethodCall/RequestInputToTypedMethodRector.php
+++ b/src/Rector/MethodCall/RequestInputToTypedMethodRector.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Cast;
+use PhpParser\Node\Expr\Cast\Bool_;
+use PhpParser\Node\Expr\Cast\Double;
+use PhpParser\Node\Expr\Cast\Int_;
+use PhpParser\Node\Expr\Cast\String_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_ as ScalarString;
+use PHPStan\Type\ObjectType;
+use RectorLaravel\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\MethodCall\RequestInputToTypedMethodRector\RequestInputToTypedMethodRectorTest
+ */
+final class RequestInputToTypedMethodRector extends AbstractRector
+{
+    private const array GENERIC_METHODS = ['input', 'get', 'data'];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Refactor Request input/get/data methods and array access to type-specific methods when the type is known',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+$name = $request->input('name');
+$age = (int) $request->get('age');
+$price = (float) $request->data('price');
+$isActive = (bool) $request['is_active'];
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+$name = $request->string('name');
+$age = $request->integer('age');
+$price = $request->float('price');
+$isActive = $request->boolean('is_active');
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Cast::class, Assign::class];
+    }
+
+    /**
+     * @param Cast|Assign $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node instanceof Cast) {
+            return $this->refactorCast($node);
+        }
+
+        if ($node instanceof Assign) {
+            return $this->refactorAssign($node);
+        }
+
+        return null;
+    }
+
+    private function refactorCast(Cast $cast): ?Node
+    {
+        $expr = $cast->expr;
+
+        if ($expr instanceof MethodCall) {
+            $typedMethod = $this->getTypedMethodFromCast($cast);
+            if ($typedMethod !== null && $this->isRequestMethodCall($expr)) {
+                return $this->replaceWithTypedMethod($expr, $typedMethod);
+            }
+        }
+
+        if ($expr instanceof ArrayDimFetch) {
+            $typedMethod = $this->getTypedMethodFromCast($cast);
+            if ($typedMethod !== null && $this->isRequestArrayAccess($expr)) {
+                return $this->convertArrayAccessToTypedMethod($expr, $typedMethod);
+            }
+        }
+
+        if ($expr instanceof PropertyFetch) {
+            $typedMethod = $this->getTypedMethodFromCast($cast);
+            if ($typedMethod !== null && $this->isRequestPropertyFetch($expr)) {
+                return $this->convertPropertyFetchToTypedMethod($expr, $typedMethod);
+            }
+        }
+
+        return null;
+    }
+
+    private function refactorAssign(Assign $assign): ?Node
+    {
+        $expr = $assign->expr;
+
+        if ($expr instanceof MethodCall && $this->isRequestMethodCall($expr)) {
+            $typedMethod = $this->inferTypeFromContext($assign);
+            if ($typedMethod !== null) {
+                $assign->expr = $this->replaceWithTypedMethod($expr, $typedMethod);
+                return $assign;
+            }
+        }
+
+        if ($expr instanceof ArrayDimFetch && $this->isRequestArrayAccess($expr)) {
+            $typedMethod = $this->inferTypeFromContext($assign);
+            if ($typedMethod !== null) {
+                $assign->expr = $this->convertArrayAccessToTypedMethod($expr, $typedMethod);
+                return $assign;
+            }
+        }
+
+        if ($expr instanceof PropertyFetch && $this->isRequestPropertyFetch($expr)) {
+            $typedMethod = $this->inferTypeFromContext($assign);
+            if ($typedMethod !== null) {
+                $assign->expr = $this->convertPropertyFetchToTypedMethod($expr, $typedMethod);
+                return $assign;
+            }
+        }
+
+        return null;
+    }
+
+    private function isRequestMethodCall(MethodCall $methodCall): bool
+    {
+        if (! $this->isObjectType($methodCall->var, new ObjectType('Illuminate\Http\Request'))) {
+            return false;
+        }
+
+        $methodName = $this->getName($methodCall->name);
+        return $methodName !== null && in_array($methodName, self::GENERIC_METHODS, true);
+    }
+
+    private function isRequestArrayAccess(ArrayDimFetch $arrayDimFetch): bool
+    {
+        return $arrayDimFetch->var instanceof Variable
+            && $this->isObjectType($arrayDimFetch->var, new ObjectType('Illuminate\Http\Request'));
+    }
+
+    private function isRequestPropertyFetch(PropertyFetch $propertyFetch): bool
+    {
+        return $propertyFetch->var instanceof Variable
+            && $this->isObjectType($propertyFetch->var, new ObjectType('Illuminate\Http\Request'));
+    }
+
+    private function getTypedMethodFromCast(Cast $cast): ?string
+    {
+        return match (true) {
+            $cast instanceof String_ => 'string',
+            $cast instanceof Int_ => 'integer',
+            $cast instanceof Double => 'float',
+            $cast instanceof Bool_ => 'boolean',
+            default => null,
+        };
+    }
+
+    private function inferTypeFromContext(Assign $assign): ?string
+    {
+        if (! $assign->var instanceof Variable) {
+            return null;
+        }
+
+        $varType = $this->nodeTypeResolver->getType($assign->var);
+
+        if ($varType->isString()->yes()) {
+            return 'string';
+        }
+
+        if ($varType->isInteger()->yes()) {
+            return 'integer';
+        }
+
+        if ($varType->isFloat()->yes()) {
+            return 'float';
+        }
+
+        if ($varType->isBoolean()->yes()) {
+            return 'boolean';
+        }
+
+        $objectClassNames = $varType->getObjectClassNames();
+        if (in_array('Carbon\Carbon', $objectClassNames, true) || in_array('Illuminate\Support\Carbon', $objectClassNames, true)) {
+            return 'date';
+        }
+
+        return null;
+    }
+
+    private function replaceWithTypedMethod(MethodCall $methodCall, string $typedMethod): MethodCall
+    {
+        $methodCall->name = new Identifier($typedMethod);
+        return $methodCall;
+    }
+
+    private function convertArrayAccessToTypedMethod(ArrayDimFetch $arrayDimFetch, string $typedMethod): MethodCall
+    {
+        if (! $arrayDimFetch->var instanceof Variable) {
+            return new MethodCall($arrayDimFetch->var, $typedMethod);
+        }
+
+        $args = [];
+        if ($arrayDimFetch->dim !== null) {
+            $args[] = new Node\Arg($arrayDimFetch->dim);
+        }
+
+        return new MethodCall($arrayDimFetch->var, $typedMethod, $args);
+    }
+
+    private function convertPropertyFetchToTypedMethod(PropertyFetch $propertyFetch, string $typedMethod): MethodCall
+    {
+        $propertyName = $this->getName($propertyFetch->name);
+        if ($propertyName === null) {
+            return new MethodCall($propertyFetch->var, $typedMethod);
+        }
+
+        return new MethodCall(
+            $propertyFetch->var,
+            $typedMethod,
+            [new Node\Arg(new ScalarString($propertyName))]
+        );
+    }
+}

--- a/tests/Rector/MethodCall/RequestInputToTypedMethodRector/Fixture/array_access_with_cast.php.inc
+++ b/tests/Rector/MethodCall/RequestInputToTypedMethodRector/Fixture/array_access_with_cast.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RequestInputToTypedMethodRector\Fixture;
+
+use Illuminate\Http\Request;
+
+class ArrayAccessWithCast
+{
+    public function store(Request $request)
+    {
+        $name = (string) $request['name'];
+        $age = (int) $request['age'];
+        $price = (float) $request['price'];
+        $isActive = (bool) $request['is_active'];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RequestInputToTypedMethodRector\Fixture;
+
+use Illuminate\Http\Request;
+
+class ArrayAccessWithCast
+{
+    public function store(Request $request)
+    {
+        $name = $request->string('name');
+        $age = $request->integer('age');
+        $price = $request->float('price');
+        $isActive = $request->boolean('is_active');
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/RequestInputToTypedMethodRector/Fixture/cast_to_boolean.php.inc
+++ b/tests/Rector/MethodCall/RequestInputToTypedMethodRector/Fixture/cast_to_boolean.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RequestInputToTypedMethodRector\Fixture;
+
+use Illuminate\Http\Request;
+
+class CastToBoolean
+{
+    public function store(Request $request)
+    {
+        $isActive = (bool) $request->input('is_active');
+        $enabled = (bool) $request->get('enabled');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RequestInputToTypedMethodRector\Fixture;
+
+use Illuminate\Http\Request;
+
+class CastToBoolean
+{
+    public function store(Request $request)
+    {
+        $isActive = $request->boolean('is_active');
+        $enabled = $request->boolean('enabled');
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/RequestInputToTypedMethodRector/Fixture/cast_to_float.php.inc
+++ b/tests/Rector/MethodCall/RequestInputToTypedMethodRector/Fixture/cast_to_float.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RequestInputToTypedMethodRector\Fixture;
+
+use Illuminate\Http\Request;
+
+class CastToFloat
+{
+    public function store(Request $request)
+    {
+        $price = (float) $request->input('price');
+        $amount = (double) $request->get('amount');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RequestInputToTypedMethodRector\Fixture;
+
+use Illuminate\Http\Request;
+
+class CastToFloat
+{
+    public function store(Request $request)
+    {
+        $price = $request->float('price');
+        $amount = $request->float('amount');
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/RequestInputToTypedMethodRector/Fixture/cast_to_integer.php.inc
+++ b/tests/Rector/MethodCall/RequestInputToTypedMethodRector/Fixture/cast_to_integer.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RequestInputToTypedMethodRector\Fixture;
+
+use Illuminate\Http\Request;
+
+class CastToInteger
+{
+    public function store(Request $request)
+    {
+        $age = (int) $request->input('age');
+        $count = (int) $request->get('count');
+        $quantity = (int) $request->data('quantity');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RequestInputToTypedMethodRector\Fixture;
+
+use Illuminate\Http\Request;
+
+class CastToInteger
+{
+    public function store(Request $request)
+    {
+        $age = $request->integer('age');
+        $count = $request->integer('count');
+        $quantity = $request->integer('quantity');
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/RequestInputToTypedMethodRector/Fixture/cast_to_string.php.inc
+++ b/tests/Rector/MethodCall/RequestInputToTypedMethodRector/Fixture/cast_to_string.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RequestInputToTypedMethodRector\Fixture;
+
+use Illuminate\Http\Request;
+
+class CastToString
+{
+    public function store(Request $request)
+    {
+        $name = (string) $request->input('name');
+        $email = (string) $request->get('email');
+        $address = (string) $request->data('address');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RequestInputToTypedMethodRector\Fixture;
+
+use Illuminate\Http\Request;
+
+class CastToString
+{
+    public function store(Request $request)
+    {
+        $name = $request->string('name');
+        $email = $request->string('email');
+        $address = $request->string('address');
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/RequestInputToTypedMethodRector/Fixture/property_fetch_with_cast.php.inc
+++ b/tests/Rector/MethodCall/RequestInputToTypedMethodRector/Fixture/property_fetch_with_cast.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RequestInputToTypedMethodRector\Fixture;
+
+use Illuminate\Http\Request;
+
+class PropertyFetchWithCast
+{
+    public function store(Request $request)
+    {
+        $name = (string) $request->name;
+        $age = (int) $request->age;
+        $price = (float) $request->price;
+        $isActive = (bool) $request->is_active;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RequestInputToTypedMethodRector\Fixture;
+
+use Illuminate\Http\Request;
+
+class PropertyFetchWithCast
+{
+    public function store(Request $request)
+    {
+        $name = $request->string('name');
+        $age = $request->integer('age');
+        $price = $request->float('price');
+        $isActive = $request->boolean('is_active');
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/RequestInputToTypedMethodRector/Fixture/skip_already_typed.php.inc
+++ b/tests/Rector/MethodCall/RequestInputToTypedMethodRector/Fixture/skip_already_typed.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RequestInputToTypedMethodRector\Fixture;
+
+use Illuminate\Http\Request;
+
+class SkipAlreadyTyped
+{
+    public function store(Request $request)
+    {
+        // Should not change if already using typed methods
+        $name = $request->string('name');
+        $age = $request->integer('age');
+        $price = $request->float('price');
+        $isActive = $request->boolean('is_active');
+        $date = $request->date('date');
+        
+        // Should not change if no cast
+        $data = $request->input('data');
+        $value = $request->get('value');
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/RequestInputToTypedMethodRector/Fixture/skip_already_typed.php.inc
+++ b/tests/Rector/MethodCall/RequestInputToTypedMethodRector/Fixture/skip_already_typed.php.inc
@@ -14,7 +14,7 @@ class SkipAlreadyTyped
         $price = $request->float('price');
         $isActive = $request->boolean('is_active');
         $date = $request->date('date');
-        
+
         // Should not change if no cast
         $data = $request->input('data');
         $value = $request->get('value');

--- a/tests/Rector/MethodCall/RequestInputToTypedMethodRector/RequestInputToTypedMethodRectorTest.php
+++ b/tests/Rector/MethodCall/RequestInputToTypedMethodRector/RequestInputToTypedMethodRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\MethodCall\RequestInputToTypedMethodRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RequestInputToTypedMethodRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule_without_configuration.php';
+    }
+}

--- a/tests/Rector/MethodCall/RequestInputToTypedMethodRector/config/configured_rule_without_configuration.php
+++ b/tests/Rector/MethodCall/RequestInputToTypedMethodRector/config/configured_rule_without_configuration.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\MethodCall\RequestInputToTypedMethodRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(RequestInputToTypedMethodRector::class);
+};


### PR DESCRIPTION
```diff
-$name = $request->input('name');
-$age = (int) $request->get('age');
-$price = (float) $request->data('price');
-$isActive = (bool) $request['is_active'];
+$name = $request->string('name');
+$age = $request->integer('age');
+$price = $request->float('price');
+$isActive = $request->boolean('is_active');
```