### PR TITLE
Adds a Laravel Boost config

### DIFF
--- a/resources/boost/guidlines/core.blade.php
+++ b/resources/boost/guidlines/core.blade.php
@@ -1,0 +1,8 @@
+## Rector Laravel
+
+This package provides PHP Rector rules for Laravel and Laravel first-party packages like Livewire.
+
+### Uses
+
+- You must run `vendor/bin/rector --output-format=json --no-diffs` before running tests or linting.
+- Do not alter the `rector.php` config file.


### PR DESCRIPTION
# Changes

Adds a [Laravel Boost](https://github.com/laravel/boost) config per the project's readme.

# Why

Feels like it would be useful for people who want to use Rector and have boost installed so that it will attempt to run Rector at the correct time and with the best options for an Agent.