### PR TITLE
Feat: missing eloquent attribute rectors

### DIFF
--- a/config/sets/laravel130-attributes.php
+++ b/config/sets/laravel130-attributes.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use RectorLaravel\Rector\Class_\AppendsPropertyToAppendsAttributeRector;
-use RectorLaravel\Rector\Class_\CollectedByPropertyToCollectedByAttributeRector;
 use RectorLaravel\Rector\Class_\BackoffPropertyToBackoffAttributeRector;
+use RectorLaravel\Rector\Class_\CollectedByPropertyToCollectedByAttributeRector;
 use RectorLaravel\Rector\Class_\ConnectionPropertyToConnectionAttributeRector;
 use RectorLaravel\Rector\Class_\DateFormatPropertyToDateFormatAttributeRector;
 use RectorLaravel\Rector\Class_\FailOnTimeoutPropertyToFailOnTimeoutAttributeRector;

--- a/config/sets/laravel130-attributes.php
+++ b/config/sets/laravel130-attributes.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use RectorLaravel\Rector\Class_\AppendsPropertyToAppendsAttributeRector;
+use RectorLaravel\Rector\Class_\CollectedByPropertyToCollectedByAttributeRector;
 use RectorLaravel\Rector\Class_\BackoffPropertyToBackoffAttributeRector;
 use RectorLaravel\Rector\Class_\ConnectionPropertyToConnectionAttributeRector;
 use RectorLaravel\Rector\Class_\DateFormatPropertyToDateFormatAttributeRector;
@@ -27,6 +28,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../config.php');
 
     $rectorConfig->rule(AppendsPropertyToAppendsAttributeRector::class);
+    $rectorConfig->rule(CollectedByPropertyToCollectedByAttributeRector::class);
     $rectorConfig->rule(BackoffPropertyToBackoffAttributeRector::class);
     $rectorConfig->rule(ConnectionPropertyToConnectionAttributeRector::class);
     $rectorConfig->rule(DateFormatPropertyToDateFormatAttributeRector::class);

--- a/config/sets/laravel130-attributes.php
+++ b/config/sets/laravel130-attributes.php
@@ -20,6 +20,7 @@ use RectorLaravel\Rector\Class_\TouchesPropertyToTouchesAttributeRector;
 use RectorLaravel\Rector\Class_\TriesPropertyToTriesAttributeRector;
 use RectorLaravel\Rector\Class_\UniqueForPropertyToUniqueForAttributeRector;
 use RectorLaravel\Rector\Class_\VisiblePropertyToVisibleAttributeRector;
+use RectorLaravel\Rector\Class_\WithoutTimestampsPropertyToWithoutTimestampsAttributeRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../config.php');
@@ -41,4 +42,5 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(TriesPropertyToTriesAttributeRector::class);
     $rectorConfig->rule(UniqueForPropertyToUniqueForAttributeRector::class);
     $rectorConfig->rule(VisiblePropertyToVisibleAttributeRector::class);
+    $rectorConfig->rule(WithoutTimestampsPropertyToWithoutTimestampsAttributeRector::class);
 };

--- a/config/sets/laravel130-attributes.php
+++ b/config/sets/laravel130-attributes.php
@@ -18,6 +18,7 @@ use RectorLaravel\Rector\Class_\TimeoutPropertyToTimeoutAttributeRector;
 use RectorLaravel\Rector\Class_\TouchesPropertyToTouchesAttributeRector;
 use RectorLaravel\Rector\Class_\TriesPropertyToTriesAttributeRector;
 use RectorLaravel\Rector\Class_\UniqueForPropertyToUniqueForAttributeRector;
+use RectorLaravel\Rector\Class_\VisiblePropertyToVisibleAttributeRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../config.php');
@@ -37,4 +38,5 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(TouchesPropertyToTouchesAttributeRector::class);
     $rectorConfig->rule(TriesPropertyToTriesAttributeRector::class);
     $rectorConfig->rule(UniqueForPropertyToUniqueForAttributeRector::class);
+    $rectorConfig->rule(VisiblePropertyToVisibleAttributeRector::class);
 };

--- a/config/sets/laravel130-attributes.php
+++ b/config/sets/laravel130-attributes.php
@@ -20,6 +20,7 @@ use RectorLaravel\Rector\Class_\TouchesPropertyToTouchesAttributeRector;
 use RectorLaravel\Rector\Class_\TriesPropertyToTriesAttributeRector;
 use RectorLaravel\Rector\Class_\UniqueForPropertyToUniqueForAttributeRector;
 use RectorLaravel\Rector\Class_\VisiblePropertyToVisibleAttributeRector;
+use RectorLaravel\Rector\Class_\WithoutIncrementingPropertyToWithoutIncrementingAttributeRector;
 use RectorLaravel\Rector\Class_\WithoutTimestampsPropertyToWithoutTimestampsAttributeRector;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -42,5 +43,6 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(TriesPropertyToTriesAttributeRector::class);
     $rectorConfig->rule(UniqueForPropertyToUniqueForAttributeRector::class);
     $rectorConfig->rule(VisiblePropertyToVisibleAttributeRector::class);
+    $rectorConfig->rule(WithoutIncrementingPropertyToWithoutIncrementingAttributeRector::class);
     $rectorConfig->rule(WithoutTimestampsPropertyToWithoutTimestampsAttributeRector::class);
 };

--- a/config/sets/laravel130-attributes.php
+++ b/config/sets/laravel130-attributes.php
@@ -6,6 +6,7 @@ use Rector\Config\RectorConfig;
 use RectorLaravel\Rector\Class_\AppendsPropertyToAppendsAttributeRector;
 use RectorLaravel\Rector\Class_\BackoffPropertyToBackoffAttributeRector;
 use RectorLaravel\Rector\Class_\ConnectionPropertyToConnectionAttributeRector;
+use RectorLaravel\Rector\Class_\DateFormatPropertyToDateFormatAttributeRector;
 use RectorLaravel\Rector\Class_\FailOnTimeoutPropertyToFailOnTimeoutAttributeRector;
 use RectorLaravel\Rector\Class_\FillablePropertyToFillableAttributeRector;
 use RectorLaravel\Rector\Class_\GuardedPropertyToGuardedAttributeRector;
@@ -26,6 +27,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(AppendsPropertyToAppendsAttributeRector::class);
     $rectorConfig->rule(BackoffPropertyToBackoffAttributeRector::class);
     $rectorConfig->rule(ConnectionPropertyToConnectionAttributeRector::class);
+    $rectorConfig->rule(DateFormatPropertyToDateFormatAttributeRector::class);
     $rectorConfig->rule(FailOnTimeoutPropertyToFailOnTimeoutAttributeRector::class);
     $rectorConfig->rule(FillablePropertyToFillableAttributeRector::class);
     $rectorConfig->rule(GuardedPropertyToGuardedAttributeRector::class);

--- a/src/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector.php
+++ b/src/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Type\ObjectType;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
+use RectorLaravel\AbstractRector;
+use RectorLaravel\Tests\Rector\Class_\CollectedByPropertyToCollectedByAttributeRector\CollectedByPropertyToCollectedByAttributeRectorTest;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see CollectedByPropertyToCollectedByAttributeRectorTest
+ */
+final class CollectedByPropertyToCollectedByAttributeRector extends AbstractRector
+{
+    public function __construct(private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer) {}
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes model collectionClass property to use the CollectedBy attribute',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+use App\Collections\UserCollection;
+
+class User extends Model
+{
+    protected $collectionClass = UserCollection::class;
+}
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+use App\Collections\UserCollection;
+use Illuminate\Database\Eloquent\Attributes\CollectedBy;
+
+#[CollectedBy(UserCollection::class)]
+class User extends Model
+{
+}
+CODE_SAMPLE
+            )]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param  Class_  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isObjectType($node, new ObjectType('Illuminate\Database\Eloquent\Model'))) {
+            return null;
+        }
+
+        $collectionClassProperty = $node->getProperty('collectionClass');
+        if ($collectionClassProperty === null) {
+            return null;
+        }
+
+        if (! $collectionClassProperty->isProtected()) {
+            return null;
+        }
+
+        $propertyProperty = $collectionClassProperty->props[0];
+        if ($propertyProperty->default === null) {
+            return null;
+        }
+
+        $value = $propertyProperty->default;
+        if (! $value instanceof ClassConstFetch && ! $value instanceof String_) {
+            return null;
+        }
+
+        if ($this->phpAttributeAnalyzer->hasPhpAttribute($node, 'Illuminate\Database\Eloquent\Attributes\CollectedBy')) {
+            return null;
+        }
+
+        $node->attrGroups[] = new AttributeGroup([
+            new Attribute(
+                new FullyQualified('Illuminate\Database\Eloquent\Attributes\CollectedBy'),
+                [new Arg($value)]
+            ),
+        ]);
+
+        foreach ($node->stmts as $key => $stmt) {
+            if ($stmt === $collectionClassProperty) {
+                unset($node->stmts[$key]);
+                break;
+            }
+        }
+
+        return $node;
+    }
+}

--- a/src/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector.php
+++ b/src/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector.php
@@ -9,8 +9,10 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Name\FullyQualified;
-use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Type\ObjectType;
 use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
@@ -29,15 +31,23 @@ final class CollectedByPropertyToCollectedByAttributeRector extends AbstractRect
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Changes model collectionClass property to use the CollectedBy attribute',
+            'Changes model newCollection method to use the CollectedBy attribute',
             [new CodeSample(
                 <<<'CODE_SAMPLE'
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection;
 use App\Collections\UserCollection;
 
 class User extends Model
 {
-    protected $collectionClass = UserCollection::class;
+    /**
+     * @param  array<int, \Illuminate\Database\Eloquent\Model>  $models
+     * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model>
+     */
+    public function newCollection(array $models = []): Collection
+    {
+        return new UserCollection($models);
+    }
 }
 CODE_SAMPLE,
                 <<<'CODE_SAMPLE'
@@ -71,26 +81,17 @@ CODE_SAMPLE
             return null;
         }
 
-        $collectionClassProperty = $node->getProperty('collectionClass');
-        if ($collectionClassProperty === null) {
-            return null;
-        }
-
-        if (! $collectionClassProperty->isProtected()) {
-            return null;
-        }
-
-        $propertyProperty = $collectionClassProperty->props[0];
-        if ($propertyProperty->default === null) {
-            return null;
-        }
-
-        $value = $propertyProperty->default;
-        if (! $value instanceof ClassConstFetch && ! $value instanceof String_) {
-            return null;
-        }
-
         if ($this->phpAttributeAnalyzer->hasPhpAttribute($node, 'Illuminate\Database\Eloquent\Attributes\CollectedBy')) {
+            return null;
+        }
+
+        $newCollectionMethod = $node->getMethod('newCollection');
+        if (! $newCollectionMethod instanceof ClassMethod) {
+            return null;
+        }
+
+        $value = $this->resolveCollectedByValue($newCollectionMethod);
+        if (! $value instanceof ClassConstFetch) {
             return null;
         }
 
@@ -102,12 +103,31 @@ CODE_SAMPLE
         ]);
 
         foreach ($node->stmts as $key => $stmt) {
-            if ($stmt === $collectionClassProperty) {
+            if ($stmt === $newCollectionMethod) {
                 unset($node->stmts[$key]);
                 break;
             }
         }
 
         return $node;
+    }
+
+    private function resolveCollectedByValue(ClassMethod $classMethod): ?ClassConstFetch
+    {
+        if ($classMethod->stmts === null || count($classMethod->stmts) !== 1) {
+            return null;
+        }
+
+        $onlyStmt = $classMethod->stmts[0];
+        if (! $onlyStmt instanceof Return_ || ! $onlyStmt->expr instanceof New_) {
+            return null;
+        }
+
+        $newClass = $onlyStmt->expr->class;
+        if (! $newClass instanceof Node\Name) {
+            return null;
+        }
+
+        return new ClassConstFetch($newClass, 'class');
     }
 }

--- a/src/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector.php
+++ b/src/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector.php
@@ -10,10 +10,11 @@ use PhpParser\Node\Attribute;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\New_;
-use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Return_;
+use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Return_;
 use PHPStan\Type\ObjectType;
 use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use RectorLaravel\AbstractRector;
@@ -124,7 +125,7 @@ CODE_SAMPLE
         }
 
         $newClass = $onlyStmt->expr->class;
-        if (! $newClass instanceof Node\Name) {
+        if (! $newClass instanceof Name) {
             return null;
         }
 

--- a/src/Rector/Class_/DateFormatPropertyToDateFormatAttributeRector.php
+++ b/src/Rector/Class_/DateFormatPropertyToDateFormatAttributeRector.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Type\ObjectType;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
+use RectorLaravel\AbstractRector;
+use RectorLaravel\Tests\Rector\Class_\DateFormatPropertyToDateFormatAttributeRector\DateFormatPropertyToDateFormatAttributeRectorTest;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see DateFormatPropertyToDateFormatAttributeRectorTest
+ */
+final class DateFormatPropertyToDateFormatAttributeRector extends AbstractRector
+{
+    public function __construct(private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer) {}
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes model dateFormat property to use the DateFormat attribute',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $dateFormat = 'U';
+}
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Attributes\DateFormat;
+
+#[DateFormat('U')]
+class User extends Model
+{
+}
+CODE_SAMPLE
+            )]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param  Class_  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isObjectType($node, new ObjectType('Illuminate\Database\Eloquent\Model'))) {
+            return null;
+        }
+
+        $dateFormatProperty = $node->getProperty('dateFormat');
+        if ($dateFormatProperty === null) {
+            return null;
+        }
+
+        if (! $dateFormatProperty->isProtected()) {
+            return null;
+        }
+
+        $propertyProperty = $dateFormatProperty->props[0];
+        if ($propertyProperty->default === null || ! $propertyProperty->default instanceof String_) {
+            return null;
+        }
+
+        $dateFormatValue = $propertyProperty->default;
+
+        if ($this->phpAttributeAnalyzer->hasPhpAttribute($node, 'Illuminate\Database\Eloquent\Attributes\DateFormat')) {
+            return null;
+        }
+
+        $node->attrGroups[] = new AttributeGroup([
+            new Attribute(
+                new FullyQualified('Illuminate\Database\Eloquent\Attributes\DateFormat'),
+                [new Arg($dateFormatValue)]
+            ),
+        ]);
+
+        foreach ($node->stmts as $key => $stmt) {
+            if ($stmt === $dateFormatProperty) {
+                unset($node->stmts[$key]);
+                break;
+            }
+        }
+
+        return $node;
+    }
+}

--- a/src/Rector/Class_/VisiblePropertyToVisibleAttributeRector.php
+++ b/src/Rector/Class_/VisiblePropertyToVisibleAttributeRector.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Type\ObjectType;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
+use RectorLaravel\AbstractRector;
+use RectorLaravel\Tests\Rector\Class_\VisiblePropertyToVisibleAttributeRector\VisiblePropertyToVisibleAttributeRectorTest;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see VisiblePropertyToVisibleAttributeRectorTest
+ */
+final class VisiblePropertyToVisibleAttributeRector extends AbstractRector
+{
+    public function __construct(private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer) {}
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes model visible property to use the Visible attribute',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $visible = [
+        'name',
+        'email',
+    ];
+}
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Attributes\Visible;
+
+#[Visible(['name', 'email'])]
+class User extends Model
+{
+}
+CODE_SAMPLE
+            )]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param  Class_  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isObjectType($node, new ObjectType('Illuminate\Database\Eloquent\Model'))) {
+            return null;
+        }
+
+        $visibleProperty = $node->getProperty('visible');
+        if ($visibleProperty === null) {
+            return null;
+        }
+
+        if (! $visibleProperty->isProtected()) {
+            return null;
+        }
+
+        $propertyProperty = $visibleProperty->props[0];
+        if ($propertyProperty->default === null || ! $propertyProperty->default instanceof Array_) {
+            return null;
+        }
+
+        $visibleArray = $propertyProperty->default;
+
+        if ($visibleArray->items === []) {
+            return null;
+        }
+
+        if (! $this->isArrayOfStrings($visibleArray)) {
+            return null;
+        }
+
+        if ($this->phpAttributeAnalyzer->hasPhpAttribute($node, 'Illuminate\Database\Eloquent\Attributes\Visible')) {
+            return null;
+        }
+
+        $node->attrGroups[] = new AttributeGroup([
+            new Attribute(
+                new FullyQualified('Illuminate\Database\Eloquent\Attributes\Visible'),
+                [new Arg($visibleArray)]
+            ),
+        ]);
+
+        foreach ($node->stmts as $key => $stmt) {
+            if ($stmt === $visibleProperty) {
+                unset($node->stmts[$key]);
+                break;
+            }
+        }
+
+        return $node;
+    }
+
+    private function isArrayOfStrings(Array_ $array): bool
+    {
+        foreach ($array->items as $item) {
+            if ($item === null) {
+                return false;
+            }
+
+            if (! $item->value instanceof String_) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Rector/Class_/VisiblePropertyToVisibleAttributeRector.php
+++ b/src/Rector/Class_/VisiblePropertyToVisibleAttributeRector.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Attribute;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Name\FullyQualified;
-use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Type\ObjectType;
 use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
@@ -124,7 +123,7 @@ CODE_SAMPLE
                 return false;
             }
 
-            if (! $item->value instanceof String_) {
+            if (! $this->getType($item->value)->isString()->yes()) {
                 return false;
             }
         }

--- a/src/Rector/Class_/WithoutIncrementingPropertyToWithoutIncrementingAttributeRector.php
+++ b/src/Rector/Class_/WithoutIncrementingPropertyToWithoutIncrementingAttributeRector.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Type\ObjectType;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
+use RectorLaravel\AbstractRector;
+use RectorLaravel\Tests\Rector\Class_\WithoutIncrementingPropertyToWithoutIncrementingAttributeRector\WithoutIncrementingPropertyToWithoutIncrementingAttributeRectorTest;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see WithoutIncrementingPropertyToWithoutIncrementingAttributeRectorTest
+ */
+final class WithoutIncrementingPropertyToWithoutIncrementingAttributeRector extends AbstractRector
+{
+    public function __construct(private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer) {}
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes model incrementing = false property to use the WithoutIncrementing attribute',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    public $incrementing = false;
+}
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
+
+#[WithoutIncrementing]
+class User extends Model
+{
+}
+CODE_SAMPLE
+            )]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param  Class_  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isObjectType($node, new ObjectType('Illuminate\Database\Eloquent\Model'))) {
+            return null;
+        }
+
+        $incrementingProperty = $node->getProperty('incrementing');
+        if ($incrementingProperty === null) {
+            return null;
+        }
+
+        if (! $incrementingProperty->isPublic()) {
+            return null;
+        }
+
+        $propertyProperty = $incrementingProperty->props[0];
+        if ($propertyProperty->default === null) {
+            return null;
+        }
+
+        $value = $propertyProperty->default;
+        if (! $value instanceof ConstFetch || $value->name->toLowerString() !== 'false') {
+            return null;
+        }
+
+        if ($this->phpAttributeAnalyzer->hasPhpAttribute($node, 'Illuminate\Database\Eloquent\Attributes\WithoutIncrementing')) {
+            return null;
+        }
+
+        $node->attrGroups[] = new AttributeGroup([
+            new Attribute(new FullyQualified('Illuminate\Database\Eloquent\Attributes\WithoutIncrementing')),
+        ]);
+
+        foreach ($node->stmts as $key => $stmt) {
+            if ($stmt === $incrementingProperty) {
+                unset($node->stmts[$key]);
+                break;
+            }
+        }
+
+        return $node;
+    }
+}

--- a/src/Rector/Class_/WithoutTimestampsPropertyToWithoutTimestampsAttributeRector.php
+++ b/src/Rector/Class_/WithoutTimestampsPropertyToWithoutTimestampsAttributeRector.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Type\ObjectType;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
+use RectorLaravel\AbstractRector;
+use RectorLaravel\Tests\Rector\Class_\WithoutTimestampsPropertyToWithoutTimestampsAttributeRector\WithoutTimestampsPropertyToWithoutTimestampsAttributeRectorTest;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see WithoutTimestampsPropertyToWithoutTimestampsAttributeRectorTest
+ */
+final class WithoutTimestampsPropertyToWithoutTimestampsAttributeRector extends AbstractRector
+{
+    public function __construct(private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer) {}
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes model timestamps = false property to use the WithoutTimestamps attribute',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+
+class EventLog extends Model
+{
+    public $timestamps = false;
+}
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
+
+#[WithoutTimestamps]
+class EventLog extends Model
+{
+}
+CODE_SAMPLE
+            )]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param  Class_  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isObjectType($node, new ObjectType('Illuminate\Database\Eloquent\Model'))) {
+            return null;
+        }
+
+        $timestampsProperty = $node->getProperty('timestamps');
+        if ($timestampsProperty === null) {
+            return null;
+        }
+
+        if (! $timestampsProperty->isPublic()) {
+            return null;
+        }
+
+        $propertyProperty = $timestampsProperty->props[0];
+        if ($propertyProperty->default === null) {
+            return null;
+        }
+
+        $value = $propertyProperty->default;
+        if (! $value instanceof ConstFetch || $value->name->toLowerString() !== 'false') {
+            return null;
+        }
+
+        if ($this->phpAttributeAnalyzer->hasPhpAttribute($node, 'Illuminate\Database\Eloquent\Attributes\WithoutTimestamps')) {
+            return null;
+        }
+
+        $node->attrGroups[] = new AttributeGroup([
+            new Attribute(new FullyQualified('Illuminate\Database\Eloquent\Attributes\WithoutTimestamps')),
+        ]);
+
+        foreach ($node->stmts as $key => $stmt) {
+            if ($stmt === $timestampsProperty) {
+                unset($node->stmts[$key]);
+                break;
+            }
+        }
+
+        return $node;
+    }
+}

--- a/tests/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector/CollectedByPropertyToCollectedByAttributeRectorTest.php
+++ b/tests/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector/CollectedByPropertyToCollectedByAttributeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\Class_\CollectedByPropertyToCollectedByAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class CollectedByPropertyToCollectedByAttributeRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector/Fixture/fixture.php.inc
@@ -2,13 +2,21 @@
 
 namespace RectorLaravel\Tests\Rector\Class_\CollectedByPropertyToCollectedByAttributeRector\Fixture;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 
 class UserCollection extends \Illuminate\Database\Eloquent\Collection {}
 
 class User extends Model
 {
-    protected $collectionClass = UserCollection::class;
+    /**
+     * @param array<int, \Illuminate\Database\Eloquent\Model> $models
+     * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model>
+     */
+    public function newCollection(array $models = []): Collection
+    {
+        return new UserCollection($models);
+    }
 }
 
 ?>
@@ -17,6 +25,7 @@ class User extends Model
 
 namespace RectorLaravel\Tests\Rector\Class_\CollectedByPropertyToCollectedByAttributeRector\Fixture;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 
 class UserCollection extends \Illuminate\Database\Eloquent\Collection {}

--- a/tests/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector/Fixture/fixture.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\CollectedByPropertyToCollectedByAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UserCollection extends \Illuminate\Database\Eloquent\Collection {}
+
+class User extends Model
+{
+    protected $collectionClass = UserCollection::class;
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\CollectedByPropertyToCollectedByAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UserCollection extends \Illuminate\Database\Eloquent\Collection {}
+
+#[\Illuminate\Database\Eloquent\Attributes\CollectedBy(UserCollection::class)]
+class User extends Model
+{
+}
+
+?>

--- a/tests/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector/Fixture/skip_existing_attribute.php.inc
+++ b/tests/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector/Fixture/skip_existing_attribute.php.inc
@@ -2,12 +2,20 @@
 
 namespace RectorLaravel\Tests\Rector\Class_\CollectedByPropertyToCollectedByAttributeRector\Fixture;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 
 #[\Illuminate\Database\Eloquent\Attributes\CollectedBy(\Illuminate\Database\Eloquent\Collection::class)]
 class SkipExistingAttribute extends Model
 {
-    protected $collectionClass = \Illuminate\Database\Eloquent\Collection::class;
+    /**
+     * @param array<int, \Illuminate\Database\Eloquent\Model> $models
+     * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model>
+     */
+    public function newCollection(array $models = []): Collection
+    {
+        return new \Illuminate\Database\Eloquent\Collection($models);
+    }
 }
 
 ?>

--- a/tests/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector/Fixture/skip_existing_attribute.php.inc
+++ b/tests/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector/Fixture/skip_existing_attribute.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\CollectedByPropertyToCollectedByAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\CollectedBy(\Illuminate\Database\Eloquent\Collection::class)]
+class SkipExistingAttribute extends Model
+{
+    protected $collectionClass = \Illuminate\Database\Eloquent\Collection::class;
+}
+
+?>

--- a/tests/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector/Fixture/skip_existing_attribute_with_different_value.php.inc
+++ b/tests/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector/Fixture/skip_existing_attribute_with_different_value.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\CollectedByPropertyToCollectedByAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+
+class UserCollection extends Collection {}
+
+class SomeOtherCollection extends Collection {}
+
+#[\Illuminate\Database\Eloquent\Attributes\CollectedBy(SomeOtherCollection::class)]
+class SkipExistingAttributeWithDifferentValue extends Model
+{
+    /**
+     * @param array<int, \Illuminate\Database\Eloquent\Model> $models
+     * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model>
+     */
+    public function newCollection(array $models = []): Collection
+    {
+        return new UserCollection($models);
+    }
+}
+
+?>

--- a/tests/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector/Fixture/skip_not_a_model.php.inc
+++ b/tests/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector/Fixture/skip_not_a_model.php.inc
@@ -6,7 +6,10 @@ use Illuminate\Database\Eloquent\Model;
 
 class SkipNotAModel
 {
-    protected $collectionClass = \Illuminate\Database\Eloquent\Collection::class;
+    public function newCollection(array $models = []): \Illuminate\Database\Eloquent\Collection
+    {
+        return new \Illuminate\Database\Eloquent\Collection($models);
+    }
 }
 
 ?>

--- a/tests/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector/Fixture/skip_not_a_model.php.inc
+++ b/tests/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector/Fixture/skip_not_a_model.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\CollectedByPropertyToCollectedByAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipNotAModel
+{
+    protected $collectionClass = \Illuminate\Database\Eloquent\Collection::class;
+}
+
+?>

--- a/tests/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector/config/configured_rule.php
+++ b/tests/Rector/Class_/CollectedByPropertyToCollectedByAttributeRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\CollectedByPropertyToCollectedByAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(CollectedByPropertyToCollectedByAttributeRector::class);
+};

--- a/tests/Rector/Class_/DateFormatPropertyToDateFormatAttributeRector/DateFormatPropertyToDateFormatAttributeRectorTest.php
+++ b/tests/Rector/Class_/DateFormatPropertyToDateFormatAttributeRector/DateFormatPropertyToDateFormatAttributeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\Class_\DateFormatPropertyToDateFormatAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DateFormatPropertyToDateFormatAttributeRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/DateFormatPropertyToDateFormatAttributeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/DateFormatPropertyToDateFormatAttributeRector/Fixture/fixture.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\DateFormatPropertyToDateFormatAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $dateFormat = 'U';
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\DateFormatPropertyToDateFormatAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\DateFormat('U')]
+class User extends Model
+{
+}
+
+?>

--- a/tests/Rector/Class_/DateFormatPropertyToDateFormatAttributeRector/Fixture/skip_existing_attribute.php.inc
+++ b/tests/Rector/Class_/DateFormatPropertyToDateFormatAttributeRector/Fixture/skip_existing_attribute.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\DateFormatPropertyToDateFormatAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\DateFormat('U')]
+class SkipExistingAttribute extends Model
+{
+    protected $dateFormat = 'U';
+}
+
+?>

--- a/tests/Rector/Class_/DateFormatPropertyToDateFormatAttributeRector/Fixture/skip_not_a_model.php.inc
+++ b/tests/Rector/Class_/DateFormatPropertyToDateFormatAttributeRector/Fixture/skip_not_a_model.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\DateFormatPropertyToDateFormatAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipNotAModel
+{
+    protected $dateFormat = 'U';
+}
+
+?>

--- a/tests/Rector/Class_/DateFormatPropertyToDateFormatAttributeRector/config/configured_rule.php
+++ b/tests/Rector/Class_/DateFormatPropertyToDateFormatAttributeRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\DateFormatPropertyToDateFormatAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(DateFormatPropertyToDateFormatAttributeRector::class);
+};

--- a/tests/Rector/Class_/VisiblePropertyToVisibleAttributeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/VisiblePropertyToVisibleAttributeRector/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\VisiblePropertyToVisibleAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $visible = [
+        'name',
+        'email',
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\VisiblePropertyToVisibleAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Visible([
+    'name',
+    'email',
+])]
+class User extends Model
+{
+}
+
+?>

--- a/tests/Rector/Class_/VisiblePropertyToVisibleAttributeRector/Fixture/fixture_constant_values.php.inc
+++ b/tests/Rector/Class_/VisiblePropertyToVisibleAttributeRector/Fixture/fixture_constant_values.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\VisiblePropertyToVisibleAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UserWithConstantVisibleValues extends Model
+{
+    private const FIELD_NAME = 'name';
+
+    private const FIELD_EMAIL = 'email';
+
+    protected $visible = [
+        self::FIELD_NAME,
+        self::FIELD_EMAIL,
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\VisiblePropertyToVisibleAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Visible([
+    self::FIELD_NAME,
+    self::FIELD_EMAIL,
+])]
+class UserWithConstantVisibleValues extends Model
+{
+    private const FIELD_NAME = 'name';
+
+    private const FIELD_EMAIL = 'email';
+}
+
+?>

--- a/tests/Rector/Class_/VisiblePropertyToVisibleAttributeRector/Fixture/skip_empty_visible.php.inc
+++ b/tests/Rector/Class_/VisiblePropertyToVisibleAttributeRector/Fixture/skip_empty_visible.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\VisiblePropertyToVisibleAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipEmptyVisible extends Model
+{
+    protected $visible = [];
+}
+
+?>

--- a/tests/Rector/Class_/VisiblePropertyToVisibleAttributeRector/Fixture/skip_existing_attribute.php.inc
+++ b/tests/Rector/Class_/VisiblePropertyToVisibleAttributeRector/Fixture/skip_existing_attribute.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\VisiblePropertyToVisibleAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\Visible(['name', 'email'])]
+class SkipExistingAttribute extends Model
+{
+    protected $visible = [
+        'name',
+        'email',
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/VisiblePropertyToVisibleAttributeRector/Fixture/skip_not_a_model.php.inc
+++ b/tests/Rector/Class_/VisiblePropertyToVisibleAttributeRector/Fixture/skip_not_a_model.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\VisiblePropertyToVisibleAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipNotAModel
+{
+    protected $visible = [
+        'name',
+        'email',
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/VisiblePropertyToVisibleAttributeRector/VisiblePropertyToVisibleAttributeRectorTest.php
+++ b/tests/Rector/Class_/VisiblePropertyToVisibleAttributeRector/VisiblePropertyToVisibleAttributeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\Class_\VisiblePropertyToVisibleAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class VisiblePropertyToVisibleAttributeRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/VisiblePropertyToVisibleAttributeRector/config/configured_rule.php
+++ b/tests/Rector/Class_/VisiblePropertyToVisibleAttributeRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\VisiblePropertyToVisibleAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(VisiblePropertyToVisibleAttributeRector::class);
+};

--- a/tests/Rector/Class_/WithoutIncrementingPropertyToWithoutIncrementingAttributeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/WithoutIncrementingPropertyToWithoutIncrementingAttributeRector/Fixture/fixture.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\WithoutIncrementingPropertyToWithoutIncrementingAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    public $incrementing = false;
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\WithoutIncrementingPropertyToWithoutIncrementingAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\WithoutIncrementing]
+class User extends Model
+{
+}
+
+?>

--- a/tests/Rector/Class_/WithoutIncrementingPropertyToWithoutIncrementingAttributeRector/Fixture/skip_existing_attribute.php.inc
+++ b/tests/Rector/Class_/WithoutIncrementingPropertyToWithoutIncrementingAttributeRector/Fixture/skip_existing_attribute.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\WithoutIncrementingPropertyToWithoutIncrementingAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\WithoutIncrementing]
+class SkipExistingAttribute extends Model
+{
+    public $incrementing = false;
+}
+
+?>

--- a/tests/Rector/Class_/WithoutIncrementingPropertyToWithoutIncrementingAttributeRector/Fixture/skip_incrementing_true.php.inc
+++ b/tests/Rector/Class_/WithoutIncrementingPropertyToWithoutIncrementingAttributeRector/Fixture/skip_incrementing_true.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\WithoutIncrementingPropertyToWithoutIncrementingAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipIncrementingTrue extends Model
+{
+    public $incrementing = true;
+}
+
+?>

--- a/tests/Rector/Class_/WithoutIncrementingPropertyToWithoutIncrementingAttributeRector/Fixture/skip_not_a_model.php.inc
+++ b/tests/Rector/Class_/WithoutIncrementingPropertyToWithoutIncrementingAttributeRector/Fixture/skip_not_a_model.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\WithoutIncrementingPropertyToWithoutIncrementingAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipNotAModel
+{
+    public $incrementing = false;
+}
+
+?>

--- a/tests/Rector/Class_/WithoutIncrementingPropertyToWithoutIncrementingAttributeRector/WithoutIncrementingPropertyToWithoutIncrementingAttributeRectorTest.php
+++ b/tests/Rector/Class_/WithoutIncrementingPropertyToWithoutIncrementingAttributeRector/WithoutIncrementingPropertyToWithoutIncrementingAttributeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\Class_\WithoutIncrementingPropertyToWithoutIncrementingAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class WithoutIncrementingPropertyToWithoutIncrementingAttributeRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/WithoutIncrementingPropertyToWithoutIncrementingAttributeRector/config/configured_rule.php
+++ b/tests/Rector/Class_/WithoutIncrementingPropertyToWithoutIncrementingAttributeRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\WithoutIncrementingPropertyToWithoutIncrementingAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(WithoutIncrementingPropertyToWithoutIncrementingAttributeRector::class);
+};

--- a/tests/Rector/Class_/WithoutTimestampsPropertyToWithoutTimestampsAttributeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/WithoutTimestampsPropertyToWithoutTimestampsAttributeRector/Fixture/fixture.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\WithoutTimestampsPropertyToWithoutTimestampsAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class EventLog extends Model
+{
+    public $timestamps = false;
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\WithoutTimestampsPropertyToWithoutTimestampsAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\WithoutTimestamps]
+class EventLog extends Model
+{
+}
+
+?>

--- a/tests/Rector/Class_/WithoutTimestampsPropertyToWithoutTimestampsAttributeRector/Fixture/skip_existing_attribute.php.inc
+++ b/tests/Rector/Class_/WithoutTimestampsPropertyToWithoutTimestampsAttributeRector/Fixture/skip_existing_attribute.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\WithoutTimestampsPropertyToWithoutTimestampsAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\WithoutTimestamps]
+class SkipExistingAttribute extends Model
+{
+    public $timestamps = false;
+}
+
+?>

--- a/tests/Rector/Class_/WithoutTimestampsPropertyToWithoutTimestampsAttributeRector/Fixture/skip_not_a_model.php.inc
+++ b/tests/Rector/Class_/WithoutTimestampsPropertyToWithoutTimestampsAttributeRector/Fixture/skip_not_a_model.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\WithoutTimestampsPropertyToWithoutTimestampsAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipNotAModel
+{
+    public $timestamps = false;
+}
+
+?>

--- a/tests/Rector/Class_/WithoutTimestampsPropertyToWithoutTimestampsAttributeRector/Fixture/skip_timestamps_true.php.inc
+++ b/tests/Rector/Class_/WithoutTimestampsPropertyToWithoutTimestampsAttributeRector/Fixture/skip_timestamps_true.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\WithoutTimestampsPropertyToWithoutTimestampsAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SkipTimestampsTrue extends Model
+{
+    public $timestamps = true;
+}
+
+?>

--- a/tests/Rector/Class_/WithoutTimestampsPropertyToWithoutTimestampsAttributeRector/WithoutTimestampsPropertyToWithoutTimestampsAttributeRectorTest.php
+++ b/tests/Rector/Class_/WithoutTimestampsPropertyToWithoutTimestampsAttributeRector/WithoutTimestampsPropertyToWithoutTimestampsAttributeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\Class_\WithoutTimestampsPropertyToWithoutTimestampsAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class WithoutTimestampsPropertyToWithoutTimestampsAttributeRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/WithoutTimestampsPropertyToWithoutTimestampsAttributeRector/config/configured_rule.php
+++ b/tests/Rector/Class_/WithoutTimestampsPropertyToWithoutTimestampsAttributeRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\WithoutTimestampsPropertyToWithoutTimestampsAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(WithoutTimestampsPropertyToWithoutTimestampsAttributeRector::class);
+};


### PR DESCRIPTION
## Rules Added
- `VisiblePropertyToVisibleAttributeRector`
- `DateFormatPropertyToDateFormatAttributeRector`
- `WithoutTimestampsPropertyToWithoutTimestampsAttributeRector`
- `WithoutIncrementingPropertyToWithoutIncrementingAttributeRector`
- `CollectedByPropertyToCollectedByAttributeRector`

## Before/After

### VisiblePropertyToVisibleAttributeRector
Before:
```php
use Illuminate\Database\Eloquent\Model;

class User extends Model
{
    protected $visible = ['id', 'name'];
}
```
After:
```php
use Illuminate\Database\Eloquent\Attributes\Visible;
use Illuminate\Database\Eloquent\Model;

#[Visible(['id', 'name'])]
class User extends Model
{
}
```

### DateFormatPropertyToDateFormatAttributeRector
Before:
```php
use Illuminate\Database\Eloquent\Model;

class User extends Model
{
    protected $dateFormat = 'U';
}
```
After:
```php
use Illuminate\Database\Eloquent\Attributes\DateFormat;
use Illuminate\Database\Eloquent\Model;

#[DateFormat('U')]
class User extends Model
{
}
```

### WithoutTimestampsPropertyToWithoutTimestampsAttributeRector
Before:
```php
use Illuminate\Database\Eloquent\Model;

class User extends Model
{
    public $timestamps = false;
}
```
After:
```php
use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
use Illuminate\Database\Eloquent\Model;

#[WithoutTimestamps]
class User extends Model
{
}
```

### WithoutIncrementingPropertyToWithoutIncrementingAttributeRector
Before:
```php
use Illuminate\Database\Eloquent\Model;

class User extends Model
{
    public $incrementing = false;
}
```
After:
```php
use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
use Illuminate\Database\Eloquent\Model;

#[WithoutIncrementing]
class User extends Model
{
}
```

### CollectedByPropertyToCollectedByAttributeRector
Before:
```php
use App\Models\Collections\UserCollection;
use Illuminate\Database\Eloquent\Collection;
use Illuminate\Database\Eloquent\Model;

class User extends Model
{
    /**
     * @param array<int, \Illuminate\Database\Eloquent\Model> $models
     * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model>
     */
    public function newCollection(array $models = []): Collection
    {
        return new UserCollection($models);
    }
}
```
After:
```php
use App\Models\Collections\UserCollection;
use Illuminate\Database\Eloquent\Attributes\CollectedBy;
use Illuminate\Database\Eloquent\Model;

#[CollectedBy(UserCollection::class)]
class User extends Model
{
}
```
