### PR TITLE
[2.x] Update action versions

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -36,13 +36,13 @@ jobs:
         name: ${{ matrix.actions.name }}
 
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
 
             -   uses: shivammathur/setup-php@v2
                 with:
                     php-version: 8.3
                     coverage: none
 
-            -   uses: ramsey/composer-install@v2
+            -   uses: ramsey/composer-install@v3
 
             -   run: ${{ matrix.actions.run }}

--- a/.github/workflows/downgraded_release.yaml
+++ b/.github/workflows/downgraded_release.yaml
@@ -15,7 +15,7 @@ jobs:
 
         steps:
             -
-                uses: "actions/checkout@v4"
+                uses: "actions/checkout@v6"
 
             -
                 uses: "shivammathur/setup-php@v2"
@@ -23,7 +23,7 @@ jobs:
                     php-version: 8.3
                     coverage: none
 
-            -   uses: "ramsey/composer-install@v2"
+            -   uses: "ramsey/composer-install@v3"
 
             # downgrade /src to PHP 7.4
             -   run: vendor/bin/rector process src config --config build/rector-downgrade-php-74.php --ansi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,13 +16,13 @@ jobs:
 
         name: PHP Tests
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
 
             -   uses: shivammathur/setup-php@v2
                 with:
                     php-version: 8.3
                     coverage: none
 
-            -   uses: ramsey/composer-install@v2
+            -   uses: ramsey/composer-install@v3
 
             -   run: vendor/bin/phpunit tests


### PR DESCRIPTION
Noticed some outdated actions here while I was about to PR a new rule, so thought I'd sort it.

- [Checkout is v6](https://github.com/actions/checkout?tab=readme-ov-file#checkout-v6)
- [composer-install is v3](https://github.com/ramsey/composer-install/releases)