### PR TITLE
chore: add rector config to composer extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,6 @@ use Rector\Config\RectorConfig;
 use RectorLaravel\Rector\FuncCall\RemoveDumpDataDeadCodeRector;
 
 return RectorConfig::configure()
-    // include default config
-    ->withSets([
-        __DIR__ . '/vendor/driftingly/rector-laravel/config/config.php'
-    ])
     ->withConfiguredRule(RemoveDumpDataDeadCodeRector::class, [
         'dd', 'dump', 'var_dump'
     ]);
@@ -131,10 +127,6 @@ use Rector\Config\RectorConfig;
 use RectorLaravel\Rector\MethodCall\ResponseHelperCallToJsonResponseRector;
 
 return RectorConfig::configure()
-    // include default config
-    ->withSets([
-        __DIR__ . '/vendor/driftingly/rector-laravel/config/config.php'
-    ])
     ->withRules([
         ResponseHelperCallToJsonResponseRector::class,
     ]);

--- a/composer.json
+++ b/composer.json
@@ -60,5 +60,10 @@
             "phpstan/extension-installer": true,
             "cweagans/composer-patches": false
         }
+    },
+    "extra": {
+        "rector": {
+            "includes": ["config/config.php"]
+        }
     }
 }


### PR DESCRIPTION
This adds the default config to the composer extras section to be picked up by rector, it also removes the example from the config because none of those rules need it anyway