### PR TITLE
feat: rename resolve() to app()

### DIFF
--- a/config/sets/laravel-code-quality.php
+++ b/config/sets/laravel-code-quality.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\FuncCall\RenameFunctionRector;
 use RectorLaravel\Rector\ArrayDimFetch\EnvVariableToEnvHelperRector;
 use RectorLaravel\Rector\ArrayDimFetch\RequestVariablesToRequestFacadeRector;
 use RectorLaravel\Rector\ArrayDimFetch\ServerVariableToRequestFacadeRector;
@@ -54,4 +55,5 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(DispatchToHelperFunctionsRector::class);
     $rectorConfig->rule(NotFilledBlankFuncCallToBlankFilledFuncCallRector::class);
     $rectorConfig->rule(EloquentOrderByToLatestOrOldestRector::class);
+    $rectorConfig->ruleWithConfiguration(RenameFunctionRector::class, ['resolve' => 'app']);
 };


### PR DESCRIPTION
Hello!

`resolve()` is just an alias of `app()`, so this renames all instances to `app()` which also slightly increases performance

Thanks!