### PR TITLE
Skip superglobal assignments in Request, Env and Server rectors

### DIFF
--- a/src/NodeVisitor/ArrayDimFetchContextNodeVisitor.php
+++ b/src/NodeVisitor/ArrayDimFetchContextNodeVisitor.php
@@ -21,8 +21,10 @@ use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 final class ArrayDimFetchContextNodeVisitor extends NodeVisitorAbstract implements DecoratingNodeVisitorInterface
 {
     public const string IS_INSIDE_ARRAY_DIM_FETCH_WITH_DIM_NOT_SCALAR = 'is_inside_array_dim_fetch_with_dim_not_scalar';
-    public const string IS_IN_SERVER_VARIABLE = 'is_in_server_variable';
+    public const string IS_IN_SUPERGLOBAL_ASSIGN = 'is_in_superglobal_assign';
     public const string IS_INSIDE_ARRAY_DIM_FETCH_WITH_DIM_NOT_EXPR = 'is_inside_array_dim_fetch_with_dim_not_expr';
+
+    private const array SUPERGLOBAL_NAMES = ['_SERVER', '_GET', '_POST', '_REQUEST', '_ENV'];
 
     public function __construct(
         private readonly NodeNameResolver $nodeNameResolver
@@ -32,15 +34,13 @@ final class ArrayDimFetchContextNodeVisitor extends NodeVisitorAbstract implemen
     {
         if (! $node instanceof ArrayDimFetch) {
             if (in_array($node::class, [Assign::class, Isset_::class, Unset_::class, InterpolatedString::class], true)
-                && (! $node instanceof Assign || $node->var instanceof ArrayDimFetch && $this->nodeNameResolver->isName($node->var->var, '_SERVER'))) {
+                && (! $node instanceof Assign || $this->isSuperglobalAssign($node))) {
                 SimpleCallableNodeTraverser::traverseNodesWithCallable($node, function (Node $subNode) {
-                    if (! $subNode instanceof ArrayDimFetch) {
-                        return null;
+                    if ($subNode instanceof ArrayDimFetch || $subNode instanceof Variable) {
+                        $subNode->setAttribute(self::IS_IN_SUPERGLOBAL_ASSIGN, true);
                     }
 
-                    $subNode->setAttribute(self::IS_IN_SERVER_VARIABLE, true);
-
-                    return $subNode;
+                    return null;
                 });
             }
 
@@ -74,5 +74,22 @@ final class ArrayDimFetchContextNodeVisitor extends NodeVisitorAbstract implemen
         });
 
         return null;
+    }
+
+    private function isSuperglobalAssign(Node $node): bool
+    {
+        if (! $node instanceof Assign) {
+            return false;
+        }
+
+        if ($node->var instanceof ArrayDimFetch && $node->var->var instanceof Variable) {
+            return $this->nodeNameResolver->isNames($node->var->var, self::SUPERGLOBAL_NAMES);
+        }
+
+        if ($node->var instanceof Variable) {
+            return $this->nodeNameResolver->isNames($node->var, self::SUPERGLOBAL_NAMES);
+        }
+
+        return false;
     }
 }

--- a/src/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector.php
+++ b/src/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector.php
@@ -6,6 +6,7 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\StaticCall;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use RectorLaravel\AbstractRector;
 use RectorLaravel\Tests\Rector\ArrayDimFetch\EnvVariableToEnvHelperRector\EnvVariableToEnvHelperRectorTest;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -41,6 +42,10 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?StaticCall
     {
+        if ($node->getAttribute(AttributeKey::IS_BEING_ASSIGNED) === true) {
+            return null;
+        }
+
         if (! $this->isName($node->var, '_ENV')) {
             return null;
         }

--- a/src/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector.php
+++ b/src/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar;
 use PhpParser\Node\Scalar\String_;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use RectorLaravel\AbstractRector;
 use RectorLaravel\NodeVisitor\ArrayDimFetchContextNodeVisitor;
 use RectorLaravel\Tests\Rector\ArrayDimFetch\RequestVariablesToRequestFacadeRector\RequestVariablesToRequestFacadeRectorTest;
@@ -67,6 +68,17 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): StaticCall|NotIdentical|null
     {
+        // skip direct assignment targets: $_POST = $data, $_POST['key'] = $value
+        if ($node->getAttribute(AttributeKey::IS_BEING_ASSIGNED) === true) {
+            return null;
+        }
+
+        // skip inner nodes of superglobal assignments (e.g. the $_POST Variable
+        // inside $_POST['key'] = ...) and non-assignment contexts like isset/unset
+        if ($node->getAttribute(ArrayDimFetchContextNodeVisitor::IS_IN_SUPERGLOBAL_ASSIGN) === true) {
+            return null;
+        }
+
         if ($node instanceof Variable) {
             if ($node->getAttribute(ArrayDimFetchContextNodeVisitor::IS_INSIDE_ARRAY_DIM_FETCH_WITH_DIM_NOT_SCALAR) === true) {
                 return null;

--- a/src/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector.php
+++ b/src/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector.php
@@ -51,7 +51,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($node->getAttribute(ArrayDimFetchContextNodeVisitor::IS_IN_SERVER_VARIABLE) === true) {
+        if ($node->getAttribute(ArrayDimFetchContextNodeVisitor::IS_IN_SUPERGLOBAL_ASSIGN) === true) {
             return null;
         }
 

--- a/tests/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector/Fixture/skip_env_assignments.php.inc
+++ b/tests/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector/Fixture/skip_env_assignments.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\EnvVariableToEnvHelperRector\Fixture;
+
+$_ENV['APP_NAME'] = 'MyApp';
+$_ENV['APP_DEBUG'] = true;
+
+?>

--- a/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/Fixture/skip_superglobal_assignments.php.inc
+++ b/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/Fixture/skip_superglobal_assignments.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\RequestVariablesToRequestFacadeRector\Fixture;
+
+$_POST = $data;
+$_GET = [];
+$_REQUEST = $input;
+$_POST['key'] = $value;
+$_GET['key'] = 'value';
+$_REQUEST['key'] = $value;
+
+?>


### PR DESCRIPTION
The `RequestVariablesToRequestFacadeRector`, `EnvVariableToEnvHelperRector` and `ServerVariableToRequestFacadeRector` rules currently transform superglobal assignments, which produces invalid code.

**Before this fix:**

`php
// This valid code:
$_POST = $data;
$_ENV['APP_NAME'] = 'MyApp';

// Was wrongly transformed into:
\Illuminate\Support\Facades\Request::post() = $data;         // fatal error
\Illuminate\Support\Env::get('APP_NAME') = 'MyApp';           // fatal error
`

**After this fix**, assignments to superglobals are left untouched while reads are still correctly transformed:

`php
// Assignments: left alone
$_POST = $data;
$_POST['key'] = $value;
$_ENV['APP_NAME'] = 'MyApp';

// Reads: still transformed
$var = $_POST['key'];    // => Request::post('key')
$env = $_ENV['APP_DEBUG']; // => Env::get('APP_DEBUG')
`

Also renames `IS_IN_SERVER_VARIABLE` to `IS_IN_SUPERGLOBAL_ASSIGN` since the visitor now covers all superglobals.