### PR TITLE
fix: deficiencies in the EloquentMagicMethodToQueryBuilderRector

### DIFF
--- a/stubs/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/stubs/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -6,4 +6,9 @@ if (class_exists('Illuminate\Database\Eloquent\Factories\Factory')) {
     return;
 }
 
-abstract class Factory {}
+/** @template TModel of \Illuminate\Database\Eloquent\Model */
+abstract class Factory
+{
+    /** @var class-string<TModel> */
+    protected $model;
+}

--- a/stubs/Illuminate/Database/Query/Builder.php
+++ b/stubs/Illuminate/Database/Query/Builder.php
@@ -22,6 +22,12 @@ class Builder implements \Illuminate\Contracts\Database\Query\Builder
      */
     public function orderByDesc($column): static {}
 
+    /**
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @return mixed
+     */
+    public function max($column) {}
+
     protected function protectedMethodBelongsToQueryBuilder(): void {}
 
     private function privateMethodBelongsToQueryBuilder(): void {}

--- a/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/EloquentMagicMethodToQueryBuilderRectorTest.php
+++ b/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/EloquentMagicMethodToQueryBuilderRectorTest.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector;
 
-use Illuminate\Database\Eloquent\Model;
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-
-final class User extends Model {}
 
 final class EloquentMagicMethodToQueryBuilderRectorTest extends AbstractRectorTestCase
 {

--- a/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Fixture/factory_model.php.inc
+++ b/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Fixture/factory_model.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Fixture;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Source\User;
+
+/** @extends Factory<User> */
+class UserFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'sort' => $this->model::max('sort') + 1,
+        ];
+    }
+}
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Fixture;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Source\User;
+
+/** @extends Factory<User> */
+class UserFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'sort' => $this->model::query()->max('sort') + 1,
+        ];
+    }
+}
+?>

--- a/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Fixture/fixture.php.inc
+++ b/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Fixture/fixture.php.inc
@@ -2,7 +2,7 @@
 
 namespace RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Fixture;
 
-use RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\User;
+use RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Source\User;
 
 class SomeController
 {
@@ -37,7 +37,7 @@ class SomeController
 
 namespace RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Fixture;
 
-use RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\User;
+use RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Source\User;
 
 class SomeController
 {

--- a/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Fixture/model_interface_intersection.php.inc
+++ b/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Fixture/model_interface_intersection.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Fixture;
+
+use RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Source\FooInterface;
+use RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Source\User;
+
+function (User&FooInterface $user) {
+    $user::max('sort') + 1;
+};
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Fixture;
+
+use RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Source\FooInterface;
+use RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Source\User;
+
+function (User&FooInterface $user) {
+    $user::query()->max('sort') + 1;
+};
+
+?>

--- a/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Fixture/model_scope.php.inc
+++ b/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Fixture/model_scope.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Fixture;
+
+use RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Source\User;
+
+User::foo();
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Fixture;
+
+use RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Source\User;
+
+User::query()->foo();
+?>

--- a/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Fixture/skip_method_matching_scope.php.inc
+++ b/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Fixture/skip_method_matching_scope.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Fixture;
+
+use RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Source\User;
+
+User::conflict();

--- a/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Fixture/unknown_model.php.inc
+++ b/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Fixture/unknown_model.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+function (string $class, Model $model) {
+    /** @var class-string<Model> $class */
+    $class::max('sort') + 1;
+    $model::max('sort') + 1;
+};
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+function (string $class, Model $model) {
+    /** @var class-string<Model> $class */
+    $class::query()->max('sort') + 1;
+    $model::query()->max('sort') + 1;
+};
+?>

--- a/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Fixture/with_exclude_methods.php.inc
+++ b/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Fixture/with_exclude_methods.php.inc
@@ -2,7 +2,7 @@
 
 namespace RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Fixture;
 
-use RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\User;
+use RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Source\User;
 
 class SomeController
 {
@@ -29,7 +29,7 @@ class SomeController
 
 namespace RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Fixture;
 
-use RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\User;
+use RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Source\User;
 
 class SomeController
 {

--- a/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Source/FooInterface.php
+++ b/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Source/FooInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Source;
+
+interface FooInterface {}

--- a/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Source/User.php
+++ b/tests/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector/Source/User.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector\Source;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    public static function conflict(): void {}
+
+    protected function scopeConflict(Builder $query): void {}
+
+    protected function scopeFoo(Builder $query): Builder
+    {
+        return $query;
+    }
+}


### PR DESCRIPTION
Hello!

This fixes several deficiencies in the rector that prevented the following cases from being converted:
- static calls on class-strings
- methods on custom builder classes
- calls on an unknown models
- calls on a model intersection with an interface
- static calls with a model scope

Thanks!