### PR TITLE
Feat: new date rule

### DIFF
--- a/src/Rector/MethodCall/DateWhereClauseToShorthandRector.php
+++ b/src/Rector/MethodCall/DateWhereClauseToShorthandRector.php
@@ -131,7 +131,11 @@ CODE_SAMPLE
             return null;
         }
 
-        $operator = $this->resolveStringArgumentValue($node->args[1] ?? null);
+        if (! $node->args[1] instanceof Arg) {
+            return null;
+        }
+
+        $operator = $this->resolveStringArgumentValue($node->args[1]);
         if ($operator === null || ! isset(self::WHERE_NOW_METHODS[$callName][$operator])) {
             return null;
         }
@@ -165,7 +169,11 @@ CODE_SAMPLE
             return null;
         }
 
-        $operator = $this->resolveStringArgumentValue($node->args[1] ?? null);
+        if (! $node->args[1] instanceof Arg) {
+            return null;
+        }
+
+        $operator = $this->resolveStringArgumentValue($node->args[1]);
         if ($operator === null || ! isset(self::WHERE_TODAY_METHODS[$callName][$operator])) {
             return null;
         }
@@ -181,12 +189,8 @@ CODE_SAMPLE
         return $this->renameAndKeepFirstArgument($node, self::WHERE_TODAY_METHODS[$callName][$operator]);
     }
 
-    private function resolveStringArgumentValue(?Arg $arg): ?string
+    private function resolveStringArgumentValue(Arg $arg): ?string
     {
-        if (! $arg instanceof Arg) {
-            return null;
-        }
-
         if (! $arg->value instanceof String_) {
             return null;
         }

--- a/src/Rector/MethodCall/DateWhereClauseToShorthandRector.php
+++ b/src/Rector/MethodCall/DateWhereClauseToShorthandRector.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Type\ObjectType;
+use RectorLaravel\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://github.com/laravel/framework/pull/54408
+ *
+ * @see \RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector\DateWhereClauseToShorthandRectorTest
+ */
+final class DateWhereClauseToShorthandRector extends AbstractRector
+{
+    private const array WHERE_NOW_METHODS = [
+        'where' => [
+            '<' => 'wherePast',
+            '<=' => 'whereNowOrPast',
+            '>' => 'whereFuture',
+            '>=' => 'whereNowOrFuture',
+        ],
+        'orwhere' => [
+            '<' => 'orWherePast',
+            '<=' => 'orWhereNowOrPast',
+            '>' => 'orWhereFuture',
+            '>=' => 'orWhereNowOrFuture',
+        ],
+    ];
+
+    private const array WHERE_TODAY_METHODS = [
+        'wheredate' => [
+            '=' => 'whereToday',
+            '<' => 'whereBeforeToday',
+            '<=' => 'whereTodayOrBefore',
+            '>' => 'whereAfterToday',
+            '>=' => 'whereTodayOrAfter',
+        ],
+        'orwheredate' => [
+            '=' => 'orWhereToday',
+            '<' => 'orWhereBeforeToday',
+            '<=' => 'orWhereTodayOrBefore',
+            '>' => 'orWhereAfterToday',
+            '>=' => 'orWhereTodayOrAfter',
+        ],
+    ];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace date comparison where clauses with Laravel query builder shorthand methods.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use Carbon\Carbon;
+
+$query->where('published_at', '<', Carbon::now());
+$query->whereDate('published_at', '=', Carbon::today());
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use Carbon\Carbon;
+
+$query->wherePast('published_at');
+$query->whereToday('published_at');
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class, StaticCall::class];
+    }
+
+    /**
+     * @param  MethodCall|StaticCall  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isSupportedCaller($node)) {
+            return null;
+        }
+
+        $callName = strtolower((string) $this->getName($node->name));
+
+        if (isset(self::WHERE_NOW_METHODS[$callName])) {
+            return $this->refactorWhereNowCall($node, $callName);
+        }
+
+        if (isset(self::WHERE_TODAY_METHODS[$callName])) {
+            return $this->refactorWhereTodayCall($node, $callName);
+        }
+
+        return null;
+    }
+
+    private function isSupportedCaller(MethodCall|StaticCall $node): bool
+    {
+        if ($node instanceof StaticCall) {
+            return $this->isObjectType($node->class, new ObjectType('Illuminate\Database\Eloquent\Model'));
+        }
+
+        return $this->isObjectType($node->var, new ObjectType('Illuminate\Contracts\Database\Query\Builder'))
+            || $this->isObjectType($node->var, new ObjectType('Illuminate\Database\Query\Builder'))
+            || $this->isObjectType($node->var, new ObjectType('Illuminate\Database\Eloquent\Builder'));
+    }
+
+    private function refactorWhereNowCall(MethodCall|StaticCall $node, string $callName): ?Node
+    {
+        if (count($node->args) !== 3) {
+            return null;
+        }
+
+        $operator = $this->resolveStringArgumentValue($node->args[1] ?? null);
+        if ($operator === null || ! isset(self::WHERE_NOW_METHODS[$callName][$operator])) {
+            return null;
+        }
+
+        if (! isset($node->args[2]) || ! $node->args[2] instanceof Arg) {
+            return null;
+        }
+
+        if (! $this->isNowExpression($node->args[2]->value)) {
+            return null;
+        }
+
+        return $this->renameAndKeepFirstArgument($node, self::WHERE_NOW_METHODS[$callName][$operator]);
+    }
+
+    private function refactorWhereTodayCall(MethodCall|StaticCall $node, string $callName): ?Node
+    {
+        if (count($node->args) === 2) {
+            if (! isset($node->args[1]) || ! $node->args[1] instanceof Arg) {
+                return null;
+            }
+
+            if (! $this->isTodayExpression($node->args[1]->value)) {
+                return null;
+            }
+
+            return $this->renameAndKeepFirstArgument($node, self::WHERE_TODAY_METHODS[$callName]['=']);
+        }
+
+        if (count($node->args) !== 3) {
+            return null;
+        }
+
+        $operator = $this->resolveStringArgumentValue($node->args[1] ?? null);
+        if ($operator === null || ! isset(self::WHERE_TODAY_METHODS[$callName][$operator])) {
+            return null;
+        }
+
+        if (! isset($node->args[2]) || ! $node->args[2] instanceof Arg) {
+            return null;
+        }
+
+        if (! $this->isTodayExpression($node->args[2]->value)) {
+            return null;
+        }
+
+        return $this->renameAndKeepFirstArgument($node, self::WHERE_TODAY_METHODS[$callName][$operator]);
+    }
+
+    private function resolveStringArgumentValue(?Arg $arg): ?string
+    {
+        if (! $arg instanceof Arg) {
+            return null;
+        }
+
+        if (! $arg->value instanceof String_) {
+            return null;
+        }
+
+        return $arg->value->value;
+    }
+
+    private function renameAndKeepFirstArgument(MethodCall|StaticCall $node, string $methodName): Node
+    {
+        if (! isset($node->args[0])) {
+            return $node;
+        }
+
+        $node->name = new Identifier($methodName);
+        $node->args = [$node->args[0]];
+
+        return $node;
+    }
+
+    private function isNowExpression(Expr $expr): bool
+    {
+        if ($expr instanceof FuncCall) {
+            return $this->isName($expr, 'now') && $expr->args === [];
+        }
+
+        return $this->isCarbonStaticCallNamed($expr, 'now');
+    }
+
+    private function isTodayExpression(Expr $expr): bool
+    {
+        if ($expr instanceof FuncCall) {
+            return $this->isName($expr, 'today') && $expr->args === [];
+        }
+
+        return $this->isCarbonStaticCallNamed($expr, 'today');
+    }
+
+    private function isCarbonStaticCallNamed(Expr $expr, string $methodName): bool
+    {
+        if (! $expr instanceof StaticCall) {
+            return false;
+        }
+
+        if (! $this->isName($expr->name, $methodName) || $expr->args !== []) {
+            return false;
+        }
+
+        return $this->isObjectType($expr->class, new ObjectType('Carbon\Carbon'))
+            || $this->isObjectType($expr->class, new ObjectType('Illuminate\Support\Carbon'));
+    }
+}

--- a/src/Rector/MethodCall/DateWhereClauseToShorthandRector.php
+++ b/src/Rector/MethodCall/DateWhereClauseToShorthandRector.php
@@ -15,13 +15,14 @@ use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\ObjectType;
 use RectorLaravel\AbstractRector;
 use RectorLaravel\NodeAnalyzer\QueryBuilderAnalyzer;
+use RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector\DateWhereClauseToShorthandRectorTest;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @changelog https://github.com/laravel/framework/pull/54408
  *
- * @see \RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector\DateWhereClauseToShorthandRectorTest
+ * @see DateWhereClauseToShorthandRectorTest
  */
 final class DateWhereClauseToShorthandRector extends AbstractRector
 {

--- a/src/Rector/MethodCall/DateWhereClauseToShorthandRector.php
+++ b/src/Rector/MethodCall/DateWhereClauseToShorthandRector.php
@@ -67,6 +67,8 @@ use Carbon\Carbon;
 
 $query->where('published_at', '<', Carbon::now());
 $query->whereDate('published_at', '=', Carbon::today());
+$query->where('published_at', '<=', now());
+$query->whereDate('published_at', '>=', today());
 CODE_SAMPLE
                     ,
                     <<<'CODE_SAMPLE'
@@ -74,6 +76,8 @@ use Carbon\Carbon;
 
 $query->wherePast('published_at');
 $query->whereToday('published_at');
+$query->whereNowOrPast('published_at');
+$query->whereTodayOrAfter('published_at');
 CODE_SAMPLE
                 ),
             ]

--- a/src/Rector/MethodCall/DateWhereClauseToShorthandRector.php
+++ b/src/Rector/MethodCall/DateWhereClauseToShorthandRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\ObjectType;
 use RectorLaravel\AbstractRector;
+use RectorLaravel\NodeAnalyzer\QueryBuilderAnalyzer;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -31,7 +32,7 @@ final class DateWhereClauseToShorthandRector extends AbstractRector
             '>' => 'whereFuture',
             '>=' => 'whereNowOrFuture',
         ],
-        'orwhere' => [
+        'orWhere' => [
             '<' => 'orWherePast',
             '<=' => 'orWhereNowOrPast',
             '>' => 'orWhereFuture',
@@ -40,14 +41,14 @@ final class DateWhereClauseToShorthandRector extends AbstractRector
     ];
 
     private const array WHERE_TODAY_METHODS = [
-        'wheredate' => [
+        'whereDate' => [
             '=' => 'whereToday',
             '<' => 'whereBeforeToday',
             '<=' => 'whereTodayOrBefore',
             '>' => 'whereAfterToday',
             '>=' => 'whereTodayOrAfter',
         ],
-        'orwheredate' => [
+        'orWhereDate' => [
             '=' => 'orWhereToday',
             '<' => 'orWhereBeforeToday',
             '<=' => 'orWhereTodayOrBefore',
@@ -55,6 +56,10 @@ final class DateWhereClauseToShorthandRector extends AbstractRector
             '>=' => 'orWhereTodayOrAfter',
         ],
     ];
+
+    public function __construct(
+        private readonly QueryBuilderAnalyzer $queryBuilderAnalyzer,
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -97,11 +102,14 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isSupportedCaller($node)) {
+        $callName = $this->getName($node->name);
+        if (! is_string($callName)) {
             return null;
         }
 
-        $callName = strtolower((string) $this->getName($node->name));
+        if (! $this->queryBuilderAnalyzer->isMatchingCall($node, $callName)) {
+            return null;
+        }
 
         if (isset(self::WHERE_NOW_METHODS[$callName])) {
             return $this->refactorWhereNowCall($node, $callName);
@@ -112,17 +120,6 @@ CODE_SAMPLE
         }
 
         return null;
-    }
-
-    private function isSupportedCaller(MethodCall|StaticCall $node): bool
-    {
-        if ($node instanceof StaticCall) {
-            return $this->isObjectType($node->class, new ObjectType('Illuminate\Database\Eloquent\Model'));
-        }
-
-        return $this->isObjectType($node->var, new ObjectType('Illuminate\Contracts\Database\Query\Builder'))
-            || $this->isObjectType($node->var, new ObjectType('Illuminate\Database\Query\Builder'))
-            || $this->isObjectType($node->var, new ObjectType('Illuminate\Database\Eloquent\Builder'));
     }
 
     private function refactorWhereNowCall(MethodCall|StaticCall $node, string $callName): ?Node
@@ -216,7 +213,7 @@ CODE_SAMPLE
             return $this->isName($expr, 'now') && $expr->args === [];
         }
 
-        return $this->isCarbonStaticCallNamed($expr, 'now');
+        return $this->isDateTimeStaticCallNamed($expr, 'now');
     }
 
     private function isTodayExpression(Expr $expr): bool
@@ -225,10 +222,10 @@ CODE_SAMPLE
             return $this->isName($expr, 'today') && $expr->args === [];
         }
 
-        return $this->isCarbonStaticCallNamed($expr, 'today');
+        return $this->isDateTimeStaticCallNamed($expr, 'today');
     }
 
-    private function isCarbonStaticCallNamed(Expr $expr, string $methodName): bool
+    private function isDateTimeStaticCallNamed(Expr $expr, string $methodName): bool
     {
         if (! $expr instanceof StaticCall) {
             return false;
@@ -238,7 +235,9 @@ CODE_SAMPLE
             return false;
         }
 
-        return $this->isObjectType($expr->class, new ObjectType('Carbon\Carbon'))
-            || $this->isObjectType($expr->class, new ObjectType('Illuminate\Support\Carbon'));
+        $objectType = new ObjectType('DateTimeInterface');
+        $callerType = $this->nodeTypeResolver->getType($expr->class);
+
+        return $objectType->isSuperTypeOf($callerType)->yes();
     }
 }

--- a/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/DateWhereClauseToShorthandRectorTest.php
+++ b/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/DateWhereClauseToShorthandRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DateWhereClauseToShorthandRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Fixture/fixture.php.inc
@@ -1,0 +1,71 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector\Fixture;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder;
+
+final class Post extends Model
+{
+}
+
+final class SomeClass
+{
+    public function run(Builder $query, EloquentBuilder $eloquentBuilder): void
+    {
+        $query->where('published_at', '<', Carbon::now());
+        $query->orWhere('published_at', '>=', Carbon::now());
+        $query->whereDate('published_at', '=', Carbon::today());
+        $query->orWhereDate('published_at', '<', Carbon::today());
+        $query->whereDate('published_at', Carbon::today());
+
+        $eloquentBuilder->where('published_at', '>', Carbon::now());
+
+        Post::whereDate('published_at', '>=', Carbon::today());
+        Post::orWhereDate('published_at', Carbon::today());
+
+        $query->where('published_at', '=', Carbon::now());
+        $query->whereDate('published_at', '!=', Carbon::today());
+        $query->whereDate('published_at', Carbon::yesterday());
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector\Fixture;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder;
+
+final class Post extends Model
+{
+}
+
+final class SomeClass
+{
+    public function run(Builder $query, EloquentBuilder $eloquentBuilder): void
+    {
+        $query->wherePast('published_at');
+        $query->orWhereNowOrFuture('published_at');
+        $query->whereToday('published_at');
+        $query->orWhereBeforeToday('published_at');
+        $query->whereToday('published_at');
+
+        $eloquentBuilder->whereFuture('published_at');
+
+        Post::whereTodayOrAfter('published_at');
+        Post::orWhereToday('published_at');
+
+        $query->where('published_at', '=', Carbon::now());
+        $query->whereDate('published_at', '!=', Carbon::today());
+        $query->whereDate('published_at', Carbon::yesterday());
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Fixture/fixture.php.inc
@@ -16,19 +16,25 @@ final class SomeClass
     public function run(Builder $query, EloquentBuilder $eloquentBuilder): void
     {
         $query->where('published_at', '<', Carbon::now());
+        $query->where('reviewed_at', '<=', now());
         $query->orWhere('published_at', '>=', Carbon::now());
         $query->whereDate('published_at', '=', Carbon::today());
+        $query->whereDate('reviewed_at', '>=', today());
         $query->orWhereDate('published_at', '<', Carbon::today());
         $query->whereDate('published_at', Carbon::today());
+        $query->orWhereDate('reviewed_at', today());
 
         $eloquentBuilder->where('published_at', '>', Carbon::now());
+        $eloquentBuilder->whereDate('reviewed_at', '<=', today());
 
         Post::whereDate('published_at', '>=', Carbon::today());
         Post::orWhereDate('published_at', Carbon::today());
+        Post::where('reviewed_at', '>', now());
 
         $query->where('published_at', '=', Carbon::now());
         $query->whereDate('published_at', '!=', Carbon::today());
         $query->whereDate('published_at', Carbon::yesterday());
+        $query->whereDate('published_at', today('UTC'));
     }
 }
 
@@ -52,19 +58,25 @@ final class SomeClass
     public function run(Builder $query, EloquentBuilder $eloquentBuilder): void
     {
         $query->wherePast('published_at');
+        $query->whereNowOrPast('reviewed_at');
         $query->orWhereNowOrFuture('published_at');
         $query->whereToday('published_at');
+        $query->whereTodayOrAfter('reviewed_at');
         $query->orWhereBeforeToday('published_at');
         $query->whereToday('published_at');
+        $query->orWhereToday('reviewed_at');
 
         $eloquentBuilder->whereFuture('published_at');
+        $eloquentBuilder->whereTodayOrBefore('reviewed_at');
 
         Post::whereTodayOrAfter('published_at');
         Post::orWhereToday('published_at');
+        Post::whereFuture('reviewed_at');
 
         $query->where('published_at', '=', Carbon::now());
         $query->whereDate('published_at', '!=', Carbon::today());
         $query->whereDate('published_at', Carbon::yesterday());
+        $query->whereDate('published_at', today('UTC'));
     }
 }
 

--- a/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Fixture/fixture.php.inc
@@ -4,12 +4,8 @@ namespace RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Builder;
-
-final class Post extends Model
-{
-}
+use RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector\Source\Post;
 
 final class SomeClass
 {
@@ -46,12 +42,8 @@ namespace RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Builder;
-
-final class Post extends Model
-{
-}
+use RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector\Source\Post;
 
 final class SomeClass
 {

--- a/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Fixture/skip_non_date_parameter.php.inc
+++ b/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Fixture/skip_non_date_parameter.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector\Fixture;
+
+use Illuminate\Database\Query\Builder;
+
+final class SkipNonDateParameter
+{
+    public function run(Builder $query): void
+    {
+        $query->where('published_at', '<', '2026-01-01 00:00:00');
+        $query->orWhere('published_at', '>=', 123);
+
+        $query->whereDate('published_at', '=', '2026-01-01');
+        $query->orWhereDate('published_at', '<', 1);
+    }
+}

--- a/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Fixture/skip_unrecognized_comparison.php.inc
+++ b/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Fixture/skip_unrecognized_comparison.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector\Fixture;
+
+use Illuminate\Database\Query\Builder;
+
+final class SkipUnrecognizedComparison
+{
+    public function run(Builder $query): void
+    {
+        $query->where('published_at', 'like', now());
+        $query->orWhere('published_at', '!=', now());
+
+        $query->whereDate('published_at', 'like', today());
+        $query->orWhereDate('published_at', '!=', today());
+    }
+}

--- a/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Fixture/skip_wrong_method_name.php.inc
+++ b/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Fixture/skip_wrong_method_name.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector\Fixture;
+
+use Illuminate\Database\Query\Builder;
+use RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector\Source\Post;
+
+final class SkipWrongMethodName
+{
+    public function run(Builder $query): void
+    {
+        $query->having('published_at', '<', now());
+        $query->orHaving('published_at', '>=', now());
+
+        Post::having('published_at', '<', now());
+    }
+}

--- a/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Fixture/skip_wrong_object_or_class.php.inc
+++ b/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Fixture/skip_wrong_object_or_class.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector\Source\NonModel;
+
+final class SkipWrongObjectOrClass
+{
+    public function run(object $notQuery): void
+    {
+        $notQuery->where('published_at', '<', now());
+
+        NonModel::where('published_at', '<', now());
+        NonModel::whereDate('published_at', '=', today());
+    }
+}

--- a/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Source/NonModel.php
+++ b/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Source/NonModel.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector\Source;
+
+final class NonModel
+{
+    public static function where(string $column, string $operator, mixed $value): void
+    {
+    }
+
+    public static function whereDate(string $column, string $operator, mixed $value): void
+    {
+    }
+}

--- a/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Source/NonModel.php
+++ b/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Source/NonModel.php
@@ -4,11 +4,7 @@ namespace RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector
 
 final class NonModel
 {
-    public static function where(string $column, string $operator, mixed $value): void
-    {
-    }
+    public static function where(string $column, string $operator, mixed $value): void {}
 
-    public static function whereDate(string $column, string $operator, mixed $value): void
-    {
-    }
+    public static function whereDate(string $column, string $operator, mixed $value): void {}
 }

--- a/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Source/Post.php
+++ b/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Source/Post.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector\Source;
+
+use Illuminate\Database\Eloquent\Model;
+
+final class Post extends Model
+{
+}

--- a/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Source/Post.php
+++ b/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Source/Post.php
@@ -4,6 +4,4 @@ namespace RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector
 
 use Illuminate\Database\Eloquent\Model;
 
-final class Post extends Model
-{
-}
+final class Post extends Model {}

--- a/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\MethodCall\DateWhereClauseToShorthandRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(DateWhereClauseToShorthandRector::class);
+};


### PR DESCRIPTION
# Summary

Adds a new standalone Rector rule, `DateWhereClauseToShorthandRector`, that converts eligible Laravel query date comparisons to the new shorthand query builder methods introduced in Laravel.

# What Changed

- Added `DateWhereClauseToShorthandRector` in `src/Rector/MethodCall`
- Converts supported `where` and `orWhere` comparisons against `Carbon::now()` and `now()` to:
  - `wherePast`
  - `whereNowOrPast`
  - `whereFuture`
  - `whereNowOrFuture`
  - `orWherePast`
  - `orWhereNowOrPast`
  - `orWhereFuture`
  - `orWhereNowOrFuture`
- Converts supported `whereDate` and `orWhereDate` comparisons against `Carbon::today()` and `today()` to:
  - `whereToday`
  - `whereBeforeToday`
  - `whereTodayOrBefore`
  - `whereAfterToday`
  - `whereTodayOrAfter`
  - `orWhereToday`
  - `orWhereBeforeToday`
  - `orWhereTodayOrBefore`
  - `orWhereAfterToday`
  - `orWhereTodayOrAfter`
- Supports Query Builder method calls, Eloquent Builder method calls, and Eloquent model static proxy calls
- Added fixture-based coverage for Carbon static calls and Laravel global helper functions

# Why

Laravel added shorthand methods such as `wherePast`, `whereFuture`, and `whereToday`. This rule helps users migrate existing explicit date comparisons to the new, more expressive API.

# Scope

This rule is intentionally standalone and is not registered in any set.

It only transforms supported zero-argument date expressions:

- `Carbon::now()`
- `Carbon::today()`
- `now()`
- `today()`

It leaves unsupported operators and helper calls with arguments unchanged, such as `today('UTC')`.

# Example

```php
$query->where('published_at', '<', now());
$query->whereDate('published_at', '>=', today());
```

Becomes:

```php
$query->wherePast('published_at');
$query->whereTodayOrAfter('published_at');
```