### PR TITLE
Add Eloquent relation stubs for HasOne, MorphMany, MorphOneOrMany, MorphToMany

### DIFF
--- a/stubs/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/stubs/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+if (class_exists('Illuminate\Database\Eloquent\Relations\HasOne')) {
+    return;
+}
+
+class HasOne extends HasOneOrMany {}

--- a/stubs/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/stubs/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+if (class_exists('Illuminate\Database\Eloquent\Relations\MorphMany')) {
+    return;
+}
+
+class MorphMany extends MorphOneOrMany {}

--- a/stubs/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/stubs/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+abstract class MorphOneOrMany extends HasMany {}

--- a/stubs/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/stubs/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+if (class_exists('Illuminate\Database\Eloquent\Relations\MorphToMany')) {
+    return;
+}
+
+class MorphToMany extends BelongsToMany {}


### PR DESCRIPTION
Adds test stubs for four Eloquent relation classes that aren't currently covered:
- HasOne
- MorphMany
- MorphOneOrMany
- MorphToMany

They mirror the existing stubs under `stubs/Illuminate/Database/Eloquent/Relations/` and let fixtures declare these relation return types so PHPStan can resolve them in rule tests.

Split into its own PR so it can land independently of [FactoryHasForToMagicMethod](https://github.com/driftingly/rector-laravel/pull/525), the rule that depends on these stubs to help keep that rule's diff focused on the rule itself.