### PR TITLE
Bump Rector to ^2.4.6 and fix test warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Rector upgrades rules for Laravel Framework",
     "require": {
         "php": ">=8.3",
-        "rector/rector": "^2.4.1",
+        "rector/rector": "^2.4.6",
         "webmozart/assert": "^1.11 || ^2.0",
         "symplify/rule-doc-generator-contracts": "^11.2"
     },

--- a/tests/NodeAnalyzer/LaravelServiceAnalyzerTest.php
+++ b/tests/NodeAnalyzer/LaravelServiceAnalyzerTest.php
@@ -10,11 +10,17 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\ObjectType;
 use PHPUnit\Framework\Assert;
+use Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocatorProvider\DynamicSourceLocatorProvider;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
 use RectorLaravel\NodeAnalyzer\LaravelServiceAnalyzer;
 
 class LaravelServiceAnalyzerTest extends AbstractLazyTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->make(DynamicSourceLocatorProvider::class)->reset();
+    }
     /**
      * @test
      */

--- a/tests/NodeAnalyzer/LaravelServiceAnalyzerTest.php
+++ b/tests/NodeAnalyzer/LaravelServiceAnalyzerTest.php
@@ -21,6 +21,7 @@ class LaravelServiceAnalyzerTest extends AbstractLazyTestCase
         parent::setUp();
         $this->make(DynamicSourceLocatorProvider::class)->reset();
     }
+
     /**
      * @test
      */


### PR DESCRIPTION
Bump Rector to ^2.4.6 and fix test warning

```
2 tests triggered 1 PHP warning:

1) phar:///Users/samsonasik/www/rector-laravel/vendor/phpstan/phpstan/phpstan.phar/src/Reflection/BetterReflection/SourceLocator/OptimizedSingleFileSourceLocator.php:48
hash_file(/Users/samsonasik/www/rector-laravel/tests/Rector/StaticCall/RouteActionCallableRector/Fixture/named_route_with_middleware.php): Failed to open stream: No such file or directory

Triggered by:

* RectorLaravel\Tests\NodeAnalyzer\LaravelServiceAnalyzerTest::it_can_detect_the_static_call_is_not_made_via_facade
  /Users/samsonasik/www/rector-laravel/tests/NodeAnalyzer/LaravelServiceAnalyzerTest.php:75

* RectorLaravel\Tests\NodeAnalyzer\LaravelServiceAnalyzerTest::it_can_find_the_proxy_origin_of_the_facade_with_string_accessor
  /Users/samsonasik/www/rector-laravel/tests/NodeAnalyzer/LaravelServiceAnalyzerTest.php:21
```