### PR TITLE
Reduce NodeVisitor::DONT_TRAVERSE_* usage on ArrayToArrGetRector (part 1)

### DIFF
--- a/src/Rector/ArrayDimFetch/ArrayToArrGetRector.php
+++ b/src/Rector/ArrayDimFetch/ArrayToArrGetRector.php
@@ -94,7 +94,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($node->getAttribute(AttributeKey::IS_BEING_ASSIGNED)) {
+        if ($node->getAttribute(AttributeKey::IS_BEING_ASSIGNED) === true) {
             return null;
         }
 


### PR DESCRIPTION
Rector is removing tweak below node usage via:

```
NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN
NodeVisitor::DONT_TRAVERSE_CHILDREN
```

see PR:

- https://github.com/rectorphp/rector-src/pull/7697

This PR is starter to keep compatible :)