### PR TITLE
Feat: Add Factory `has()`/`for()` to Magic Method Rector

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 122 Rules Overview
+# 125 Rules Overview
 
 ## AbortIfRector
 
@@ -69,7 +69,7 @@ Add generic Builder return type to scopes in child of `Illuminate\Database\Eloqu
  use App\Post;
  use Illuminate\Database\Eloquent\Model;
  use Illuminate\Database\Eloquent\Builder;
- 
+
  class Post extends Model
  {
 +    /**
@@ -161,6 +161,34 @@ Adds the HasFactory trait to Models.
  class User extends Model
  {
 +    use \Illuminate\Database\Eloquent\Factories\HasFactory;
+ }
+```
+
+<br>
+
+## AddMockConsoleOutputFalseToConsoleTestsRector
+
+Add "$this->mockConsoleOutput = false"; to console tests that work with output content
+
+- class: [`RectorLaravel\Rector\Class_\AddMockConsoleOutputFalseToConsoleTestsRector`](../src/Rector/Class_/AddMockConsoleOutputFalseToConsoleTestsRector.php)
+
+```diff
+ use Illuminate\Support\Facades\Artisan;
+ use Illuminate\Foundation\Testing\TestCase;
+
+ final class SomeTest extends TestCase
+ {
++    protected function setUp(): void
++    {
++        parent::setUp();
++
++        $this->mockConsoleOutput = false;
++    }
++
+     public function test(): void
+     {
+         $this->assertEquals('content', \trim((new Artisan())::output()));
+     }
  }
 ```
 
@@ -995,7 +1023,7 @@ Add type hinting to where relation has methods e.g. `whereHas`, `orWhereHas`, `w
 +User::whereHas('posts', function (\Illuminate\Contracts\Database\Query\Builder $query) {
      $query->where('is_published', true);
  });
- 
+
 -$query->whereHas('posts', function ($query) {
 +$query->whereHas('posts', function (\Illuminate\Contracts\Database\Query\Builder $query) {
      $query->where('is_published', true);
@@ -1135,6 +1163,19 @@ Use the static factory method instead of global factory function.
 ```diff
 -factory(User::class);
 +User::factory();
+```
+
+<br>
+
+## FactoryHasForToMagicMethodRector
+
+Encapsulate simple factory `->has()/->for()` relationship calls into their magic method equivalents.
+
+- class: [`RectorLaravel\Rector\MethodCall\FactoryHasForToMagicMethodRector`](../src/Rector/MethodCall/FactoryHasForToMagicMethodRector.php)
+
+```diff
+-Product::factory()->has(Variation::factory()->times(3))->create();
++Product::factory()->hasVariations(3)->create();
 ```
 
 <br>
@@ -1760,6 +1801,37 @@ Replace assertTimesSent with assertSentTimes
 ```diff
 -Notification::assertTimesSent(1, SomeNotification::class);
 +Notification::assertSentTimes(SomeNotification::class, 1);
+```
+
+<br>
+
+## ReplaceExpectsMethodsInTestsRector
+
+Replace expectJobs and expectEvents methods in tests
+
+- class: [`RectorLaravel\Rector\Class_\ReplaceExpectsMethodsInTestsRector`](../src/Rector/Class_/ReplaceExpectsMethodsInTestsRector.php)
+
+```diff
+ use Illuminate\Foundation\Testing\TestCase;
+
+ class SomethingTest extends TestCase
+ {
+     public function testSomething()
+     {
+-        $this->expectsJobs([\App\Jobs\SomeJob::class, \App\Jobs\SomeOtherJob::class]);
+-        $this->expectsEvents(\App\Events\SomeEvent::class);
+-        $this->doesntExpectEvents(\App\Events\SomeOtherEvent::class);
++        \Illuminate\Support\Facades\Bus::fake([\App\Jobs\SomeJob::class, \App\Jobs\SomeOtherJob::class]);
++        \Illuminate\Support\Facades\Event::fake([\App\Events\SomeEvent::class, \App\Events\SomeOtherEvent::class]);
+
+         $this->get('/');
++
++        \Illuminate\Support\Facades\Bus::assertDispatched(\App\Jobs\SomeJob::class);
++        \Illuminate\Support\Facades\Bus::assertDispatched(\App\Jobs\SomeOtherJob::class);
++        \Illuminate\Support\Facades\Event::assertDispatched(\App\Events\SomeEvent::class);
++        \Illuminate\Support\Facades\Event::assertNotDispatched(\App\Events\SomeOtherEvent::class);
+     }
+ }
 ```
 
 <br>

--- a/src/Rector/MethodCall/FactoryHasForToMagicMethodRector.php
+++ b/src/Rector/MethodCall/FactoryHasForToMagicMethodRector.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\MethodCall;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use Rector\PhpParser\Node\Value\ValueResolver;
+use RectorLaravel\AbstractRector;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\FactoryHasForToMagicMethodRectorTest;
+use ReflectionMethod;
+use ReflectionNamedType;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see FactoryHasForToMagicMethodRectorTest
+ */
+final class FactoryHasForToMagicMethodRector extends AbstractRector
+{
+    public function __construct(private readonly ValueResolver $valueResolver) {}
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Encapsulate simple factory ->has()/->for() relationship calls into their magic method equivalents.',
+            [
+                new CodeSample(<<<'CODE_SAMPLE'
+Product::factory()->has(Variation::factory()->times(3))->create();
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+Product::factory()->hasVariations(3)->create();
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param  MethodCall  $node
+     */
+    public function refactor(Node $node): ?MethodCall
+    {
+        if (! $this->isRelationshipCall($node)) {
+            return null;
+        }
+
+        $factory = $node->getArgs()[0]->value;
+        $relatedClass = $this->resolveFactoryClass($factory);
+        $arguments = $this->magicMethodArguments($node, $factory);
+
+        if ($relatedClass === null || $arguments === null) {
+            return null;
+        }
+
+        $relation = $this->resolveRelation($node, $relatedClass);
+
+        if ($relation === null) {
+            return null;
+        }
+
+        $node->name = new Identifier($this->getName($node->name) . ucfirst($relation));
+        $node->args = array_map(static fn (Expr $expr): Arg => new Arg($expr), $arguments);
+
+        return $node;
+    }
+
+    private function isRelationshipCall(MethodCall $methodCall): bool
+    {
+        return $this->isNames($methodCall->name, ['has', 'for'])
+            && in_array(count($methodCall->args), [1, 2], true)
+            && $methodCall->args[0] instanceof Arg;
+    }
+
+    private function resolveFactoryClass(Expr $expr): ?string
+    {
+        while ($expr instanceof MethodCall) {
+            $expr = $expr->var;
+        }
+
+        if (! $expr instanceof StaticCall || ! $this->isName($expr->name, 'factory')) {
+            return null;
+        }
+
+        return $this->getName($expr->class);
+    }
+
+    /**
+     * @return list<Expr>|null
+     */
+    private function magicMethodArguments(MethodCall $methodCall, Expr $expr): ?array
+    {
+        $count = null;
+        $state = null;
+
+        while ($expr instanceof MethodCall) {
+            $name = $this->getName($expr->name);
+            $value = $expr->args[0]->value ?? null;
+
+            if (count($expr->args) !== 1 || ! $value instanceof Expr || ! in_array($name, ['times', 'count', 'state'], true)) {
+                return null;
+            }
+
+            if ($name === 'state' && ! $state instanceof Array_ && $value instanceof Array_) {
+                $state = $value;
+            } elseif ($name !== 'state' && ! $count instanceof Expr) {
+                $count = $value;
+            } else {
+                return null;
+            }
+
+            $expr = $expr->var;
+        }
+
+        if ($expr instanceof StaticCall) {
+            $merged = $this->mergeFactoryArguments($expr, $count, $state);
+
+            if ($merged === null) {
+                return null;
+            }
+
+            [$count, $state] = $merged;
+        }
+
+        if ($this->isName($methodCall->name, 'for')) {
+            return $state instanceof Array_ ? [$state] : [];
+        }
+
+        $arguments = [];
+
+        if ($count instanceof Expr) {
+            $arguments[] = $count;
+        }
+
+        if ($state instanceof Array_) {
+            $arguments[] = $state;
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * @return array{Expr|null, Array_|null}|null
+     */
+    private function mergeFactoryArguments(StaticCall $staticCall, ?Expr $expr, ?Array_ $array): ?array
+    {
+        if ($staticCall->args === []) {
+            return [$expr, $array];
+        }
+
+        if (count($staticCall->args) > 2 || ! $staticCall->args[0] instanceof Arg) {
+            return null;
+        }
+
+        $first = $staticCall->args[0]->value;
+
+        if ($first instanceof Array_) {
+            return count($staticCall->args) === 1 ? [$expr, $this->mergeState($first, $array)] : null;
+        }
+
+        if ($expr instanceof Expr || ! is_numeric($this->valueResolver->getValue($first))) {
+            return null;
+        }
+
+        $second = $staticCall->args[1] ?? null;
+
+        if ($second === null) {
+            return [$first, $array];
+        }
+
+        if (! $second instanceof Arg || ! $second->value instanceof Array_) {
+            return null;
+        }
+
+        return [$first, $this->mergeState($second->value, $array)];
+    }
+
+    private function mergeState(Array_ $factoryState, ?Array_ $chainState): Array_
+    {
+        return $chainState instanceof Array_
+            ? new Array_(array_merge($factoryState->items, $chainState->items))
+            : $factoryState;
+    }
+
+    private function resolveRelation(MethodCall $methodCall, string $relatedClass): ?string
+    {
+        $model = $this->resolveFactoryClass($methodCall->var);
+
+        if ($model === null || ! is_subclass_of($model, Model::class)) {
+            return null;
+        }
+
+        $relation = $this->guessRelationName($methodCall, $model, $relatedClass);
+
+        if ($relation === null || ! $this->isEncapsulatableRelation($model, $relation)) {
+            return null;
+        }
+
+        return $relation;
+    }
+
+    private function guessRelationName(MethodCall $methodCall, string $model, string $relatedClass): ?string
+    {
+        if (isset($methodCall->args[1]) && $methodCall->args[1] instanceof Arg && $methodCall->args[1]->value instanceof String_) {
+            return $methodCall->args[1]->value->value;
+        }
+
+        $basename = basename(str_replace('\\', '/', $relatedClass));
+        $singular = lcfirst($basename);
+        $plural = lcfirst($this->pluralise($basename));
+
+        if ($this->isName($methodCall->name, 'has') && method_exists($model, $plural)) {
+            return $plural;
+        }
+
+        return method_exists($model, $singular) ? $singular : null;
+    }
+
+    /**
+     * Best-effort English pluralisation of a class basename. The result is only ever used as a
+     * candidate relation name that is then verified with method_exists(), so an inexact guess
+     * simply causes the rule to fall back to the singular form or skip the node.
+     */
+    private function pluralise(string $word): string
+    {
+        $lower = strtolower($word);
+
+        if (str_ends_with($lower, 'y') && preg_match('/[aeiou]y$/', $lower) === 0) {
+            return substr($word, 0, -1) . 'ies';
+        }
+
+        if (preg_match('/(s|x|z|ch|sh)$/', $lower) === 1) {
+            return $word . 'es';
+        }
+
+        return $word . 's';
+    }
+
+    private function isEncapsulatableRelation(string $model, string $relation): bool
+    {
+        if (! method_exists($model, $relation)) {
+            return false;
+        }
+
+        $returnType = (new ReflectionMethod($model, $relation))->getReturnType();
+
+        if (! $returnType instanceof ReflectionNamedType || $returnType->isBuiltin()) {
+            return false;
+        }
+
+        $type = $returnType->getName();
+
+        if (! is_a($type, Relation::class, true)) {
+            return false;
+        }
+
+        return ! is_a($type, MorphTo::class, true); // MorphTo relations lack the necessary resolvable class from relation
+    }
+}

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/FactoryHasForToMagicMethodRectorTest.php
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/FactoryHasForToMagicMethodRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class FactoryHasForToMagicMethodRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/for_factory.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/for_factory.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Type;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Variation::factory()->for(Type::factory())->create();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Type;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Variation::factory()->forType()->create();
+
+?>

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/for_factory_state.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/for_factory_state.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Type;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Variation::factory()->for(Type::factory(['name' => 'Colour']))->create();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Type;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Variation::factory()->forType(['name' => 'Colour'])->create();
+
+?>

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/for_with_state.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/for_with_state.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Type;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Variation::factory()->for(Type::factory()->state(['name' => 'Colour']))->create();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Type;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Variation::factory()->forType(['name' => 'Colour'])->create();
+
+?>

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_count.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_count.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()->has(Variation::factory()->count(2))->create();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()->hasVariations(2)->create();
+
+?>

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_explicit_relation.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_explicit_relation.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()->has(Variation::factory()->times(3), 'pieces')->create();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()->hasPieces(3)->create();
+
+?>

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_factory_count.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_factory_count.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()->has(Variation::factory(3))->create();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()->hasVariations(3)->create();
+
+?>

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_factory_count_state.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_factory_count_state.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()->has(Variation::factory(3, ['online' => true]))->create();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()->hasVariations(3, ['online' => true])->create();
+
+?>

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_factory_state.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_factory_state.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()->has(Variation::factory(['online' => true]))->create();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()->hasVariations(['online' => true])->create();
+
+?>

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_no_count.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_no_count.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()->has(Variation::factory())->create();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()->hasVariations()->create();
+
+?>

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_polymorphic_many.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_polymorphic_many.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Comment;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+
+Product::factory()->has(Comment::factory())->create();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Comment;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+
+Product::factory()->hasComments()->create();
+
+?>

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_polymorphic_many_count.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_polymorphic_many_count.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Comment;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+
+Product::factory()->has(Comment::factory()->times(2))->create();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Comment;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+
+Product::factory()->hasComments(2)->create();
+
+?>

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_polymorphic_to_many.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_polymorphic_to_many.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Label;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+
+Product::factory()->has(Label::factory())->create();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Label;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+
+Product::factory()->hasLabels()->create();
+
+?>

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_singular_relation.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_singular_relation.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Photo;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+
+Product::factory()->has(Photo::factory())->create();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Photo;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+
+Product::factory()->hasPhoto()->create();
+
+?>

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_times.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_times.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()->has(Variation::factory()->times(3))->create();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()->hasVariations(3)->create();
+
+?>

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_with_state.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/has_with_state.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()->has(Variation::factory()->times(3)->state(['online' => true]))->create();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()->hasVariations(3, ['online' => true])->create();
+
+?>

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/preserves_multiline_after_hasattached.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/preserves_multiline_after_hasattached.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+function makeWithAttached($tag)
+{
+    return Product::factory()
+        ->hasAttached($tag)
+        ->has(Variation::factory()->state(['online' => true]))
+        ->create();
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+function makeWithAttached($tag)
+{
+    return Product::factory()
+        ->hasAttached($tag)
+        ->hasVariations(['online' => true])
+        ->create();
+}
+
+?>

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/preserves_multiline_after_method.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/preserves_multiline_after_method.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()
+    ->hasPhoto()
+    ->has(Variation::factory()->times(2))
+    ->create();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()
+    ->hasPhoto()
+    ->hasVariations(2)
+    ->create();
+
+?>

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/preserves_multiline_chain.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/preserves_multiline_chain.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Type;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Variation::factory()
+    ->for(Type::factory()->state(['name' => 'Colour']))
+    ->create();
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Type;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Variation::factory()
+    ->forType(['name' => 'Colour'])
+    ->create();
+
+?>

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/skip_builder_relation.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/skip_builder_relation.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Type;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Type::factory()->has(Variation::factory())->create();

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/skip_custom_state_method.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/skip_custom_state_method.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()->has(Variation::factory()->offline())->create();

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/skip_factory_dynamic_arg.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/skip_factory_dynamic_arg.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()->has(Variation::factory(random_int(1, 3)))->create();

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/skip_for_model_instance.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/skip_for_model_instance.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Type;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+function makeVariationFor(Type $type): void
+{
+    Variation::factory()->for($type)->create();
+}

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/skip_non_factory.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/skip_non_factory.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use Illuminate\Support\Collection;
+
+function hasKey(Collection $collection): bool
+{
+    return $collection->has('variations');
+}

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/skip_polymorphic_for_relation.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/skip_polymorphic_for_relation.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Photo;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+
+Photo::factory()->for(Product::factory(), 'model')->create();

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/skip_state_closure.php.inc
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Fixture/skip_state_closure.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Fixture;
+
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Product;
+use RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source\Variation;
+
+Product::factory()->has(Variation::factory()->state(fn () => ['online' => true]))->create();

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Source/Comment.php
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Source/Comment.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    use HasFactory;
+}

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Source/Label.php
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Source/Label.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Label extends Model
+{
+    use HasFactory;
+}

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Source/Photo.php
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Source/Photo.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class Photo extends Model
+{
+    use HasFactory;
+
+    public function model(): MorphTo
+    {
+        return $this->morphTo(__FUNCTION__, 'model_type', 'model_id');
+    }
+}

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Source/Product.php
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Source/Product.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+
+class Product extends Model
+{
+    use HasFactory;
+
+    public function variations(): BelongsToMany
+    {
+        return $this->belongsToMany(Variation::class);
+    }
+
+    public function pieces(): BelongsToMany
+    {
+        return $this->belongsToMany(Variation::class);
+    }
+
+    public function photo(): HasOne
+    {
+        return $this->hasOne(Photo::class);
+    }
+
+    public function comments(): MorphMany
+    {
+        return $this->morphMany(Comment::class, 'model');
+    }
+
+    public function labels(): MorphToMany
+    {
+        return $this->morphToMany(Label::class, 'labelable'); // LOL
+    }
+}

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Source/Type.php
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Source/Type.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Type extends Model
+{
+    use HasFactory;
+
+    public function variations(): Builder
+    {
+        return Variation::query()->where('type_id', $this->id);
+    }
+}

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Source/Variation.php
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/Source/Variation.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\FactoryHasForToMagicMethodRector\Source;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Variation extends Model
+{
+    use HasFactory;
+
+    public function type(): BelongsTo
+    {
+        return $this->belongsTo(Type::class);
+    }
+}

--- a/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/FactoryHasForToMagicMethodRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\MethodCall\FactoryHasForToMagicMethodRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(FactoryHasForToMagicMethodRector::class);
+};


### PR DESCRIPTION
See (now removed, as per repo convention) description below:

```php
/**
 * Rewrites factory ->has()/->for() calls into their magic method equivalents, folding any
 * count and literal state into the arguments (e.g. ->has(Variation::factory()->times(3)) becomes
 * ->hasVariations(3)). Genuine relationships with simple factories qualify, including polymorphic
 * has-side relations; only the inverse morphTo is excluded.
 *
 * @see FactoryHasForToMagicMethodRectorTest
 */
```

Hi, I work with an ancient (18 years old) PHP codebase which has been converted to use Laravel over the last 5+ years so a lot of it has very old ways of working still, but we are trying our hardest to be progressive and make use of the multitude of Laravel 13 conveniences. We had previously decided that, going forward, we would make more use of the eloquent magic methods for factory relationship definitions as we often find complex nested factories to be quite distracting when reading the setup for tests.

However, we all attended Laravel Live London recently and it was brought to our attention that we could use Rector (better than we already had been already) to help enforce it going forward **and** convert existing cases in one fell swoop.

This rule in the PR comes from the custom rule I got working with our 4000+ PHPUnit tests (+ a lot of Dusk tests) and we were all quite happy with the result, so I have tried to share it here and make it fit better with Rector-Laravel conventions.

Please do let me know if I can make further changes or take different approaches anywhere.

### Possible concerns

- There are an awful lot of fixtures, but it's due to there being an awful lot of edge cases that I found while developing this. I believe that I came to a sensible and acceptable position before finalising
- I had to add some missing relationship stubs: I would be happy to add those in a separate PR if it's preferred?
- I used British English for one of the self contained helper method names (cos I'm Brit-ish, innit)
- I regenerated the docs as a final step as my understanding of the CI run is that it would not accept this without it (?): If I got that wrong I left it as the final commit so it could be easily reverted

Thanks for your time and a great package. It's value is immeasurable to teams like mine!