### PR TITLE
feat: Add Laravel 13 set without attribute migrations

### DIFF
--- a/config/sets/laravel130-attributes.php
+++ b/config/sets/laravel130-attributes.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\AppendsPropertyToAppendsAttributeRector;
+use RectorLaravel\Rector\Class_\BackoffPropertyToBackoffAttributeRector;
+use RectorLaravel\Rector\Class_\ConnectionPropertyToConnectionAttributeRector;
+use RectorLaravel\Rector\Class_\FailOnTimeoutPropertyToFailOnTimeoutAttributeRector;
+use RectorLaravel\Rector\Class_\FillablePropertyToFillableAttributeRector;
+use RectorLaravel\Rector\Class_\GuardedPropertyToGuardedAttributeRector;
+use RectorLaravel\Rector\Class_\HiddenPropertyToHiddenAttributeRector;
+use RectorLaravel\Rector\Class_\JobConnectionPropertyToJobConnectionAttributeRector;
+use RectorLaravel\Rector\Class_\MaxExceptionsPropertyToMaxExceptionsAttributeRector;
+use RectorLaravel\Rector\Class_\QueuePropertyToQueueAttributeRector;
+use RectorLaravel\Rector\Class_\TablePropertyToTableAttributeRector;
+use RectorLaravel\Rector\Class_\TimeoutPropertyToTimeoutAttributeRector;
+use RectorLaravel\Rector\Class_\TouchesPropertyToTouchesAttributeRector;
+use RectorLaravel\Rector\Class_\TriesPropertyToTriesAttributeRector;
+use RectorLaravel\Rector\Class_\UniqueForPropertyToUniqueForAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../config.php');
+
+    $rectorConfig->rule(AppendsPropertyToAppendsAttributeRector::class);
+    $rectorConfig->rule(BackoffPropertyToBackoffAttributeRector::class);
+    $rectorConfig->rule(ConnectionPropertyToConnectionAttributeRector::class);
+    $rectorConfig->rule(FailOnTimeoutPropertyToFailOnTimeoutAttributeRector::class);
+    $rectorConfig->rule(FillablePropertyToFillableAttributeRector::class);
+    $rectorConfig->rule(GuardedPropertyToGuardedAttributeRector::class);
+    $rectorConfig->rule(HiddenPropertyToHiddenAttributeRector::class);
+    $rectorConfig->rule(JobConnectionPropertyToJobConnectionAttributeRector::class);
+    $rectorConfig->rule(MaxExceptionsPropertyToMaxExceptionsAttributeRector::class);
+    $rectorConfig->rule(QueuePropertyToQueueAttributeRector::class);
+    $rectorConfig->rule(TablePropertyToTableAttributeRector::class);
+    $rectorConfig->rule(TimeoutPropertyToTimeoutAttributeRector::class);
+    $rectorConfig->rule(TouchesPropertyToTouchesAttributeRector::class);
+    $rectorConfig->rule(TriesPropertyToTriesAttributeRector::class);
+    $rectorConfig->rule(UniqueForPropertyToUniqueForAttributeRector::class);
+};

--- a/config/sets/laravel130-core.php
+++ b/config/sets/laravel130-core.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+
+// see https://laravel.com/docs/13.x/upgrade
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../config.php');
+
+    // see https://laravel.com/docs/13.x/upgrade#request-forgery-protection
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'Illuminate\Foundation\Http\Middleware\VerifyCsrfToken' => 'Illuminate\Foundation\Http\Middleware\PreventRequestForgery',
+        'Illuminate\Foundation\Http\Middleware\ValidateCsrfToken' => 'Illuminate\Foundation\Http\Middleware\PreventRequestForgery',
+    ]);
+};

--- a/config/sets/laravel130-without-attributes.php
+++ b/config/sets/laravel130-without-attributes.php
@@ -6,5 +6,4 @@ use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/laravel130-core.php');
-    $rectorConfig->import(__DIR__ . '/laravel130-attributes.php');
 };

--- a/config/sets/level/up-to-laravel-130-without-attributes.php
+++ b/config/sets/level/up-to-laravel-130-without-attributes.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Set\LaravelLevelSetList;
+use RectorLaravel\Set\LaravelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([LaravelSetList::LARAVEL_130_WITHOUT_ATTRIBUTES, LaravelLevelSetList::UP_TO_LARAVEL_120]);
+};

--- a/src/Set/LaravelLevelSetList.php
+++ b/src/Set/LaravelLevelSetList.php
@@ -37,4 +37,6 @@ final class LaravelLevelSetList
     final public const string UP_TO_LARAVEL_120 = __DIR__ . '/../../config/sets/level/up-to-laravel-120.php';
 
     final public const string UP_TO_LARAVEL_130 = __DIR__ . '/../../config/sets/level/up-to-laravel-130.php';
+
+    final public const string UP_TO_LARAVEL_130_WITHOUT_ATTRIBUTES = __DIR__ . '/../../config/sets/level/up-to-laravel-130-without-attributes.php';
 }

--- a/src/Set/LaravelSetList.php
+++ b/src/Set/LaravelSetList.php
@@ -42,6 +42,8 @@ final class LaravelSetList
 
     final public const string LARAVEL_130 = __DIR__ . '/../../config/sets/laravel130.php';
 
+    final public const string LARAVEL_130_WITHOUT_ATTRIBUTES = __DIR__ . '/../../config/sets/laravel130-without-attributes.php';
+
     final public const string LARAVEL_ARRAYACCESS_TO_METHOD_CALL = __DIR__ . '/../../config/sets/laravel-arrayaccess-to-method-call.php';
 
     final public const string LARAVEL_ARRAY_STR_FUNCTION_TO_STATIC_CALL = __DIR__ . '/../../config/sets/laravel-array-str-functions-to-static-call.php';

--- a/tests/Sets/Laravel130WithoutAttributes/Fixture/laravel130_without_attributes.php.inc
+++ b/tests/Sets/Laravel130WithoutAttributes/Fixture/laravel130_without_attributes.php.inc
@@ -1,0 +1,107 @@
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel130WithoutAttributes\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $fillable = [
+        'name',
+        'email',
+    ];
+
+    protected $hidden = [
+        'password',
+    ];
+
+    protected $table = 'users';
+
+    protected $primaryKey = 'user_id';
+
+    protected $keyType = 'string';
+
+    protected $incrementing = false;
+
+    protected $appends = [
+        'full_name',
+    ];
+
+    protected $guarded = [
+        'is_admin',
+    ];
+
+    protected $touches = [
+        'posts',
+    ];
+
+    protected $connection = 'sqlite';
+}
+
+final class ProcessPodcast implements \Illuminate\Contracts\Queue\ShouldQueue
+{
+    public $tries = 3;
+    public $timeout = 120;
+    public $backoff = [10, 20, 30];
+    public $queue = 'podcasts';
+    public $connection = 'redis';
+    public $failOnTimeout = true;
+    public $maxExceptions = 3;
+    public $uniqueFor = 600;
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel130WithoutAttributes\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $fillable = [
+        'name',
+        'email',
+    ];
+
+    protected $hidden = [
+        'password',
+    ];
+
+    protected $table = 'users';
+
+    protected $primaryKey = 'user_id';
+
+    protected $keyType = 'string';
+
+    protected $incrementing = false;
+
+    protected $appends = [
+        'full_name',
+    ];
+
+    protected $guarded = [
+        'is_admin',
+    ];
+
+    protected $touches = [
+        'posts',
+    ];
+
+    protected $connection = 'sqlite';
+}
+
+final class ProcessPodcast implements \Illuminate\Contracts\Queue\ShouldQueue
+{
+    public $tries = 3;
+    public $timeout = 120;
+    public $backoff = [10, 20, 30];
+    public $queue = 'podcasts';
+    public $connection = 'redis';
+    public $failOnTimeout = true;
+    public $maxExceptions = 3;
+    public $uniqueFor = 600;
+}
+
+?>

--- a/tests/Sets/Laravel130WithoutAttributes/Fixture/validate_csrf_token_to_prevent_request_forgery.php.inc
+++ b/tests/Sets/Laravel130WithoutAttributes/Fixture/validate_csrf_token_to_prevent_request_forgery.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel130WithoutAttributes\Fixture;
+
+Route::post('/bar', function () {})->withoutMiddleware([\Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class]);
+
+class CustomValidateCsrfMiddleware extends \Illuminate\Foundation\Http\Middleware\ValidateCsrfToken
+{
+    protected $except = [
+        'webhooks/*',
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel130WithoutAttributes\Fixture;
+
+Route::post('/bar', function () {})->withoutMiddleware([\Illuminate\Foundation\Http\Middleware\PreventRequestForgery::class]);
+
+class CustomValidateCsrfMiddleware extends \Illuminate\Foundation\Http\Middleware\PreventRequestForgery
+{
+    protected $except = [
+        'webhooks/*',
+    ];
+}
+
+?>

--- a/tests/Sets/Laravel130WithoutAttributes/Fixture/verify_csrf_token_to_prevent_request_forgery.php.inc
+++ b/tests/Sets/Laravel130WithoutAttributes/Fixture/verify_csrf_token_to_prevent_request_forgery.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel130WithoutAttributes\Fixture;
+
+Route::post('/foo', function () {})->withoutMiddleware([\Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class]);
+
+class CustomCsrfMiddleware extends \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken
+{
+    protected $except = [
+        'stripe/*',
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Sets\Laravel130WithoutAttributes\Fixture;
+
+Route::post('/foo', function () {})->withoutMiddleware([\Illuminate\Foundation\Http\Middleware\PreventRequestForgery::class]);
+
+class CustomCsrfMiddleware extends \Illuminate\Foundation\Http\Middleware\PreventRequestForgery
+{
+    protected $except = [
+        'stripe/*',
+    ];
+}
+
+?>

--- a/tests/Sets/Laravel130WithoutAttributes/Laravel130WithoutAttributesTest.php
+++ b/tests/Sets/Laravel130WithoutAttributes/Laravel130WithoutAttributesTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Sets\Laravel130WithoutAttributes;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class Laravel130WithoutAttributesTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Sets/Laravel130WithoutAttributes/Laravel130WithoutAttributesTest.php
+++ b/tests/Sets/Laravel130WithoutAttributes/Laravel130WithoutAttributesTest.php
@@ -15,6 +15,9 @@ final class Laravel130WithoutAttributesTest extends AbstractRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
+    /**
+     * @test
+     */
     #[DataProvider('provideData')]
     public function test(string $filePath): void
     {

--- a/tests/Sets/Laravel130WithoutAttributes/config/configured_rule.php
+++ b/tests/Sets/Laravel130WithoutAttributes/config/configured_rule.php
@@ -3,8 +3,8 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use RectorLaravel\Set\LaravelSetList;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/laravel130-core.php');
-    $rectorConfig->import(__DIR__ . '/laravel130-attributes.php');
+    $rectorConfig->sets([LaravelSetList::LARAVEL_130_WITHOUT_ATTRIBUTES]);
 };

--- a/tests/Sets/LaravelSetProviderTest.php
+++ b/tests/Sets/LaravelSetProviderTest.php
@@ -33,7 +33,10 @@ final class LaravelSetProviderTest extends TestCase
         LaravelSetList::LARAVEL_50,
     ];
 
-    public function testIt_provides_sets(): void
+    /**
+     * @test
+     */
+    public function it_provides_sets(): void
     {
         $laravelSetProvider = new LaravelSetProvider;
 
@@ -43,7 +46,10 @@ final class LaravelSetProviderTest extends TestCase
         );
     }
 
-    public function testIt_returns_unique_sets(): void
+    /**
+     * @test
+     */
+    public function it_returns_unique_sets(): void
     {
         $laravelSetProvider = new LaravelSetProvider;
 
@@ -54,7 +60,10 @@ final class LaravelSetProviderTest extends TestCase
         Assert::assertCount(count($sets), $uniqueSets);
     }
 
-    public function testIt_provides_all_laravel_versions(): void
+    /**
+     * @test
+     */
+    public function it_provides_all_laravel_versions(): void
     {
         $laravelSetProvider = new LaravelSetProvider;
 
@@ -71,7 +80,10 @@ final class LaravelSetProviderTest extends TestCase
         Assert::assertSame(self::LARAVEL_VERSION_SETS, array_values($filePaths));
     }
 
-    public function testIt_exposes_laravel_130_without_attributes_sets(): void
+    /**
+     * @test
+     */
+    public function it_exposes_laravel_130_without_attributes_sets(): void
     {
         Assert::assertFileExists(LaravelSetList::LARAVEL_130_WITHOUT_ATTRIBUTES);
         Assert::assertFileExists(LaravelLevelSetList::UP_TO_LARAVEL_130_WITHOUT_ATTRIBUTES);

--- a/tests/Sets/LaravelSetProviderTest.php
+++ b/tests/Sets/LaravelSetProviderTest.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RectorLaravel\Tests\Sets;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Rector\Set\Contract\SetInterface;
+use RectorLaravel\Set\LaravelLevelSetList;
 use RectorLaravel\Set\LaravelSetList;
 use RectorLaravel\Set\LaravelSetProvider;
 
@@ -30,10 +33,7 @@ final class LaravelSetProviderTest extends TestCase
         LaravelSetList::LARAVEL_50,
     ];
 
-    /**
-     * @test
-     */
-    public function it_provides_sets(): void
+    public function testIt_provides_sets(): void
     {
         $laravelSetProvider = new LaravelSetProvider;
 
@@ -43,24 +43,18 @@ final class LaravelSetProviderTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function it_returns_unique_sets(): void
+    public function testIt_returns_unique_sets(): void
     {
         $laravelSetProvider = new LaravelSetProvider;
 
         $sets = $laravelSetProvider->provide();
 
-        $uniqueSets = array_unique(array_map(fn (SetInterface $set) => $set->getSetFilePath(), $sets));
+        $uniqueSets = array_unique(array_map(fn (SetInterface $set): string => $set->getSetFilePath(), $sets));
 
         Assert::assertCount(count($sets), $uniqueSets);
     }
 
-    /**
-     * @test
-     */
-    public function it_provides_all_laravel_versions(): void
+    public function testIt_provides_all_laravel_versions(): void
     {
         $laravelSetProvider = new LaravelSetProvider;
 
@@ -68,12 +62,18 @@ final class LaravelSetProviderTest extends TestCase
 
         $filePaths = array_filter(
             array_map(
-                fn (SetInterface $set) => $set->getSetFilePath(),
+                fn (SetInterface $set): string => $set->getSetFilePath(),
                 $sets
             ),
-            fn (string $filePath) => in_array($filePath, self::LARAVEL_VERSION_SETS, true),
+            fn (string $filePath): bool => in_array($filePath, self::LARAVEL_VERSION_SETS, true),
         );
 
         Assert::assertSame(self::LARAVEL_VERSION_SETS, array_values($filePaths));
+    }
+
+    public function testIt_exposes_laravel_130_without_attributes_sets(): void
+    {
+        Assert::assertFileExists(LaravelSetList::LARAVEL_130_WITHOUT_ATTRIBUTES);
+        Assert::assertFileExists(LaravelLevelSetList::UP_TO_LARAVEL_130_WITHOUT_ATTRIBUTES);
     }
 }


### PR DESCRIPTION
Add a Laravel 13 set variant that excludes attribute migration rules.

This splits the current Laravel 13 set into:

- a core set for non-attribute Laravel 13 upgrades
- an attributes-only set for PHP attribute migrations

The default `LARAVEL_130` and `UP_TO_LARAVEL_130` behavior stays unchanged.
New `LARAVEL_130_WITHOUT_ATTRIBUTES` and `UP_TO_LARAVEL_130_WITHOUT_ATTRIBUTES`
constants make it possible to opt out of attribute migrations while still
applying the remaining Laravel 13 upgrade rules.

## Changes

- split `config/sets/laravel130.php` into:
    - `laravel130-core.php`
    - `laravel130-attributes.php`
    - `laravel130-without-attributes.php`
- add `up-to-laravel-130-without-attributes.php`
- add:
    - `LaravelSetList::LARAVEL_130_WITHOUT_ATTRIBUTES`
    - `LaravelLevelSetList::UP_TO_LARAVEL_130_WITHOUT_ATTRIBUTES`
- add tests for the new set variant

## Motivation

Some projects want Laravel 13 upgrade rules, but don?t want Rector to migrate model/job properties to PHP attributes
automatically. This provides a supported alternative without requiring users to maintain a growing skip list.

refs: https://github.com/driftingly/rector-laravel/issues/493