### PR TITLE
feat: add rule for Laravel Timestamps property to attribute

### DIFF
--- a/config/sets/laravel130.php
+++ b/config/sets/laravel130.php
@@ -16,6 +16,7 @@ use RectorLaravel\Rector\Class_\MaxExceptionsPropertyToMaxExceptionsAttributeRec
 use RectorLaravel\Rector\Class_\QueuePropertyToQueueAttributeRector;
 use RectorLaravel\Rector\Class_\TablePropertyToTableAttributeRector;
 use RectorLaravel\Rector\Class_\TimeoutPropertyToTimeoutAttributeRector;
+use RectorLaravel\Rector\Class_\TimestampsPropertyToTimestampsAttributeRector;
 use RectorLaravel\Rector\Class_\TouchesPropertyToTouchesAttributeRector;
 use RectorLaravel\Rector\Class_\TriesPropertyToTriesAttributeRector;
 use RectorLaravel\Rector\Class_\UniqueForPropertyToUniqueForAttributeRector;
@@ -36,6 +37,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(QueuePropertyToQueueAttributeRector::class);
     $rectorConfig->rule(TablePropertyToTableAttributeRector::class);
     $rectorConfig->rule(TimeoutPropertyToTimeoutAttributeRector::class);
+    $rectorConfig->rule(TimestampsPropertyToTimestampsAttributeRector::class);
     $rectorConfig->rule(TouchesPropertyToTouchesAttributeRector::class);
     $rectorConfig->rule(TriesPropertyToTriesAttributeRector::class);
     $rectorConfig->rule(UniqueForPropertyToUniqueForAttributeRector::class);

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1937,6 +1937,25 @@ Changes the timeout property to use the Timeout attribute
 
 <br>
 
+## TimestampsPropertyToTimestampsAttributeRector
+
+Changes the timestamps property to use the WithoutTimestamps attribute
+
+- class: [`RectorLaravel\Rector\Class_\TimestampsPropertyToTimestampsAttributeRector`](../src/Rector/Class_/TimestampsPropertyToTimestampsAttributeRector.php)
+
+```diff
+ use Illuminate\Database\Eloquent\Model;
++use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
+
++#[WithoutTimestamps]
+ final class User extends Model
+ {
+-    public $timestamps = false;
+ }
+```
+
+<br>
+
 ## TouchesPropertyToTouchesAttributeRector
 
 Changes model touches property to use the touches attribute

--- a/src/Rector/Class_/TimestampsPropertyToTimestampsAttributeRector.php
+++ b/src/Rector/Class_/TimestampsPropertyToTimestampsAttributeRector.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\Type\ObjectType;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class TimestampsPropertyToTimestampsAttributeRector extends AbstractRector
+{
+    public function __construct(
+        private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
+    ) {}
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace $timestamps = false property with #[WithoutTimestamps] attribute in Eloquent Models',
+            [
+                new CodeSample(
+                    <<<'PHP'
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    public $timestamps = false;
+}
+PHP,
+                    <<<'PHP'
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
+use Illuminate\Database\Eloquent\Model;
+
+#[WithoutTimestamps]
+class User extends Model
+{
+}
+PHP,
+                ),
+            ],
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (!$this->isAnEloquentModelClass($node)) {
+            return null;
+        }
+
+        if ($this->phpAttributeAnalyzer->hasPhpAttribute($node, 'Illuminate\Database\Eloquent\Attributes\WithoutTimestamps')) {
+            return null;
+        }
+
+        $timestampsProperty = $node->getProperty('timestamps');
+        if ($timestampsProperty === null){
+            return null;
+        }
+
+        $this->removePropertyFromClass($node, $timestampsProperty);
+        if($this->isFalseProperty($timestampsProperty)){
+            $this->addWithoutTimestampsAttribute($node);
+        }
+
+        return $node;
+    }
+
+    private function isAnEloquentModelClass(Class_ $class): bool
+    {
+        if ($class->extends === null) {
+            return false;
+        }
+
+        return $this->isName($class->extends, 'Illuminate\Database\Eloquent\Model') || $this->isName($class->extends, 'Model');
+    }
+
+    private function isFalseProperty(Property $timestampsProperty): bool
+    {
+        if (count($timestampsProperty->props) === 0) {
+            return false;
+        }
+
+        $default = $timestampsProperty->props[0]->default;
+        if ($default === null) {
+            return false;
+        }
+
+        return $default instanceof ConstFetch && $this->isName($default->name, 'false');
+    }
+
+    private function removePropertyFromClass(Class_ $class, Property $timestampsProperty): void
+    {
+        foreach ($class->stmts as $key => $stmt) {
+            if ($stmt === $timestampsProperty) {
+                unset($class->stmts[$key]);
+                break;
+            }
+        }
+    }
+
+    private function addWithoutTimestampsAttribute(Class_ $class): void
+    {
+        $class->attrGroups[] = new AttributeGroup([
+            new Attribute(new FullyQualified('Illuminate\Database\Eloquent\Attributes\WithoutTimestamps')),
+        ]);
+    }
+}

--- a/tests/Rector/Class_/TimestampsPropertyToTimestampsAttributeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/TimestampsPropertyToTimestampsAttributeRector/Fixture/fixture.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TimestampsPropertyToTimestampsAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TimestampsFalse extends Model
+{
+    public $timestamps = false;
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TimestampsPropertyToTimestampsAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\WithoutTimestamps]
+class TimestampsFalse extends Model
+{
+}
+
+?>

--- a/tests/Rector/Class_/TimestampsPropertyToTimestampsAttributeRector/Fixture/remove_timestamps_true.php.inc
+++ b/tests/Rector/Class_/TimestampsPropertyToTimestampsAttributeRector/Fixture/remove_timestamps_true.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TimestampsPropertyToTimestampsAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TimestampsTrue extends Model
+{
+    public $timestamps = true;
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TimestampsPropertyToTimestampsAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TimestampsTrue extends Model
+{
+}
+
+?>

--- a/tests/Rector/Class_/TimestampsPropertyToTimestampsAttributeRector/Fixture/skip_existing_attribute.php.inc
+++ b/tests/Rector/Class_/TimestampsPropertyToTimestampsAttributeRector/Fixture/skip_existing_attribute.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TimestampsPropertyToTimestampsAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[Illuminate\Database\Eloquent\Attributes\WithoutTimestamps]
+class ExistingAttribute extends Model
+{
+}
+
+?>

--- a/tests/Rector/Class_/TimestampsPropertyToTimestampsAttributeRector/Fixture/skip_existing_fqn_attribute.php.inc
+++ b/tests/Rector/Class_/TimestampsPropertyToTimestampsAttributeRector/Fixture/skip_existing_fqn_attribute.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TimestampsPropertyToTimestampsAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
+use Illuminate\Database\Eloquent\Model;
+
+#[WithoutTimestamps]
+class ExistingFqnAttribute extends Model
+{
+}
+
+?>

--- a/tests/Rector/Class_/TimestampsPropertyToTimestampsAttributeRector/Fixture/skip_not_a_model.php.inc
+++ b/tests/Rector/Class_/TimestampsPropertyToTimestampsAttributeRector/Fixture/skip_not_a_model.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\TimestampsPropertyToTimestampsAttributeRector\Fixture;
+
+class NotAModel
+{
+    public $timestamps = true;
+}
+
+?>

--- a/tests/Rector/Class_/TimestampsPropertyToTimestampsAttributeRector/TimestampsPropertyToTimestampsAttributeRectorTest.php
+++ b/tests/Rector/Class_/TimestampsPropertyToTimestampsAttributeRector/TimestampsPropertyToTimestampsAttributeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PlayPlay\Rector\Tests\Rule\TimestampsPropertyToTimestampsAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class TimestampsPropertyToTimestampsAttributeRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/TimestampsPropertyToTimestampsAttributeRector/config/configured_rule.php
+++ b/tests/Rector/Class_/TimestampsPropertyToTimestampsAttributeRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\TimestampsPropertyToTimestampsAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
+        TimestampsPropertyToTimestampsAttributeRector::class,
+    ]);
+};


### PR DESCRIPTION
# Context
Laravel 13 introduces the WithoutTimestamps attributes ([source](https://laravel.com/docs/13.x/eloquent#timestamps)).

# Description

This new rule replaces the old property `$timestamps` by the new `#[WithoutTimestamps]` attribute : 

```diff
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;

+#[WithoutTimestamps]
 final class User extends Model
 {
-    public $timestamps = false;
 }
```

or, removes the property when the value is true, because that's the default behavior : 
```diff
 use Illuminate\Database\Eloquent\Model;

 final class User extends Model
 {
-    public $timestamps = true;
 }
```