### PR TITLE
Fix DispatchToHelperFunctionsRector when dispatching within self

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 87 Rules Overview
+# 88 Rules Overview
 
 ## AbortIfRector
 

--- a/src/Rector/StaticCall/DispatchToHelperFunctionsRector.php
+++ b/src/Rector/StaticCall/DispatchToHelperFunctionsRector.php
@@ -3,7 +3,6 @@
 namespace RectorLaravel\Rector\StaticCall;
 
 use PhpParser\Node;
-use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
@@ -137,11 +136,13 @@ final class DispatchToHelperFunctionsRector extends AbstractRector
             return null;
         }
 
-        return new FuncCall(
-            new Name($method),
-            [
-                new Arg(new New_(new FullyQualified($class), $staticCall->args)),
-            ],
+        $className = $class->isSpecialClassName()
+            ? $class
+            : new FullyQualified($class);
+
+        return $this->nodeFactory->createFuncCall(
+            $method,
+            [new New_($className, $staticCall->args)],
         );
     }
 }

--- a/tests/Rector/StaticCall/DispatchToHelperFunctionsRector/Fixture/bus_dispatchable_within_self.php.inc
+++ b/tests/Rector/StaticCall/DispatchToHelperFunctionsRector/Fixture/bus_dispatchable_within_self.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\DispatchToHelperFunctionsRector\Fixture;
+
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class BusDispatchableWithinSelf
+{
+    use Dispatchable;
+
+    public function handle()
+    {
+        self::dispatch();
+    }
+}
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\DispatchToHelperFunctionsRector\Fixture;
+
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class BusDispatchableWithinSelf
+{
+    use Dispatchable;
+
+    public function handle()
+    {
+        dispatch(new self());
+    }
+}


### PR DESCRIPTION
Currently, the rule produces invalid code when converting `self::dispatch()` into `dispatch(new \self())`. The error is ` "'\self' is an invalid class name"`.

I've modified it so the new code is `dispatch(new self()`.