### PR TITLE
chore: Add Structarmed for QA with bring fixed PSR4 class names usage

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -33,6 +33,10 @@ jobs:
                         name: 'PHPStan'
                         run: composer phpstan
 
+                    -
+                        name: 'Structarmed'
+                        run: composer structarmed
+
         name: ${{ matrix.actions.name }}
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "tightenco/duster": "^3.1",
         "nette/utils": "^4.0",
         "tracy/tracy": "^2.10",
-        "boundwize/structarmed": "^0.3.3"
+        "boundwize/structarmed": "^0.3.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "tightenco/duster": "^3.1",
         "nette/utils": "^4.0",
         "tracy/tracy": "^2.10",
-        "boundwize/structarmed": "^0.3.4"
+        "boundwize/structarmed": "^0.4.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "symplify/rule-doc-generator": "^12.2",
         "tightenco/duster": "^3.1",
         "nette/utils": "^4.0",
-        "tracy/tracy": "^2.10"
+        "tracy/tracy": "^2.10",
+        "boundwize/structarmed": "^0.3.3"
     },
     "autoload": {
         "psr-4": {
@@ -37,6 +38,7 @@
     },
     "scripts": {
         "phpstan": "vendor/bin/phpstan analyse --ansi",
+        "structarmed": "vendor/bin/structarmed analyze",
         "test": "vendor/bin/phpunit tests",
         "lint": "vendor/bin/duster lint",
         "fix": "vendor/bin/duster fix",
@@ -48,7 +50,8 @@
             "@fix",
             "@phpstan",
             "@docs",
-            "@test"
+            "@test",
+            "@structarmed"
         ],
         "make:rule": "php commands/make-rule.php"
     },

--- a/structarmed.php
+++ b/structarmed.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Boundwize\StructArmed\Architecture;
+use Boundwize\StructArmed\Preset\Preset;
+
+return Architecture::define()
+    ->withPreset(Preset::PSR4());

--- a/tests/NodeAnalyzer/RelationshipAnalyzerTest.php
+++ b/tests/NodeAnalyzer/RelationshipAnalyzerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace NodeAnalyzer;
+namespace RectorLaravel\Tests\NodeAnalyzer;
 
 use Exception;
 use PhpParser\Node\Expr\MethodCall;

--- a/tests/Rector/Namespace_/FactoryDefinitionRectorConfigured/Source/Model.php
+++ b/tests/Rector/Namespace_/FactoryDefinitionRectorConfigured/Source/Model.php
@@ -1,5 +1,5 @@
 <?php
 
-namespace RectorLaravel\Tests\Rector\Namespace_\FactoryDefinitionRector\Source;
+namespace RectorLaravel\Tests\Rector\Namespace_\FactoryDefinitionRectorConfigured\Source;
 
 class Model {}


### PR DESCRIPTION
I created a new tool named `Structarmed`, a configurable PHP architecture guards — define your layers and rules, then keep them enforced.

https://github.com/boundwize/structarmed

The some patches here detected by it with PSR4 preset:

```
➜  rector-laravel git:(main) ✗ vendor/bin/structarmed analyze
Analyzing [============================] 100% 430/430

StructArmed — Architecture Enforcement
==========================================

Found 2 violation(s):
──────────────────────────────────────────

✗  [psr4.classes.must_match_composer]
   Class [RectorLaravel\Tests\Rector\Namespace_\FactoryDefinitionRector\Source\Model] must match PSR-4 class [RectorLaravel\Tests\Rector\Namespace_\FactoryDefinitionRectorConfigured\Source\Model]
   → /Users/samsonasik/www/rector-laravel/tests/Rector/Namespace_/FactoryDefinitionRectorConfigured/Source/Model.php:5
   Layer: Source

✗  [psr4.classes.must_match_composer]
   Class [NodeAnalyzer\RelationshipAnalyzerTest] must match PSR-4 class [RectorLaravel\Tests\NodeAnalyzer\RelationshipAnalyzerTest]
   → /Users/samsonasik/www/rector-laravel/tests/NodeAnalyzer/RelationshipAnalyzerTest.php:19
   Layer: Source

──────────────────────────────────────────
2 violation(s) found  •  0.85s
```

This PR:

- add structarmed to require-dev
- fix the violations detected
- add it to github workflow