### PR TITLE
feat: add new RemoveDownMethodFromMigrations as an opt-in rule for removing the down method's of migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ return RectorConfig::configure()
 | [UseComponentPropertyWithinCommandsRector](https://github.com/driftingly/rector-laravel/blob/main/src/Rector/MethodCall/UseComponentPropertyWithinCommandsRector.php) | Use `$this->components` property within commands. |
 | [UseForwardsCallsTraitRector](https://github.com/driftingly/rector-laravel/blob/main/src/Rector/Class_/UseForwardsCallsTraitRector.php) | Replaces the use of `call_user_func` and `call_user_func_array` method with the CallForwarding trait. |
 | [EmptyToBlankAndFilledFuncRector](https://github.com/driftingly/rector-laravel/blob/main/src/Rector/Empty_/EmptyToBlankAndFilledFuncRector.php) | Converts `empty()` to `blank()` and `filled()` |
+| [RemoveDownMethodFromMigrationsRector](https://github.com/driftingly/rector-laravel/blob/main/src/Rector/Class_/RemoveDownMethodFromMigrationsRector.php) | Removes the `down()` method from migrations. |
 
 ## Creating New Rules
 

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -2169,3 +2169,37 @@ Can be configured for the Postgres driver with `[WhereToWhereLikeRector::USING_P
 ```
 
 <br>
+
+## RemoveDownMethodFromMigrationsRector
+
+Removes the `down()` method from migrations.
+
+- class: [`RectorLaravel\Rector\Class_\RemoveDownMethodFromMigrationsRector`](../src/Rector/Class_/RemoveDownMethodFromMigrationsRector.php)
+
+```diff
+ use Illuminate\Database\Migrations\Migration;
+ use Illuminate\Database\Schema\Blueprint;
+ use Illuminate\Support\Facades\Schema;
+
+ class CreateUsersTable extends Migration
+ {
+    /**
+     * Run the migrations.
+     */
+     public function up(): void
+     {
+         Schema::create('users', function (Blueprint $table) {
+             $table->id();
+         });
+     }
+-
+-    /**
+-     * Reverse the migrations.
+-     */
+-    public function down(): void
+-    {
+-        Schema::dropIfExists('users');
+-    }
+ }
+
+<br>

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 97 Rules Overview
+# 98 Rules Overview
 
 ## AbortIfRector
 
@@ -1993,6 +1993,41 @@ Can be configured for the Postgres driver with `[WhereToWhereLikeRector::USING_P
 +$query->whereLike('name', 'Rector');
 +$query->orWhereLike('name', 'Rector');
 +$query->whereLike('name', 'Rector', true);
+```
+
+<br>
+
+## RemoveDownMethodFromMigrationsRector
+
+Removes the `down()` method from migrations.
+
+- class: [`RectorLaravel\Rector\Class_\RemoveDownMethodFromMigrationsRector`](../src/Rector/Class_/RemoveDownMethodFromMigrationsRector.php)
+
+```diff
+ use Illuminate\Database\Migrations\Migration;
+ use Illuminate\Database\Schema\Blueprint;
+ use Illuminate\Support\Facades\Schema;
+
+ class CreateUsersTable extends Migration
+ {
+    /**
+     * Run the migrations.
+     */
+     public function up(): void
+     {
+         Schema::create('users', function (Blueprint $table) {
+             $table->id();
+         });
+     }
+-
+-    /**
+-     * Reverse the migrations.
+-     */
+-    public function down(): void
+-    {
+-        Schema::dropIfExists('users');
+-    }
+ }
 ```
 
 <br>

--- a/src/Rector/Class_/RemoveDownMethodFromMigrationsRector.php
+++ b/src/Rector/Class_/RemoveDownMethodFromMigrationsRector.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Type\ObjectType;
+use RectorLaravel\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \RectorLaravel\Tests\Rector\Class_\RemoveDownMethodFromMigrationsRector\RemoveDownMethodFromMigrationsRectorTest
+ */
+final class RemoveDownMethodFromMigrationsRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Removes the down() method from migrations.', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+        });
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param  Class_  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node->extends instanceof Name) {
+            return null;
+        }
+
+        if (! $this->isObjectType($node, new ObjectType('Illuminate\Database\Migrations\Migration'))) {
+            return null;
+        }
+
+        foreach ($node->stmts as $index => $stmt) {
+            if (! $stmt instanceof ClassMethod) {
+                continue;
+            }
+
+            if (! $this->isName($stmt, 'down')) {
+                continue;
+            }
+
+            unset($node->stmts[$index]);
+            $node->stmts = array_values($node->stmts);
+
+            return $node;
+        }
+
+        return null;
+    }
+}

--- a/tests/Rector/Class_/RemoveDownMethodFromMigrationsRector/Fixture/anonymous_migration.php.inc
+++ b/tests/Rector/Class_/RemoveDownMethodFromMigrationsRector/Fixture/anonymous_migration.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\RemoveDownMethodFromMigrationsRector\Fixture;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+};
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\RemoveDownMethodFromMigrationsRector\Fixture;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+        });
+    }
+};
+
+?>

--- a/tests/Rector/Class_/RemoveDownMethodFromMigrationsRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/RemoveDownMethodFromMigrationsRector/Fixture/fixture.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\RemoveDownMethodFromMigrationsRector\Fixture;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\RemoveDownMethodFromMigrationsRector\Fixture;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+        });
+    }
+}
+
+?>

--- a/tests/Rector/Class_/RemoveDownMethodFromMigrationsRector/Fixture/fixture_with_docblock.php.inc
+++ b/tests/Rector/Class_/RemoveDownMethodFromMigrationsRector/Fixture/fixture_with_docblock.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\RemoveDownMethodFromMigrationsRector\Fixture;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostsTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('posts');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\RemoveDownMethodFromMigrationsRector\Fixture;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostsTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+        });
+    }
+}
+
+?>

--- a/tests/Rector/Class_/RemoveDownMethodFromMigrationsRector/Fixture/skip_no_down_method.php.inc
+++ b/tests/Rector/Class_/RemoveDownMethodFromMigrationsRector/Fixture/skip_no_down_method.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\RemoveDownMethodFromMigrationsRector\Fixture;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTagsTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+        });
+    }
+}
+
+?>

--- a/tests/Rector/Class_/RemoveDownMethodFromMigrationsRector/Fixture/skip_not_a_migration.php.inc
+++ b/tests/Rector/Class_/RemoveDownMethodFromMigrationsRector/Fixture/skip_not_a_migration.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\RemoveDownMethodFromMigrationsRector\Fixture;
+
+class NotAMigrationClass
+{
+    public function down(): void
+    {
+        // not a migration
+    }
+}
+
+?>

--- a/tests/Rector/Class_/RemoveDownMethodFromMigrationsRector/RemoveDownMethodFromMigrationsRectorTest.php
+++ b/tests/Rector/Class_/RemoveDownMethodFromMigrationsRector/RemoveDownMethodFromMigrationsRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\Class_\RemoveDownMethodFromMigrationsRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveDownMethodFromMigrationsRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/RemoveDownMethodFromMigrationsRector/config/configured_rule.php
+++ b/tests/Rector/Class_/RemoveDownMethodFromMigrationsRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\RemoveDownMethodFromMigrationsRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(RemoveDownMethodFromMigrationsRector::class);
+};


### PR DESCRIPTION
As someone who always removes the down() method, I felt this rule could be useful as an opt-in alternative to publishing custom migration stubs via Artisan — with the same end result.

It removes the down() method and its docblock comment from migration files.

Enable it by adding:

``` php
->withRules([
    RemoveDownMethodFromMigrationsRector::class,
]);
````