### PR TITLE
wip: try to get ci passing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,14 @@
     "description": "Rector upgrades rules for Laravel Framework",
     "require": {
         "php": ">=8.3",
-        "rector/rector": "^2.3.0",
+        "rector/rector": "2.3.1",
         "webmozart/assert": "^1.11 || ^2.0",
         "symplify/rule-doc-generator-contracts": "^11.2"
     },
     "require-dev": {
         "nikic/php-parser": "^5.6",
         "phpstan/extension-installer": "^1.3",
-        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan": "2.1.33",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0",


### PR DESCRIPTION
Try rolling back to the last rector and phpstan releases

See https://github.com/rectorphp/rector-src/pull/7846 problem looks to be PHPStan 2.1.35