### PR TITLE
Laravel 13 Model Attributes

### DIFF
--- a/config/sets/laravel130.php
+++ b/config/sets/laravel130.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use RectorLaravel\Rector\Class_\AppendsPropertyToAppendsAttributeRector;
 use RectorLaravel\Rector\Class_\FillablePropertyToFillableAttributeRector;
+use RectorLaravel\Rector\Class_\GuardedPropertyToGuardedAttributeRector;
 use RectorLaravel\Rector\Class_\HiddenPropertyToHiddenAttributeRector;
 use RectorLaravel\Rector\Class_\TablePropertyToTableAttributeRector;
 
@@ -14,6 +15,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->rule(AppendsPropertyToAppendsAttributeRector::class);
     $rectorConfig->rule(FillablePropertyToFillableAttributeRector::class);
+    $rectorConfig->rule(GuardedPropertyToGuardedAttributeRector::class);
     $rectorConfig->rule(HiddenPropertyToHiddenAttributeRector::class);
     $rectorConfig->rule(TablePropertyToTableAttributeRector::class);
 };

--- a/config/sets/laravel130.php
+++ b/config/sets/laravel130.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\AppendsPropertyToAppendsAttributeRector;
 use RectorLaravel\Rector\Class_\FillablePropertyToFillableAttributeRector;
 use RectorLaravel\Rector\Class_\HiddenPropertyToHiddenAttributeRector;
 use RectorLaravel\Rector\Class_\TablePropertyToTableAttributeRector;
@@ -11,6 +12,7 @@ use RectorLaravel\Rector\Class_\TablePropertyToTableAttributeRector;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../config.php');
 
+    $rectorConfig->rule(AppendsPropertyToAppendsAttributeRector::class);
     $rectorConfig->rule(FillablePropertyToFillableAttributeRector::class);
     $rectorConfig->rule(HiddenPropertyToHiddenAttributeRector::class);
     $rectorConfig->rule(TablePropertyToTableAttributeRector::class);

--- a/config/sets/laravel130.php
+++ b/config/sets/laravel130.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use RectorLaravel\Rector\Class_\AppendsPropertyToAppendsAttributeRector;
+use RectorLaravel\Rector\Class_\ConnectionPropertyToConnectionAttributeRector;
 use RectorLaravel\Rector\Class_\FillablePropertyToFillableAttributeRector;
 use RectorLaravel\Rector\Class_\GuardedPropertyToGuardedAttributeRector;
 use RectorLaravel\Rector\Class_\HiddenPropertyToHiddenAttributeRector;
@@ -15,6 +16,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../config.php');
 
     $rectorConfig->rule(AppendsPropertyToAppendsAttributeRector::class);
+    $rectorConfig->rule(ConnectionPropertyToConnectionAttributeRector::class);
     $rectorConfig->rule(FillablePropertyToFillableAttributeRector::class);
     $rectorConfig->rule(GuardedPropertyToGuardedAttributeRector::class);
     $rectorConfig->rule(HiddenPropertyToHiddenAttributeRector::class);

--- a/config/sets/laravel130.php
+++ b/config/sets/laravel130.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use RectorLaravel\Rector\Class_\FillablePropertyToFillableAttributeRector;
 use RectorLaravel\Rector\Class_\HiddenPropertyToHiddenAttributeRector;
+use RectorLaravel\Rector\Class_\TablePropertyToTableAttributeRector;
 
 // see https://laravel.com/docs/13.x/upgrade
 return static function (RectorConfig $rectorConfig): void {
@@ -12,4 +13,5 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->rule(FillablePropertyToFillableAttributeRector::class);
     $rectorConfig->rule(HiddenPropertyToHiddenAttributeRector::class);
+    $rectorConfig->rule(TablePropertyToTableAttributeRector::class);
 };

--- a/config/sets/laravel130.php
+++ b/config/sets/laravel130.php
@@ -8,6 +8,7 @@ use RectorLaravel\Rector\Class_\FillablePropertyToFillableAttributeRector;
 use RectorLaravel\Rector\Class_\GuardedPropertyToGuardedAttributeRector;
 use RectorLaravel\Rector\Class_\HiddenPropertyToHiddenAttributeRector;
 use RectorLaravel\Rector\Class_\TablePropertyToTableAttributeRector;
+use RectorLaravel\Rector\Class_\TouchesPropertyToTouchesAttributeRector;
 
 // see https://laravel.com/docs/13.x/upgrade
 return static function (RectorConfig $rectorConfig): void {
@@ -18,4 +19,5 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(GuardedPropertyToGuardedAttributeRector::class);
     $rectorConfig->rule(HiddenPropertyToHiddenAttributeRector::class);
     $rectorConfig->rule(TablePropertyToTableAttributeRector::class);
+    $rectorConfig->rule(TouchesPropertyToTouchesAttributeRector::class);
 };

--- a/config/sets/laravel130.php
+++ b/config/sets/laravel130.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\FillablePropertyToFillableAttributeRector;
+
+// see https://laravel.com/docs/13.x/upgrade
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../config.php');
+
+    $rectorConfig->rule(FillablePropertyToFillableAttributeRector::class);
+};

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 90 Rules Overview
+# 97 Rules Overview
 
 ## AbortIfRector
 
@@ -255,6 +255,27 @@ Convert `app()` to `resolve()` where applicable.
 ```diff
 -app('foo');
 +resolve('foo');
+```
+
+<br>
+
+## AppendsPropertyToAppendsAttributeRector
+
+Changes model appends property to use the appends attribute
+
+- class: [`RectorLaravel\Rector\Class_\AppendsPropertyToAppendsAttributeRector`](../src/Rector/Class_/AppendsPropertyToAppendsAttributeRector.php)
+
+```diff
+ use Illuminate\Database\Eloquent\Model;
++use Illuminate\Database\Eloquent\Attributes\Appends;
+
++#[Appends(['full_name'])]
+ class User extends Model
+ {
+-    protected $appends = [
+-        'full_name',
+-    ];
+ }
 ```
 
 <br>
@@ -593,6 +614,25 @@ Refactor `config()` calls to use type-specific methods when the expected type is
 
 <br>
 
+## ConnectionPropertyToConnectionAttributeRector
+
+Changes model connection property to use the Connection attribute
+
+- class: [`RectorLaravel\Rector\Class_\ConnectionPropertyToConnectionAttributeRector`](../src/Rector/Class_/ConnectionPropertyToConnectionAttributeRector.php)
+
+```diff
+ use Illuminate\Database\Eloquent\Model;
++use Illuminate\Database\Eloquent\Attributes\Connection;
+
++#[Connection('sqlite')]
+ class User extends Model
+ {
+-    protected $connection = 'sqlite';
+ }
+```
+
+<br>
+
 ## ContainerBindConcreteWithClosureOnlyRector
 
 Drop the specified abstract class from the bind method and replace it with a closure that returns the abstract class.
@@ -880,6 +920,49 @@ Use the static factory method instead of global factory function.
 
 <br>
 
+## FillablePropertyToFillableAttributeRector
+
+Changes model fillable property to use the fillable attribute
+
+- class: [`RectorLaravel\Rector\Class_\FillablePropertyToFillableAttributeRector`](../src/Rector/Class_/FillablePropertyToFillableAttributeRector.php)
+
+```diff
+ use Illuminate\Database\Eloquent\Model;
++use Illuminate\Database\Eloquent\Attributes\Fillable;
+
++#[Fillable(['name', 'email'])]
+ class User extends Model
+ {
+-    protected $fillable = [
+-        'name',
+-        'email',
+-    ];
+ }
+```
+
+<br>
+
+## GuardedPropertyToGuardedAttributeRector
+
+Changes model guarded property to use the guarded attribute
+
+- class: [`RectorLaravel\Rector\Class_\GuardedPropertyToGuardedAttributeRector`](../src/Rector/Class_/GuardedPropertyToGuardedAttributeRector.php)
+
+```diff
+ use Illuminate\Database\Eloquent\Model;
++use Illuminate\Database\Eloquent\Attributes\Guarded;
+
++#[Guarded(['is_admin'])]
+ class User extends Model
+ {
+-    protected $guarded = [
+-        'is_admin',
+-    ];
+ }
+```
+
+<br>
+
 ## HelperFuncCallToFacadeClassRector
 
 Change `app()` func calls to facade calls
@@ -894,6 +977,27 @@ Change `app()` func calls to facade calls
 -        return app('translator')->trans('value');
 +        return \Illuminate\Support\Facades\App::make('translator')->trans('value');
      }
+ }
+```
+
+<br>
+
+## HiddenPropertyToHiddenAttributeRector
+
+Changes model hidden property to use the hidden attribute
+
+- class: [`RectorLaravel\Rector\Class_\HiddenPropertyToHiddenAttributeRector`](../src/Rector/Class_/HiddenPropertyToHiddenAttributeRector.php)
+
+```diff
+ use Illuminate\Database\Eloquent\Model;
++use Illuminate\Database\Eloquent\Attributes\Hidden;
+
++#[Hidden(['password'])]
+ class User extends Model
+ {
+-    protected $hidden = [
+-        'password',
+-    ];
  }
 ```
 
@@ -1641,6 +1745,31 @@ Use `Str::startsWith()` or `Str::endsWith()` instead of `substr()` === `$str`
 
 <br>
 
+## TablePropertyToTableAttributeRector
+
+Changes model table-related properties to use the Table attribute
+
+- class: [`RectorLaravel\Rector\Class_\TablePropertyToTableAttributeRector`](../src/Rector/Class_/TablePropertyToTableAttributeRector.php)
+
+```diff
+ use Illuminate\Database\Eloquent\Model;
++use Illuminate\Database\Eloquent\Attributes\Table;
+
++#[Table(table: 'users', key: 'user_id', keyType: 'string', incrementing: false)]
+ class User extends Model
+ {
+-    protected $table = 'users';
+-
+-    protected $primaryKey = 'user_id';
+-
+-    protected $keyType = 'string';
+-
+-    protected $incrementing = false;
+ }
+```
+
+<br>
+
 ## ThrowIfAndThrowUnlessExceptionsToUseClassStringRector
 
 changes use of a new throw instance to class string
@@ -1669,6 +1798,27 @@ Change if throw to throw_if
 -}
 +throw_if($condition, new Exception());
 +throw_unless($condition, new Exception());
+```
+
+<br>
+
+## TouchesPropertyToTouchesAttributeRector
+
+Changes model touches property to use the touches attribute
+
+- class: [`RectorLaravel\Rector\Class_\TouchesPropertyToTouchesAttributeRector`](../src/Rector/Class_/TouchesPropertyToTouchesAttributeRector.php)
+
+```diff
+ use Illuminate\Database\Eloquent\Model;
++use Illuminate\Database\Eloquent\Attributes\Touches;
+
++#[Touches(['posts'])]
+ class User extends Model
+ {
+-    protected $touches = [
+-        'posts',
+-    ];
+ }
 ```
 
 <br>

--- a/src/NodeFactory/TableAttributeFactory.php
+++ b/src/NodeFactory/TableAttributeFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\NodeFactory;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name\FullyQualified;
+
+final readonly class TableAttributeFactory
+{
+    /**
+     * @param  array<string, Expr>  $options
+     */
+    public function create(Expr $table, array $options): AttributeGroup
+    {
+        $args = [new Arg($table, false, false, [], new Identifier('table'))];
+
+        foreach ($options as $name => $expr) {
+            $args[] = new Arg($expr, false, false, [], new Identifier($name));
+        }
+
+        return new AttributeGroup([
+            new Attribute(
+                new FullyQualified('Illuminate\Database\Eloquent\Attributes\Table'),
+                $args
+            ),
+        ]);
+    }
+}

--- a/src/Rector/Class_/AppendsPropertyToAppendsAttributeRector.php
+++ b/src/Rector/Class_/AppendsPropertyToAppendsAttributeRector.php
@@ -86,6 +86,10 @@ CODE_SAMPLE
 
         $appendsArray = $propertyProperty->default;
 
+        if ($appendsArray->items === []) {
+            return null;
+        }
+
         if (! $this->isArrayOfStrings($appendsArray)) {
             return null;
         }

--- a/src/Rector/Class_/AppendsPropertyToAppendsAttributeRector.php
+++ b/src/Rector/Class_/AppendsPropertyToAppendsAttributeRector.php
@@ -9,7 +9,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Type\ObjectType;
@@ -90,7 +90,7 @@ CODE_SAMPLE
         // Add attribute to class
         $node->attrGroups[] = new AttributeGroup([
             new Attribute(
-                new Name('\Illuminate\Database\Eloquent\Attributes\Appends'),
+                new FullyQualified('Illuminate\Database\Eloquent\Attributes\Appends'),
                 [new Arg($appendsArray)]
             ),
         ]);

--- a/src/Rector/Class_/AppendsPropertyToAppendsAttributeRector.php
+++ b/src/Rector/Class_/AppendsPropertyToAppendsAttributeRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Type\ObjectType;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use RectorLaravel\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -22,6 +23,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class AppendsPropertyToAppendsAttributeRector extends AbstractRector
 {
+    public function __construct(private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer) {}
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -84,6 +87,10 @@ CODE_SAMPLE
         $appendsArray = $propertyProperty->default;
 
         if (! $this->isArrayOfStrings($appendsArray)) {
+            return null;
+        }
+
+        if ($this->phpAttributeAnalyzer->hasPhpAttribute($node, 'Illuminate\Database\Eloquent\Attributes\Appends')) {
             return null;
         }
 

--- a/src/Rector/Class_/AppendsPropertyToAppendsAttributeRector.php
+++ b/src/Rector/Class_/AppendsPropertyToAppendsAttributeRector.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Type\ObjectType;
+use RectorLaravel\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\Class_\AppendsPropertyToAppendsAttributeRector\AppendsPropertyToAppendsAttributeRectorTest
+ */
+final class AppendsPropertyToAppendsAttributeRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes model appends property to use the appends attribute',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $appends = [
+        'full_name',
+    ];
+}
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Attributes\Appends;
+
+#[Appends(['full_name'])]
+class User extends Model
+{
+}
+CODE_SAMPLE
+            )]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param  Class_  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isObjectType($node, new ObjectType('Illuminate\Database\Eloquent\Model'))) {
+            return null;
+        }
+
+        $appendsProperty = $node->getProperty('appends');
+        if ($appendsProperty === null) {
+            return null;
+        }
+
+        if (! $appendsProperty->isProtected()) {
+            return null;
+        }
+
+        $propertyProperty = $appendsProperty->props[0];
+        if ($propertyProperty->default === null || ! $propertyProperty->default instanceof Array_) {
+            return null;
+        }
+
+        $appendsArray = $propertyProperty->default;
+
+        if (! $this->isArrayOfStrings($appendsArray)) {
+            return null;
+        }
+
+        // Add attribute to class
+        $node->attrGroups[] = new AttributeGroup([
+            new Attribute(
+                new Name('\Illuminate\Database\Eloquent\Attributes\Appends'),
+                [new Arg($appendsArray)]
+            ),
+        ]);
+
+        // Remove property
+        foreach ($node->stmts as $key => $stmt) {
+            if ($stmt === $appendsProperty) {
+                unset($node->stmts[$key]);
+                break;
+            }
+        }
+
+        return $node;
+    }
+
+    private function isArrayOfStrings(Array_ $array): bool
+    {
+        foreach ($array->items as $item) {
+            if ($item === null) {
+                return false;
+            }
+
+            if (! $item->value instanceof String_) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Rector/Class_/ConnectionPropertyToConnectionAttributeRector.php
+++ b/src/Rector/Class_/ConnectionPropertyToConnectionAttributeRector.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Type\ObjectType;
+use RectorLaravel\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\Class_\ConnectionPropertyToConnectionAttributeRector\ConnectionPropertyToConnectionAttributeRectorTest
+ */
+final class ConnectionPropertyToConnectionAttributeRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes model connection property to use the Connection attribute',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $connection = 'sqlite';
+}
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Attributes\Connection;
+
+#[Connection('sqlite')]
+class User extends Model
+{
+}
+CODE_SAMPLE
+            )]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param  Class_  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isObjectType($node, new ObjectType('Illuminate\Database\Eloquent\Model'))) {
+            return null;
+        }
+
+        $connectionProperty = $node->getProperty('connection');
+        if ($connectionProperty === null) {
+            return null;
+        }
+
+        if (! $connectionProperty->isProtected()) {
+            return null;
+        }
+
+        $propertyProperty = $connectionProperty->props[0];
+        if ($propertyProperty->default === null || ! $propertyProperty->default instanceof String_) {
+            return null;
+        }
+
+        $connectionValue = $propertyProperty->default;
+
+        // Add attribute to class
+        $node->attrGroups[] = new AttributeGroup([
+            new Attribute(
+                new FullyQualified('Illuminate\Database\Eloquent\Attributes\Connection'),
+                [new Arg($connectionValue)]
+            ),
+        ]);
+
+        // Remove property
+        foreach ($node->stmts as $key => $stmt) {
+            if ($stmt === $connectionProperty) {
+                unset($node->stmts[$key]);
+                break;
+            }
+        }
+
+        return $node;
+    }
+}

--- a/src/Rector/Class_/FillablePropertyToFillableAttributeRector.php
+++ b/src/Rector/Class_/FillablePropertyToFillableAttributeRector.php
@@ -9,7 +9,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Type\ObjectType;
@@ -91,7 +91,7 @@ CODE_SAMPLE
         // Add attribute to class
         $node->attrGroups[] = new AttributeGroup([
             new Attribute(
-                new Name('\Illuminate\Database\Eloquent\Attributes\Fillable'),
+                new FullyQualified('Illuminate\Database\Eloquent\Attributes\Fillable'),
                 [new Arg($fillableArray)]
             ),
         ]);

--- a/src/Rector/Class_/FillablePropertyToFillableAttributeRector.php
+++ b/src/Rector/Class_/FillablePropertyToFillableAttributeRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Type\ObjectType;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use RectorLaravel\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -22,6 +23,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class FillablePropertyToFillableAttributeRector extends AbstractRector
 {
+    public function __construct(private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer) {}
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -85,6 +88,10 @@ CODE_SAMPLE
         $fillableArray = $propertyProperty->default;
 
         if (! $this->isArrayOfStrings($fillableArray)) {
+            return null;
+        }
+
+        if ($this->phpAttributeAnalyzer->hasPhpAttribute($node, 'Illuminate\Database\Eloquent\Attributes\Fillable')) {
             return null;
         }
 

--- a/src/Rector/Class_/FillablePropertyToFillableAttributeRector.php
+++ b/src/Rector/Class_/FillablePropertyToFillableAttributeRector.php
@@ -87,6 +87,10 @@ CODE_SAMPLE
 
         $fillableArray = $propertyProperty->default;
 
+        if ($fillableArray->items === []) {
+            return null;
+        }
+
         if (! $this->isArrayOfStrings($fillableArray)) {
             return null;
         }

--- a/src/Rector/Class_/FillablePropertyToFillableAttributeRector.php
+++ b/src/Rector/Class_/FillablePropertyToFillableAttributeRector.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Type\ObjectType;
+use RectorLaravel\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\Class_\FillablePropertyToFillableAttributeRector\FillablePropertyToFillableAttributeRectorTest
+ */
+final class FillablePropertyToFillableAttributeRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes model fillable property to use the fillable attribute',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $fillable = [
+        'name',
+        'email',
+    ];
+}
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+
+#[Fillable(['name', 'email'])]
+class User extends Model
+{
+}
+CODE_SAMPLE
+            )]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param  Class_  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isObjectType($node, new ObjectType('Illuminate\Database\Eloquent\Model'))) {
+            return null;
+        }
+
+        $fillableProperty = $node->getProperty('fillable');
+        if ($fillableProperty === null) {
+            return null;
+        }
+
+        if (! $fillableProperty->isProtected()) {
+            return null;
+        }
+
+        $propertyProperty = $fillableProperty->props[0];
+        if ($propertyProperty->default === null || ! $propertyProperty->default instanceof Array_) {
+            return null;
+        }
+
+        $fillableArray = $propertyProperty->default;
+
+        if (! $this->isArrayOfStrings($fillableArray)) {
+            return null;
+        }
+
+        // Add attribute to class
+        $node->attrGroups[] = new AttributeGroup([
+            new Attribute(
+                new Name('\Illuminate\Database\Eloquent\Attributes\Fillable'),
+                [new Arg($fillableArray)]
+            ),
+        ]);
+
+        // Remove property
+        foreach ($node->stmts as $key => $stmt) {
+            if ($stmt === $fillableProperty) {
+                unset($node->stmts[$key]);
+                break;
+            }
+        }
+
+        return $node;
+    }
+
+    private function isArrayOfStrings(Array_ $array): bool
+    {
+        foreach ($array->items as $item) {
+            if ($item === null) {
+                return false;
+            }
+
+            if (! $item->value instanceof String_) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Rector/Class_/GuardedPropertyToGuardedAttributeRector.php
+++ b/src/Rector/Class_/GuardedPropertyToGuardedAttributeRector.php
@@ -86,6 +86,10 @@ CODE_SAMPLE
 
         $guardedArray = $propertyProperty->default;
 
+        if ($guardedArray->items === []) {
+            return null;
+        }
+
         if (! $this->isArrayOfStrings($guardedArray)) {
             return null;
         }

--- a/src/Rector/Class_/GuardedPropertyToGuardedAttributeRector.php
+++ b/src/Rector/Class_/GuardedPropertyToGuardedAttributeRector.php
@@ -9,7 +9,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Type\ObjectType;
@@ -90,7 +90,7 @@ CODE_SAMPLE
         // Add attribute to class
         $node->attrGroups[] = new AttributeGroup([
             new Attribute(
-                new Name('\Illuminate\Database\Eloquent\Attributes\Guarded'),
+                new FullyQualified('Illuminate\Database\Eloquent\Attributes\Guarded'),
                 [new Arg($guardedArray)]
             ),
         ]);

--- a/src/Rector/Class_/GuardedPropertyToGuardedAttributeRector.php
+++ b/src/Rector/Class_/GuardedPropertyToGuardedAttributeRector.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Type\ObjectType;
+use RectorLaravel\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\Class_\GuardedPropertyToGuardedAttributeRector\GuardedPropertyToGuardedAttributeRectorTest
+ */
+final class GuardedPropertyToGuardedAttributeRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes model guarded property to use the guarded attribute',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $guarded = [
+        'is_admin',
+    ];
+}
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Attributes\Guarded;
+
+#[Guarded(['is_admin'])]
+class User extends Model
+{
+}
+CODE_SAMPLE
+            )]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param  Class_  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isObjectType($node, new ObjectType('Illuminate\Database\Eloquent\Model'))) {
+            return null;
+        }
+
+        $guardedProperty = $node->getProperty('guarded');
+        if ($guardedProperty === null) {
+            return null;
+        }
+
+        if (! $guardedProperty->isProtected()) {
+            return null;
+        }
+
+        $propertyProperty = $guardedProperty->props[0];
+        if ($propertyProperty->default === null || ! $propertyProperty->default instanceof Array_) {
+            return null;
+        }
+
+        $guardedArray = $propertyProperty->default;
+
+        if (! $this->isArrayOfStrings($guardedArray)) {
+            return null;
+        }
+
+        // Add attribute to class
+        $node->attrGroups[] = new AttributeGroup([
+            new Attribute(
+                new Name('\Illuminate\Database\Eloquent\Attributes\Guarded'),
+                [new Arg($guardedArray)]
+            ),
+        ]);
+
+        // Remove property
+        foreach ($node->stmts as $key => $stmt) {
+            if ($stmt === $guardedProperty) {
+                unset($node->stmts[$key]);
+                break;
+            }
+        }
+
+        return $node;
+    }
+
+    private function isArrayOfStrings(Array_ $array): bool
+    {
+        foreach ($array->items as $item) {
+            if ($item === null) {
+                return false;
+            }
+
+            if (! $item->value instanceof String_) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Rector/Class_/GuardedPropertyToGuardedAttributeRector.php
+++ b/src/Rector/Class_/GuardedPropertyToGuardedAttributeRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Type\ObjectType;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use RectorLaravel\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -22,6 +23,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class GuardedPropertyToGuardedAttributeRector extends AbstractRector
 {
+    public function __construct(private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer) {}
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -84,6 +87,10 @@ CODE_SAMPLE
         $guardedArray = $propertyProperty->default;
 
         if (! $this->isArrayOfStrings($guardedArray)) {
+            return null;
+        }
+
+        if ($this->phpAttributeAnalyzer->hasPhpAttribute($node, 'Illuminate\Database\Eloquent\Attributes\Guarded')) {
             return null;
         }
 

--- a/src/Rector/Class_/HiddenPropertyToHiddenAttributeRector.php
+++ b/src/Rector/Class_/HiddenPropertyToHiddenAttributeRector.php
@@ -86,6 +86,10 @@ CODE_SAMPLE
 
         $hiddenArray = $propertyProperty->default;
 
+        if ($hiddenArray->items === []) {
+            return null;
+        }
+
         if (! $this->isArrayOfStrings($hiddenArray)) {
             return null;
         }

--- a/src/Rector/Class_/HiddenPropertyToHiddenAttributeRector.php
+++ b/src/Rector/Class_/HiddenPropertyToHiddenAttributeRector.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Type\ObjectType;
+use RectorLaravel\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\Class_\HiddenPropertyToHiddenAttributeRector\HiddenPropertyToHiddenAttributeRectorTest
+ */
+final class HiddenPropertyToHiddenAttributeRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes model hidden property to use the hidden attribute',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $hidden = [
+        'password',
+    ];
+}
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Attributes\Hidden;
+
+#[Hidden(['password'])]
+class User extends Model
+{
+}
+CODE_SAMPLE
+            )]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param  Class_  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isObjectType($node, new ObjectType('Illuminate\Database\Eloquent\Model'))) {
+            return null;
+        }
+
+        $hiddenProperty = $node->getProperty('hidden');
+        if ($hiddenProperty === null) {
+            return null;
+        }
+
+        if (! $hiddenProperty->isProtected()) {
+            return null;
+        }
+
+        $propertyProperty = $hiddenProperty->props[0];
+        if ($propertyProperty->default === null || ! $propertyProperty->default instanceof Array_) {
+            return null;
+        }
+
+        $hiddenArray = $propertyProperty->default;
+
+        if (! $this->isArrayOfStrings($hiddenArray)) {
+            return null;
+        }
+
+        // Add attribute to class
+        $node->attrGroups[] = new AttributeGroup([
+            new Attribute(
+                new Name('\Illuminate\Database\Eloquent\Attributes\Hidden'),
+                [new Arg($hiddenArray)]
+            ),
+        ]);
+
+        // Remove property
+        foreach ($node->stmts as $key => $stmt) {
+            if ($stmt === $hiddenProperty) {
+                unset($node->stmts[$key]);
+                break;
+            }
+        }
+
+        return $node;
+    }
+
+    private function isArrayOfStrings(Array_ $array): bool
+    {
+        foreach ($array->items as $item) {
+            if ($item === null) {
+                return false;
+            }
+
+            if (! $item->value instanceof String_) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Rector/Class_/HiddenPropertyToHiddenAttributeRector.php
+++ b/src/Rector/Class_/HiddenPropertyToHiddenAttributeRector.php
@@ -9,7 +9,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Type\ObjectType;
@@ -90,7 +90,7 @@ CODE_SAMPLE
         // Add attribute to class
         $node->attrGroups[] = new AttributeGroup([
             new Attribute(
-                new Name('\Illuminate\Database\Eloquent\Attributes\Hidden'),
+                new FullyQualified('Illuminate\Database\Eloquent\Attributes\Hidden'),
                 [new Arg($hiddenArray)]
             ),
         ]);

--- a/src/Rector/Class_/HiddenPropertyToHiddenAttributeRector.php
+++ b/src/Rector/Class_/HiddenPropertyToHiddenAttributeRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Type\ObjectType;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use RectorLaravel\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -22,6 +23,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class HiddenPropertyToHiddenAttributeRector extends AbstractRector
 {
+    public function __construct(private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer) {}
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -84,6 +87,10 @@ CODE_SAMPLE
         $hiddenArray = $propertyProperty->default;
 
         if (! $this->isArrayOfStrings($hiddenArray)) {
+            return null;
+        }
+
+        if ($this->phpAttributeAnalyzer->hasPhpAttribute($node, 'Illuminate\Database\Eloquent\Attributes\Hidden')) {
             return null;
         }
 

--- a/src/Rector/Class_/TablePropertyToTableAttributeRector.php
+++ b/src/Rector/Class_/TablePropertyToTableAttributeRector.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\Type\ObjectType;
+use RectorLaravel\AbstractRector;
+use RectorLaravel\NodeFactory\TableAttributeFactory;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\Class_\TablePropertyToTableAttributeRector\TablePropertyToTableAttributeRectorTest
+ */
+final class TablePropertyToTableAttributeRector extends AbstractRector
+{
+    public function __construct(
+        private readonly TableAttributeFactory $tableAttributeFactory,
+    ) {}
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes model table-related properties to use the Table attribute',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $table = 'users';
+
+    protected $primaryKey = 'user_id';
+
+    protected $keyType = 'string';
+
+    protected $incrementing = false;
+}
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Attributes\Table;
+
+#[Table(table: 'users', key: 'user_id', keyType: 'string', incrementing: false)]
+class User extends Model
+{
+}
+CODE_SAMPLE
+            )]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param  Class_  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isObjectType($node, new ObjectType('Illuminate\Database\Eloquent\Model'))) {
+            return null;
+        }
+
+        $tableProperty = $node->getProperty('table');
+        if ($tableProperty === null || ! $tableProperty->isProtected()) {
+            return null;
+        }
+
+        $tableValue = $this->getPropertyDefaultValue($tableProperty);
+        if (! $tableValue instanceof String_) {
+            return null;
+        }
+
+        $options = [];
+
+        $primaryKeyProperty = $node->getProperty('primaryKey');
+        if ($primaryKeyProperty !== null && $primaryKeyProperty->isProtected()) {
+            $primaryKeyValue = $this->getPropertyDefaultValue($primaryKeyProperty);
+            if ($primaryKeyValue instanceof Expr) {
+                $options['key'] = $primaryKeyValue;
+            }
+        }
+
+        $keyTypeProperty = $node->getProperty('keyType');
+        if ($keyTypeProperty !== null && $keyTypeProperty->isProtected()) {
+            $keyTypeValue = $this->getPropertyDefaultValue($keyTypeProperty);
+            if ($keyTypeValue instanceof Expr) {
+                $options['keyType'] = $keyTypeValue;
+            }
+        }
+
+        $incrementingProperty = $node->getProperty('incrementing');
+        if ($incrementingProperty !== null && $incrementingProperty->isProtected()) {
+            $incrementingValue = $this->getPropertyDefaultValue($incrementingProperty);
+            if ($incrementingValue instanceof Expr) {
+                $options['incrementing'] = $incrementingValue;
+            }
+        }
+
+        $node->attrGroups[] = $this->tableAttributeFactory->create($tableValue, $options);
+
+        // Remove properties
+        $this->removeProperty($node, $tableProperty);
+        if (isset($primaryKeyProperty)) {
+            $this->removeProperty($node, $primaryKeyProperty);
+        }
+        if (isset($keyTypeProperty)) {
+            $this->removeProperty($node, $keyTypeProperty);
+        }
+        if (isset($incrementingProperty)) {
+            $this->removeProperty($node, $incrementingProperty);
+        }
+
+        return $node;
+    }
+
+    private function getPropertyDefaultValue(Property $property): ?Expr
+    {
+        return $property->props[0]->default;
+    }
+
+    private function removeProperty(Class_ $class, Property $property): void
+    {
+        foreach ($class->stmts as $key => $stmt) {
+            if ($stmt === $property) {
+                unset($class->stmts[$key]);
+                break;
+            }
+        }
+    }
+}

--- a/src/Rector/Class_/TablePropertyToTableAttributeRector.php
+++ b/src/Rector/Class_/TablePropertyToTableAttributeRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Type\ObjectType;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use RectorLaravel\AbstractRector;
 use RectorLaravel\NodeFactory\TableAttributeFactory;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -22,6 +23,7 @@ final class TablePropertyToTableAttributeRector extends AbstractRector
 {
     public function __construct(
         private readonly TableAttributeFactory $tableAttributeFactory,
+        private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
     ) {}
 
     public function getRuleDefinition(): RuleDefinition
@@ -73,24 +75,55 @@ CODE_SAMPLE
             return null;
         }
 
+        $tableAttributeClass = 'Illuminate\Database\Eloquent\Attributes\Table';
+        $hasExistingAttribute = $this->phpAttributeAnalyzer->hasPhpAttribute($node, $tableAttributeClass);
+
+        // Resolve the table value: from $table property, or from existing attribute
         $tableProperty = $node->getProperty('table');
-        if ($tableProperty === null || ! $tableProperty->isProtected()) {
-            return null;
+        $tableValue = null;
+
+        if ($tableProperty !== null) {
+            if (! $tableProperty->isProtected()) {
+                return null;
+            }
+            $tableValue = $this->getPropertyDefaultValue($tableProperty);
+            if (! $tableValue instanceof String_) {
+                return null;
+            }
         }
 
-        $tableValue = $this->getPropertyDefaultValue($tableProperty);
+        if (! $tableValue instanceof String_ && $hasExistingAttribute) {
+            $tableValue = $this->getExistingAttributeArg($node, $tableAttributeClass, 'table');
+            if (! $tableValue instanceof String_) {
+                return null;
+            }
+        }
+
         if (! $tableValue instanceof String_) {
             return null;
         }
 
+        // Seed options from existing attribute args (properties take precedence below)
         $options = [];
+        if ($hasExistingAttribute) {
+            foreach (['key', 'keyType', 'incrementing'] as $argName) {
+                $existingArg = $this->getExistingAttributeArg($node, $tableAttributeClass, $argName);
+                if ($existingArg instanceof Expr) {
+                    $options[$argName] = $existingArg;
+                }
+            }
+        }
 
         $primaryKeyProperty = $node->getProperty('primaryKey');
         if ($primaryKeyProperty !== null && $primaryKeyProperty->isProtected()) {
             $primaryKeyValue = $this->getPropertyDefaultValue($primaryKeyProperty);
             if ($primaryKeyValue instanceof Expr) {
                 $options['key'] = $primaryKeyValue;
+            } else {
+                $primaryKeyProperty = null;
             }
+        } else {
+            $primaryKeyProperty = null;
         }
 
         $keyTypeProperty = $node->getProperty('keyType');
@@ -98,7 +131,11 @@ CODE_SAMPLE
             $keyTypeValue = $this->getPropertyDefaultValue($keyTypeProperty);
             if ($keyTypeValue instanceof Expr) {
                 $options['keyType'] = $keyTypeValue;
+            } else {
+                $keyTypeProperty = null;
             }
+        } else {
+            $keyTypeProperty = null;
         }
 
         $incrementingProperty = $node->getProperty('incrementing');
@@ -106,20 +143,44 @@ CODE_SAMPLE
             $incrementingValue = $this->getPropertyDefaultValue($incrementingProperty);
             if ($incrementingValue instanceof Expr) {
                 $options['incrementing'] = $incrementingValue;
+            } else {
+                $incrementingProperty = null;
             }
+        } else {
+            $incrementingProperty = null;
         }
 
-        $node->attrGroups[] = $this->tableAttributeFactory->create($tableValue, $options);
+        // If the attribute exists but there are no properties to remove, there is nothing to do
+        if ($hasExistingAttribute && $tableProperty === null && $primaryKeyProperty === null && $keyTypeProperty === null && $incrementingProperty === null) {
+            return null;
+        }
+
+        $attributeGroup = $this->tableAttributeFactory->create($tableValue, $options);
+
+        if ($hasExistingAttribute) {
+            foreach ($node->attrGroups as $key => $attrGroup) {
+                foreach ($attrGroup->attrs as $attr) {
+                    if ($this->isName($attr->name, $tableAttributeClass)) {
+                        $node->attrGroups[$key] = $attributeGroup;
+                        break 2;
+                    }
+                }
+            }
+        } else {
+            $node->attrGroups[] = $attributeGroup;
+        }
 
         // Remove properties
-        $this->removeProperty($node, $tableProperty);
-        if (isset($primaryKeyProperty)) {
+        if ($tableProperty !== null) {
+            $this->removeProperty($node, $tableProperty);
+        }
+        if ($primaryKeyProperty !== null) {
             $this->removeProperty($node, $primaryKeyProperty);
         }
-        if (isset($keyTypeProperty)) {
+        if ($keyTypeProperty !== null) {
             $this->removeProperty($node, $keyTypeProperty);
         }
-        if (isset($incrementingProperty)) {
+        if ($incrementingProperty !== null) {
             $this->removeProperty($node, $incrementingProperty);
         }
 
@@ -129,6 +190,23 @@ CODE_SAMPLE
     private function getPropertyDefaultValue(Property $property): ?Expr
     {
         return $property->props[0]->default;
+    }
+
+    private function getExistingAttributeArg(Class_ $class, string $attributeClass, string $argName): ?Expr
+    {
+        foreach ($class->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                if ($this->isName($attr->name, $attributeClass)) {
+                    foreach ($attr->args as $arg) {
+                        if ($arg->name !== null && $arg->name->name === $argName) {
+                            return $arg->value;
+                        }
+                    }
+                }
+            }
+        }
+
+        return null;
     }
 
     private function removeProperty(Class_ $class, Property $property): void

--- a/src/Rector/Class_/TouchesPropertyToTouchesAttributeRector.php
+++ b/src/Rector/Class_/TouchesPropertyToTouchesAttributeRector.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Type\ObjectType;
+use RectorLaravel\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\Class_\TouchesPropertyToTouchesAttributeRector\TouchesPropertyToTouchesAttributeRectorTest
+ */
+final class TouchesPropertyToTouchesAttributeRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes model touches property to use the touches attribute',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $touches = [
+        'posts',
+    ];
+}
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Attributes\Touches;
+
+#[Touches(['posts'])]
+class User extends Model
+{
+}
+CODE_SAMPLE
+            )]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param  Class_  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isObjectType($node, new ObjectType('Illuminate\Database\Eloquent\Model'))) {
+            return null;
+        }
+
+        $touchesProperty = $node->getProperty('touches');
+        if ($touchesProperty === null) {
+            return null;
+        }
+
+        if (! $touchesProperty->isProtected()) {
+            return null;
+        }
+
+        $propertyProperty = $touchesProperty->props[0];
+        if ($propertyProperty->default === null || ! $propertyProperty->default instanceof Array_) {
+            return null;
+        }
+
+        $touchesArray = $propertyProperty->default;
+
+        if (! $this->isArrayOfStrings($touchesArray)) {
+            return null;
+        }
+
+        // Add attribute to class
+        $node->attrGroups[] = new AttributeGroup([
+            new Attribute(
+                new Name('\Illuminate\Database\Eloquent\Attributes\Touches'),
+                [new Arg($touchesArray)]
+            ),
+        ]);
+
+        // Remove property
+        foreach ($node->stmts as $key => $stmt) {
+            if ($stmt === $touchesProperty) {
+                unset($node->stmts[$key]);
+                break;
+            }
+        }
+
+        return $node;
+    }
+
+    private function isArrayOfStrings(Array_ $array): bool
+    {
+        foreach ($array->items as $item) {
+            if ($item === null) {
+                return false;
+            }
+
+            if (! $item->value instanceof String_) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Rector/Class_/TouchesPropertyToTouchesAttributeRector.php
+++ b/src/Rector/Class_/TouchesPropertyToTouchesAttributeRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Type\ObjectType;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use RectorLaravel\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -22,6 +23,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class TouchesPropertyToTouchesAttributeRector extends AbstractRector
 {
+    public function __construct(private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer) {}
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -84,6 +87,10 @@ CODE_SAMPLE
         $touchesArray = $propertyProperty->default;
 
         if (! $this->isArrayOfStrings($touchesArray)) {
+            return null;
+        }
+
+        if ($this->phpAttributeAnalyzer->hasPhpAttribute($node, 'Illuminate\Database\Eloquent\Attributes\Touches')) {
             return null;
         }
 

--- a/src/Rector/Class_/TouchesPropertyToTouchesAttributeRector.php
+++ b/src/Rector/Class_/TouchesPropertyToTouchesAttributeRector.php
@@ -9,7 +9,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Type\ObjectType;
@@ -90,7 +90,7 @@ CODE_SAMPLE
         // Add attribute to class
         $node->attrGroups[] = new AttributeGroup([
             new Attribute(
-                new Name('\Illuminate\Database\Eloquent\Attributes\Touches'),
+                new FullyQualified('Illuminate\Database\Eloquent\Attributes\Touches'),
                 [new Arg($touchesArray)]
             ),
         ]);

--- a/src/Rector/Class_/TouchesPropertyToTouchesAttributeRector.php
+++ b/src/Rector/Class_/TouchesPropertyToTouchesAttributeRector.php
@@ -86,6 +86,10 @@ CODE_SAMPLE
 
         $touchesArray = $propertyProperty->default;
 
+        if ($touchesArray->items === []) {
+            return null;
+        }
+
         if (! $this->isArrayOfStrings($touchesArray)) {
             return null;
         }

--- a/src/Set/LaravelSetList.php
+++ b/src/Set/LaravelSetList.php
@@ -40,6 +40,8 @@ final class LaravelSetList
 
     final public const string LARAVEL_120 = __DIR__ . '/../../config/sets/laravel120.php';
 
+    final public const string LARAVEL_130 = __DIR__ . '/../../config/sets/laravel130.php';
+
     final public const string LARAVEL_ARRAYACCESS_TO_METHOD_CALL = __DIR__ . '/../../config/sets/laravel-arrayaccess-to-method-call.php';
 
     final public const string LARAVEL_ARRAY_STR_FUNCTION_TO_STATIC_CALL = __DIR__ . '/../../config/sets/laravel-array-str-functions-to-static-call.php';

--- a/tests/Rector/Class_/AppendsPropertyToAppendsAttributeRector/AppendsPropertyToAppendsAttributeRectorTest.php
+++ b/tests/Rector/Class_/AppendsPropertyToAppendsAttributeRector/AppendsPropertyToAppendsAttributeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\Class_\AppendsPropertyToAppendsAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AppendsPropertyToAppendsAttributeRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/AppendsPropertyToAppendsAttributeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/AppendsPropertyToAppendsAttributeRector/Fixture/fixture.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\AppendsPropertyToAppendsAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $appends = [
+        'full_name',
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\AppendsPropertyToAppendsAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Appends([
+    'full_name',
+])]
+class User extends Model
+{
+}
+
+?>

--- a/tests/Rector/Class_/AppendsPropertyToAppendsAttributeRector/Fixture/skip_empty_appends.php.inc
+++ b/tests/Rector/Class_/AppendsPropertyToAppendsAttributeRector/Fixture/skip_empty_appends.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\AppendsPropertyToAppendsAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipEmptyAppends extends Model
+{
+    protected $appends = [];
+}
+
+?>

--- a/tests/Rector/Class_/AppendsPropertyToAppendsAttributeRector/Fixture/skip_existing_attribute.php.inc
+++ b/tests/Rector/Class_/AppendsPropertyToAppendsAttributeRector/Fixture/skip_existing_attribute.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\AppendsPropertyToAppendsAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Appends(['full_name'])]
+class SkipExistingAttribute extends Model
+{
+    protected $appends = [
+        'full_name',
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/AppendsPropertyToAppendsAttributeRector/Fixture/skip_non_string_appends.php.inc
+++ b/tests/Rector/Class_/AppendsPropertyToAppendsAttributeRector/Fixture/skip_non_string_appends.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\AppendsPropertyToAppendsAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipNonStringAppends extends Model
+{
+    protected $appends = [
+        1,
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/AppendsPropertyToAppendsAttributeRector/Fixture/skip_not_a_model.php.inc
+++ b/tests/Rector/Class_/AppendsPropertyToAppendsAttributeRector/Fixture/skip_not_a_model.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\AppendsPropertyToAppendsAttributeRector\Fixture;
+
+class SkipNotAModel
+{
+    protected $appends = [
+        'full_name',
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/AppendsPropertyToAppendsAttributeRector/Fixture/skip_public_appends.php.inc
+++ b/tests/Rector/Class_/AppendsPropertyToAppendsAttributeRector/Fixture/skip_public_appends.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\AppendsPropertyToAppendsAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipPublicAppends extends Model
+{
+    public $appends = [
+        'full_name',
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/AppendsPropertyToAppendsAttributeRector/config/configured_rule.php
+++ b/tests/Rector/Class_/AppendsPropertyToAppendsAttributeRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\AppendsPropertyToAppendsAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AppendsPropertyToAppendsAttributeRector::class);
+};

--- a/tests/Rector/Class_/ConnectionPropertyToConnectionAttributeRector/ConnectionPropertyToConnectionAttributeRectorTest.php
+++ b/tests/Rector/Class_/ConnectionPropertyToConnectionAttributeRector/ConnectionPropertyToConnectionAttributeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\Class_\ConnectionPropertyToConnectionAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ConnectionPropertyToConnectionAttributeRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/ConnectionPropertyToConnectionAttributeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/ConnectionPropertyToConnectionAttributeRector/Fixture/fixture.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\ConnectionPropertyToConnectionAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $connection = 'sqlite';
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\ConnectionPropertyToConnectionAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Connection('sqlite')]
+class User extends Model
+{
+}
+
+?>

--- a/tests/Rector/Class_/ConnectionPropertyToConnectionAttributeRector/Fixture/skip_non_string_connection.php.inc
+++ b/tests/Rector/Class_/ConnectionPropertyToConnectionAttributeRector/Fixture/skip_non_string_connection.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\ConnectionPropertyToConnectionAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipNonStringConnection extends Model
+{
+    protected $connection = ['sqlite'];
+}
+
+?>

--- a/tests/Rector/Class_/ConnectionPropertyToConnectionAttributeRector/Fixture/skip_not_a_model.php.inc
+++ b/tests/Rector/Class_/ConnectionPropertyToConnectionAttributeRector/Fixture/skip_not_a_model.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\ConnectionPropertyToConnectionAttributeRector\Fixture;
+
+class SkipNotAModel
+{
+    protected $connection = 'sqlite';
+}
+
+?>

--- a/tests/Rector/Class_/ConnectionPropertyToConnectionAttributeRector/Fixture/skip_public_connection.php.inc
+++ b/tests/Rector/Class_/ConnectionPropertyToConnectionAttributeRector/Fixture/skip_public_connection.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\ConnectionPropertyToConnectionAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipPublicConnection extends Model
+{
+    public $connection = 'sqlite';
+}
+
+?>

--- a/tests/Rector/Class_/ConnectionPropertyToConnectionAttributeRector/config/configured_rule.php
+++ b/tests/Rector/Class_/ConnectionPropertyToConnectionAttributeRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\ConnectionPropertyToConnectionAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ConnectionPropertyToConnectionAttributeRector::class);
+};

--- a/tests/Rector/Class_/FillablePropertyToFillableAttributeRector/FillablePropertyToFillableAttributeRectorTest.php
+++ b/tests/Rector/Class_/FillablePropertyToFillableAttributeRector/FillablePropertyToFillableAttributeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\Class_\FillablePropertyToFillableAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class FillablePropertyToFillableAttributeRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/FillablePropertyToFillableAttributeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/FillablePropertyToFillableAttributeRector/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\FillablePropertyToFillableAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $fillable = [
+        'name',
+        'email',
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\FillablePropertyToFillableAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Fillable([
+    'name',
+    'email',
+])]
+class User extends Model
+{
+}
+
+?>

--- a/tests/Rector/Class_/FillablePropertyToFillableAttributeRector/Fixture/skip_empty_fillable.php.inc
+++ b/tests/Rector/Class_/FillablePropertyToFillableAttributeRector/Fixture/skip_empty_fillable.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\FillablePropertyToFillableAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipEmptyFillable extends Model
+{
+    protected $fillable = [];
+}
+
+?>

--- a/tests/Rector/Class_/FillablePropertyToFillableAttributeRector/Fixture/skip_existing_attribute.php.inc
+++ b/tests/Rector/Class_/FillablePropertyToFillableAttributeRector/Fixture/skip_existing_attribute.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\FillablePropertyToFillableAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Fillable(['name', 'email'])]
+class SkipExistingAttribute extends Model
+{
+    protected $fillable = [
+        'name',
+        'email',
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/FillablePropertyToFillableAttributeRector/Fixture/skip_non_array_fillable.php.inc
+++ b/tests/Rector/Class_/FillablePropertyToFillableAttributeRector/Fixture/skip_non_array_fillable.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\FillablePropertyToFillableAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class NonArrayFillable extends Model
+{
+    protected $fillable = 'name';
+}
+
+?>

--- a/tests/Rector/Class_/FillablePropertyToFillableAttributeRector/Fixture/skip_non_string_fillable.php.inc
+++ b/tests/Rector/Class_/FillablePropertyToFillableAttributeRector/Fixture/skip_non_string_fillable.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\FillablePropertyToFillableAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class NonStringFillable extends Model
+{
+    protected $fillable = [
+        'name',
+        123,
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/FillablePropertyToFillableAttributeRector/Fixture/skip_not_a_model.php.inc
+++ b/tests/Rector/Class_/FillablePropertyToFillableAttributeRector/Fixture/skip_not_a_model.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\FillablePropertyToFillableAttributeRector\Fixture;
+
+class NotAModel
+{
+    protected $fillable = ['name'];
+}
+
+?>

--- a/tests/Rector/Class_/FillablePropertyToFillableAttributeRector/Fixture/skip_public_fillable.php.inc
+++ b/tests/Rector/Class_/FillablePropertyToFillableAttributeRector/Fixture/skip_public_fillable.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\FillablePropertyToFillableAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PublicFillable extends Model
+{
+    public $fillable = ['name'];
+}
+
+?>

--- a/tests/Rector/Class_/FillablePropertyToFillableAttributeRector/config/configured_rule.php
+++ b/tests/Rector/Class_/FillablePropertyToFillableAttributeRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\FillablePropertyToFillableAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(FillablePropertyToFillableAttributeRector::class);
+};

--- a/tests/Rector/Class_/GuardedPropertyToGuardedAttributeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/GuardedPropertyToGuardedAttributeRector/Fixture/fixture.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\GuardedPropertyToGuardedAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $guarded = [
+        'is_admin',
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\GuardedPropertyToGuardedAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Guarded([
+    'is_admin',
+])]
+class User extends Model
+{
+}
+
+?>

--- a/tests/Rector/Class_/GuardedPropertyToGuardedAttributeRector/Fixture/skip_empty_guarded.php.inc
+++ b/tests/Rector/Class_/GuardedPropertyToGuardedAttributeRector/Fixture/skip_empty_guarded.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\GuardedPropertyToGuardedAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipEmptyGuarded extends Model
+{
+    protected $guarded = [];
+}
+
+?>

--- a/tests/Rector/Class_/GuardedPropertyToGuardedAttributeRector/Fixture/skip_existing_attribute.php.inc
+++ b/tests/Rector/Class_/GuardedPropertyToGuardedAttributeRector/Fixture/skip_existing_attribute.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\GuardedPropertyToGuardedAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Guarded(['is_admin'])]
+class SkipExistingAttribute extends Model
+{
+    protected $guarded = [
+        'is_admin',
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/GuardedPropertyToGuardedAttributeRector/Fixture/skip_non_string_guarded.php.inc
+++ b/tests/Rector/Class_/GuardedPropertyToGuardedAttributeRector/Fixture/skip_non_string_guarded.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\GuardedPropertyToGuardedAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipNonStringGuarded extends Model
+{
+    protected $guarded = [
+        1,
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/GuardedPropertyToGuardedAttributeRector/Fixture/skip_not_a_model.php.inc
+++ b/tests/Rector/Class_/GuardedPropertyToGuardedAttributeRector/Fixture/skip_not_a_model.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\GuardedPropertyToGuardedAttributeRector\Fixture;
+
+class SkipNotAModel
+{
+    protected $guarded = [
+        'is_admin',
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/GuardedPropertyToGuardedAttributeRector/Fixture/skip_public_guarded.php.inc
+++ b/tests/Rector/Class_/GuardedPropertyToGuardedAttributeRector/Fixture/skip_public_guarded.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\GuardedPropertyToGuardedAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipPublicGuarded extends Model
+{
+    public $guarded = [
+        'is_admin',
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/GuardedPropertyToGuardedAttributeRector/GuardedPropertyToGuardedAttributeRectorTest.php
+++ b/tests/Rector/Class_/GuardedPropertyToGuardedAttributeRector/GuardedPropertyToGuardedAttributeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\Class_\GuardedPropertyToGuardedAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class GuardedPropertyToGuardedAttributeRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/GuardedPropertyToGuardedAttributeRector/config/configured_rule.php
+++ b/tests/Rector/Class_/GuardedPropertyToGuardedAttributeRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\GuardedPropertyToGuardedAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(GuardedPropertyToGuardedAttributeRector::class);
+};

--- a/tests/Rector/Class_/HiddenPropertyToHiddenAttributeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/HiddenPropertyToHiddenAttributeRector/Fixture/fixture.php.inc
@@ -1,16 +1,11 @@
 <?php
 
-namespace RectorLaravel\Tests\Sets\Laravel130\Fixture;
+namespace RectorLaravel\Tests\Rector\Class_\HiddenPropertyToHiddenAttributeRector\Fixture;
 
 use Illuminate\Database\Eloquent\Model;
 
 class User extends Model
 {
-    protected $fillable = [
-        'name',
-        'email',
-    ];
-
     protected $hidden = [
         'password',
     ];
@@ -20,14 +15,10 @@ class User extends Model
 -----
 <?php
 
-namespace RectorLaravel\Tests\Sets\Laravel130\Fixture;
+namespace RectorLaravel\Tests\Rector\Class_\HiddenPropertyToHiddenAttributeRector\Fixture;
 
 use Illuminate\Database\Eloquent\Model;
 
-#[\Illuminate\Database\Eloquent\Attributes\Fillable([
-    'name',
-    'email',
-])]
 #[\Illuminate\Database\Eloquent\Attributes\Hidden([
     'password',
 ])]

--- a/tests/Rector/Class_/HiddenPropertyToHiddenAttributeRector/Fixture/skip_empty_hidden.php.inc
+++ b/tests/Rector/Class_/HiddenPropertyToHiddenAttributeRector/Fixture/skip_empty_hidden.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\HiddenPropertyToHiddenAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipEmptyHidden extends Model
+{
+    protected $hidden = [];
+}
+
+?>

--- a/tests/Rector/Class_/HiddenPropertyToHiddenAttributeRector/Fixture/skip_existing_attribute.php.inc
+++ b/tests/Rector/Class_/HiddenPropertyToHiddenAttributeRector/Fixture/skip_existing_attribute.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\HiddenPropertyToHiddenAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Hidden(['password'])]
+class SkipExistingAttribute extends Model
+{
+    protected $hidden = [
+        'password',
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/HiddenPropertyToHiddenAttributeRector/Fixture/skip_non_array_hidden.php.inc
+++ b/tests/Rector/Class_/HiddenPropertyToHiddenAttributeRector/Fixture/skip_non_array_hidden.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\HiddenPropertyToHiddenAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class NonArrayHidden extends Model
+{
+    protected $hidden = 'password';
+}
+
+?>

--- a/tests/Rector/Class_/HiddenPropertyToHiddenAttributeRector/Fixture/skip_non_string_hidden.php.inc
+++ b/tests/Rector/Class_/HiddenPropertyToHiddenAttributeRector/Fixture/skip_non_string_hidden.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\HiddenPropertyToHiddenAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class NonStringHidden extends Model
+{
+    protected $hidden = [
+        'password',
+        123,
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/HiddenPropertyToHiddenAttributeRector/Fixture/skip_not_a_model.php.inc
+++ b/tests/Rector/Class_/HiddenPropertyToHiddenAttributeRector/Fixture/skip_not_a_model.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\HiddenPropertyToHiddenAttributeRector\Fixture;
+
+class NotAModel
+{
+    protected $hidden = ['password'];
+}
+
+?>

--- a/tests/Rector/Class_/HiddenPropertyToHiddenAttributeRector/Fixture/skip_public_hidden.php.inc
+++ b/tests/Rector/Class_/HiddenPropertyToHiddenAttributeRector/Fixture/skip_public_hidden.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\HiddenPropertyToHiddenAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PublicHidden extends Model
+{
+    public $hidden = ['password'];
+}
+
+?>

--- a/tests/Rector/Class_/HiddenPropertyToHiddenAttributeRector/HiddenPropertyToHiddenAttributeRectorTest.php
+++ b/tests/Rector/Class_/HiddenPropertyToHiddenAttributeRector/HiddenPropertyToHiddenAttributeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\Class_\HiddenPropertyToHiddenAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class HiddenPropertyToHiddenAttributeRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/HiddenPropertyToHiddenAttributeRector/config/configured_rule.php
+++ b/tests/Rector/Class_/HiddenPropertyToHiddenAttributeRector/config/configured_rule.php
@@ -3,13 +3,8 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use RectorLaravel\Rector\Class_\FillablePropertyToFillableAttributeRector;
 use RectorLaravel\Rector\Class_\HiddenPropertyToHiddenAttributeRector;
 
-// see https://laravel.com/docs/13.x/upgrade
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../config.php');
-
-    $rectorConfig->rule(FillablePropertyToFillableAttributeRector::class);
     $rectorConfig->rule(HiddenPropertyToHiddenAttributeRector::class);
 };

--- a/tests/Rector/Class_/TablePropertyToTableAttributeRector/Fixture/combine_existing_attribute.php.inc
+++ b/tests/Rector/Class_/TablePropertyToTableAttributeRector/Fixture/combine_existing_attribute.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TablePropertyToTableAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Table(table: 'users')]
+class CombineExistingAttribute extends Model
+{
+    protected $primaryKey = 'user_id';
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TablePropertyToTableAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Table(table: 'users', key: 'user_id')]
+class CombineExistingAttribute extends Model
+{
+}
+
+?>

--- a/tests/Rector/Class_/TablePropertyToTableAttributeRector/Fixture/do_not_remove_invalid_properties.php.inc
+++ b/tests/Rector/Class_/TablePropertyToTableAttributeRector/Fixture/do_not_remove_invalid_properties.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TablePropertyToTableAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DoNotRemoveInvalidProperties extends Model
+{
+    protected $table = 'users';
+    public $primaryKey = 'user_id';
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TablePropertyToTableAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Table(table: 'users')]
+class DoNotRemoveInvalidProperties extends Model
+{
+    public $primaryKey = 'user_id';
+}
+
+?>

--- a/tests/Rector/Class_/TablePropertyToTableAttributeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/TablePropertyToTableAttributeRector/Fixture/fixture.php.inc
@@ -1,20 +1,11 @@
 <?php
 
-namespace RectorLaravel\Tests\Sets\Laravel130\Fixture;
+namespace RectorLaravel\Tests\Rector\Class_\TablePropertyToTableAttributeRector\Fixture;
 
 use Illuminate\Database\Eloquent\Model;
 
 class User extends Model
 {
-    protected $fillable = [
-        'name',
-        'email',
-    ];
-
-    protected $hidden = [
-        'password',
-    ];
-
     protected $table = 'users';
 
     protected $primaryKey = 'user_id';
@@ -28,17 +19,10 @@ class User extends Model
 -----
 <?php
 
-namespace RectorLaravel\Tests\Sets\Laravel130\Fixture;
+namespace RectorLaravel\Tests\Rector\Class_\TablePropertyToTableAttributeRector\Fixture;
 
 use Illuminate\Database\Eloquent\Model;
 
-#[\Illuminate\Database\Eloquent\Attributes\Fillable([
-    'name',
-    'email',
-])]
-#[\Illuminate\Database\Eloquent\Attributes\Hidden([
-    'password',
-])]
 #[\Illuminate\Database\Eloquent\Attributes\Table(table: 'users', key: 'user_id', keyType: 'string', incrementing: false)]
 class User extends Model
 {

--- a/tests/Rector/Class_/TablePropertyToTableAttributeRector/Fixture/only_table.php.inc
+++ b/tests/Rector/Class_/TablePropertyToTableAttributeRector/Fixture/only_table.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TablePropertyToTableAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UserOnlyTable extends Model
+{
+    protected $table = 'users';
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TablePropertyToTableAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Table(table: 'users')]
+class UserOnlyTable extends Model
+{
+}
+
+?>

--- a/tests/Rector/Class_/TablePropertyToTableAttributeRector/Fixture/replace_existing_attribute.php.inc
+++ b/tests/Rector/Class_/TablePropertyToTableAttributeRector/Fixture/replace_existing_attribute.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TablePropertyToTableAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Table(table: 'customers')]
+class ReplaceExistingAttribute extends Model
+{
+    protected $table = 'users';
+
+    protected $primaryKey = 'user_id';
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TablePropertyToTableAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Table(table: 'users', key: 'user_id')]
+class ReplaceExistingAttribute extends Model
+{
+}
+
+?>

--- a/tests/Rector/Class_/TablePropertyToTableAttributeRector/Fixture/skip_combining_when_property_is_public.php.inc
+++ b/tests/Rector/Class_/TablePropertyToTableAttributeRector/Fixture/skip_combining_when_property_is_public.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TablePropertyToTableAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Table(table: 'users')]
+class SkipCombiningWhenPropertyIsPublic extends Model
+{
+    public $primaryKey = 'user_id';
+}
+
+?>

--- a/tests/Rector/Class_/TablePropertyToTableAttributeRector/Fixture/skip_non_string_table.php.inc
+++ b/tests/Rector/Class_/TablePropertyToTableAttributeRector/Fixture/skip_non_string_table.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TablePropertyToTableAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UserNonStringTable extends Model
+{
+    protected $table = ['users'];
+}
+
+?>

--- a/tests/Rector/Class_/TablePropertyToTableAttributeRector/Fixture/skip_not_a_model.php.inc
+++ b/tests/Rector/Class_/TablePropertyToTableAttributeRector/Fixture/skip_not_a_model.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TablePropertyToTableAttributeRector\Fixture;
+
+class NotAModel
+{
+    protected $table = 'users';
+}
+
+?>

--- a/tests/Rector/Class_/TablePropertyToTableAttributeRector/Fixture/skip_public_table.php.inc
+++ b/tests/Rector/Class_/TablePropertyToTableAttributeRector/Fixture/skip_public_table.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TablePropertyToTableAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UserPublicTable extends Model
+{
+    public $table = 'users';
+}
+
+?>

--- a/tests/Rector/Class_/TablePropertyToTableAttributeRector/TablePropertyToTableAttributeRectorTest.php
+++ b/tests/Rector/Class_/TablePropertyToTableAttributeRector/TablePropertyToTableAttributeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\Class_\TablePropertyToTableAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class TablePropertyToTableAttributeRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/TablePropertyToTableAttributeRector/config/configured_rule.php
+++ b/tests/Rector/Class_/TablePropertyToTableAttributeRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\TablePropertyToTableAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(TablePropertyToTableAttributeRector::class);
+};

--- a/tests/Rector/Class_/TouchesPropertyToTouchesAttributeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/TouchesPropertyToTouchesAttributeRector/Fixture/fixture.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TouchesPropertyToTouchesAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $touches = [
+        'posts',
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TouchesPropertyToTouchesAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Touches([
+    'posts',
+])]
+class User extends Model
+{
+}
+
+?>

--- a/tests/Rector/Class_/TouchesPropertyToTouchesAttributeRector/Fixture/skip_empty_touches.php.inc
+++ b/tests/Rector/Class_/TouchesPropertyToTouchesAttributeRector/Fixture/skip_empty_touches.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TouchesPropertyToTouchesAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipEmptyTouches extends Model
+{
+    protected $touches = [];
+}
+
+?>

--- a/tests/Rector/Class_/TouchesPropertyToTouchesAttributeRector/Fixture/skip_existing_attribute.php.inc
+++ b/tests/Rector/Class_/TouchesPropertyToTouchesAttributeRector/Fixture/skip_existing_attribute.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TouchesPropertyToTouchesAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Touches(['posts'])]
+class SkipExistingAttribute extends Model
+{
+    protected $touches = [
+        'posts',
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/TouchesPropertyToTouchesAttributeRector/Fixture/skip_non_string_touches.php.inc
+++ b/tests/Rector/Class_/TouchesPropertyToTouchesAttributeRector/Fixture/skip_non_string_touches.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TouchesPropertyToTouchesAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipNonStringTouches extends Model
+{
+    protected $touches = [
+        1,
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/TouchesPropertyToTouchesAttributeRector/Fixture/skip_not_a_model.php.inc
+++ b/tests/Rector/Class_/TouchesPropertyToTouchesAttributeRector/Fixture/skip_not_a_model.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TouchesPropertyToTouchesAttributeRector\Fixture;
+
+class SkipNotAModel
+{
+    protected $touches = [
+        'posts',
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/TouchesPropertyToTouchesAttributeRector/Fixture/skip_public_touches.php.inc
+++ b/tests/Rector/Class_/TouchesPropertyToTouchesAttributeRector/Fixture/skip_public_touches.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TouchesPropertyToTouchesAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipPublicTouches extends Model
+{
+    public $touches = [
+        'posts',
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/TouchesPropertyToTouchesAttributeRector/TouchesPropertyToTouchesAttributeRectorTest.php
+++ b/tests/Rector/Class_/TouchesPropertyToTouchesAttributeRector/TouchesPropertyToTouchesAttributeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\Class_\TouchesPropertyToTouchesAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class TouchesPropertyToTouchesAttributeRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/TouchesPropertyToTouchesAttributeRector/config/configured_rule.php
+++ b/tests/Rector/Class_/TouchesPropertyToTouchesAttributeRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\TouchesPropertyToTouchesAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(TouchesPropertyToTouchesAttributeRector::class);
+};

--- a/tests/Sets/Laravel130/Fixture/laravel130.php.inc
+++ b/tests/Sets/Laravel130/Fixture/laravel130.php.inc
@@ -34,6 +34,8 @@ class User extends Model
     protected $touches = [
         'posts',
     ];
+
+    protected $connection = 'sqlite';
 }
 
 ?>
@@ -47,6 +49,7 @@ use Illuminate\Database\Eloquent\Model;
 #[\Illuminate\Database\Eloquent\Attributes\Appends([
     'full_name',
 ])]
+#[\Illuminate\Database\Eloquent\Attributes\Connection('sqlite')]
 #[\Illuminate\Database\Eloquent\Attributes\Fillable([
     'name',
     'email',

--- a/tests/Sets/Laravel130/Fixture/laravel130.php.inc
+++ b/tests/Sets/Laravel130/Fixture/laravel130.php.inc
@@ -22,6 +22,10 @@ class User extends Model
     protected $keyType = 'string';
 
     protected $incrementing = false;
+
+    protected $appends = [
+        'full_name',
+    ];
 }
 
 ?>
@@ -32,6 +36,9 @@ namespace RectorLaravel\Tests\Sets\Laravel130\Fixture;
 
 use Illuminate\Database\Eloquent\Model;
 
+#[\Illuminate\Database\Eloquent\Attributes\Appends([
+    'full_name',
+])]
 #[\Illuminate\Database\Eloquent\Attributes\Fillable([
     'name',
     'email',

--- a/tests/Sets/Laravel130/Fixture/laravel130.php.inc
+++ b/tests/Sets/Laravel130/Fixture/laravel130.php.inc
@@ -30,6 +30,10 @@ class User extends Model
     protected $guarded = [
         'is_admin',
     ];
+
+    protected $touches = [
+        'posts',
+    ];
 }
 
 ?>
@@ -54,6 +58,9 @@ use Illuminate\Database\Eloquent\Model;
     'password',
 ])]
 #[\Illuminate\Database\Eloquent\Attributes\Table(table: 'users', key: 'user_id', keyType: 'string', incrementing: false)]
+#[\Illuminate\Database\Eloquent\Attributes\Touches([
+    'posts',
+])]
 class User extends Model
 {
 }

--- a/tests/Sets/Laravel130/Fixture/laravel130.php.inc
+++ b/tests/Sets/Laravel130/Fixture/laravel130.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\FillablePropertyToFillableAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $fillable = [
+        'name',
+        'email',
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\FillablePropertyToFillableAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Fillable([
+    'name',
+    'email',
+])]
+class User extends Model
+{
+}
+
+?>

--- a/tests/Sets/Laravel130/Fixture/laravel130.php.inc
+++ b/tests/Sets/Laravel130/Fixture/laravel130.php.inc
@@ -26,6 +26,10 @@ class User extends Model
     protected $appends = [
         'full_name',
     ];
+
+    protected $guarded = [
+        'is_admin',
+    ];
 }
 
 ?>
@@ -42,6 +46,9 @@ use Illuminate\Database\Eloquent\Model;
 #[\Illuminate\Database\Eloquent\Attributes\Fillable([
     'name',
     'email',
+])]
+#[\Illuminate\Database\Eloquent\Attributes\Guarded([
+    'is_admin',
 ])]
 #[\Illuminate\Database\Eloquent\Attributes\Hidden([
     'password',

--- a/tests/Sets/Laravel130/Laravel130Test.php
+++ b/tests/Sets/Laravel130/Laravel130Test.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Sets\Laravel130;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class Laravel130Test extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Sets/Laravel130/config/configured_rule.php
+++ b/tests/Sets/Laravel130/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Set\LaravelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([LaravelSetList::LARAVEL_130]);
+};


### PR DESCRIPTION
# Changes

- Adds the Laravel 13 set list
- Adds rules for converting several properties like Hidden, Fillable, Guarded etc.

# Why

These have been confirmed for [Laravel 13](https://laravel-news.com/laravel-13). I wanted to start with these and then move onto the other changes with attributes like console commands and queue jobs.