### PR TITLE
Stricter checks for converting startOfDay() to today()

### DIFF
--- a/src/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector.php
+++ b/src/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector.php
@@ -45,6 +45,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if (! $node->var instanceof FuncCall) {
+            return null;
+        }
+
         if (! $this->isName($node->var, 'now')) {
             return null;
         }

--- a/tests/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector/Fixture/skip_non_now_helper_calls.php.inc
+++ b/tests/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector/Fixture/skip_non_now_helper_calls.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\HelperFuncCallToFacadeClassRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        $now->startOfDay();
+        $this->now->startOfDay();
+        $this->now()->startOfDay();
+
+        now()->startOfDay();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\HelperFuncCallToFacadeClassRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        $now->startOfDay();
+        $this->now->startOfDay();
+        $this->now()->startOfDay();
+
+        today();
+    }
+}
+
+?>


### PR DESCRIPTION
Fixes #448 where this rule will incorrectly match any variable on the left hand side of the call to the startOfDay() method as long as its called "now" rather than just the now() helper.

Eg: $now->startOfDay(), $this->now->startOfDay() or $this->now()->startOfDay()