### PR TITLE
fix: skip abstract methods

### DIFF
--- a/src/Rector/ClassMethod/MigrateToSimplifiedAttributeRector.php
+++ b/src/Rector/ClassMethod/MigrateToSimplifiedAttributeRector.php
@@ -58,7 +58,7 @@ final class MigrateToSimplifiedAttributeRector extends AbstractRector
         $hasChanged = false;
 
         foreach ($node->stmts as $key => $stmt) {
-            if (! $stmt instanceof ClassMethod) {
+            if (! $stmt instanceof ClassMethod || $stmt->isAbstract()) {
                 continue;
             }
 

--- a/src/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector.php
+++ b/src/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector.php
@@ -83,6 +83,10 @@ CODE_SAMPLE
 
         $changes = false;
         foreach ($node->getMethods() as $classMethod) {
+            if ($classMethod->isAbstract()) {
+                continue;
+            }
+
             $name = $this->getName($classMethod);
             // make sure it starts with scope and the next character is upper case
             if (! str_starts_with($name, 'scope') || ! ctype_upper(substr($name, 5, 1))) {

--- a/tests/Rector/ClassMethod/MigrateToSimplifiedAttributeRector/Fixture/skip-abstract-methods.php.inc
+++ b/tests/Rector/ClassMethod/MigrateToSimplifiedAttributeRector/Fixture/skip-abstract-methods.php.inc
@@ -1,0 +1,5 @@
+<?php
+class SkipAbstractMethods extends \Illuminate\Database\Eloquent\Model
+{
+    abstract public function getStatusAttribute(): string;
+}

--- a/tests/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector/Fixture/skip_abstract_methods.php.inc
+++ b/tests/Rector/ClassMethod/ScopeNamedClassMethodToScopeAttributedClassMethodRector/Fixture/skip_abstract_methods.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ScopeNamedClassMethodToScopeAttributedClassMethodRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipAbstractMethods extends Model
+{
+    abstract public function scopeSomeMethod();
+}


### PR DESCRIPTION
Rules:
  - MigrateToSimplifiedAttributeRector
  - ScopeNamedClassMethodToScopeAttributedClassMethodRector

Closes #445