### PR TITLE
Add AddGenericBuilderToScopesRector 

### DIFF
--- a/config/sets/laravel-type-declarations.php
+++ b/config/sets/laravel-type-declarations.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use RectorLaravel\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector;
+use RectorLaravel\Rector\ClassMethod\AddGenericBuilderToScopesRector;
 use RectorLaravel\Rector\FuncCall\TypeHintTappableCallRector;
 use RectorLaravel\Rector\MethodCall\EloquentWhereRelationTypeHintingParameterRector;
 use RectorLaravel\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector;
@@ -12,6 +13,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../config.php');
     $rectorConfig->rule(TypeHintTappableCallRector::class);
     $rectorConfig->rule(AddGenericReturnTypeToRelationsRector::class);
+    $rectorConfig->rule(AddGenericBuilderToScopesRector::class);
     $rectorConfig->rule(EloquentWhereRelationTypeHintingParameterRector::class);
     $rectorConfig->rule(EloquentWhereTypeHintClosureParameterRector::class);
 };

--- a/config/sets/laravel-type-declarations.php
+++ b/config/sets/laravel-type-declarations.php
@@ -3,8 +3,8 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use RectorLaravel\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector;
 use RectorLaravel\Rector\ClassMethod\AddGenericBuilderToScopesRector;
+use RectorLaravel\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector;
 use RectorLaravel\Rector\FuncCall\TypeHintTappableCallRector;
 use RectorLaravel\Rector\MethodCall\EloquentWhereRelationTypeHintingParameterRector;
 use RectorLaravel\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector;

--- a/src/NodeAnalyzer/ApplicationAnalyzer.php
+++ b/src/NodeAnalyzer/ApplicationAnalyzer.php
@@ -25,7 +25,6 @@ class ApplicationAnalyzer
 
     /**
      * @param  class-string  $applicationClass
-     * @return $this
      */
     public function setApplicationClass(string $applicationClass): static
     {

--- a/src/Rector/ClassMethod/AddGenericBuilderToScopesRector.php
+++ b/src/Rector/ClassMethod/AddGenericBuilderToScopesRector.php
@@ -11,6 +11,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
@@ -71,8 +72,8 @@ use Illuminate\Database\Eloquent\Builder;
 class Post extends Model
 {
     /**
-     * @param \Illuminate\Database\Eloquent\Builder<\App\Post> $query
-     * @return \Illuminate\Database\Eloquent\Builder<\App\Post>
+     * @param \Illuminate\Database\Eloquent\Builder<static> $query
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function scopePopular(Builder $query): Builder
     {
@@ -125,8 +126,6 @@ CODE_SAMPLE
             return null;
         }
 
-        $modelClass = $classReflection->getName();
-
         $firstParam = $node->params[0];
         $paramName = $this->getName($firstParam->var);
 
@@ -136,8 +135,8 @@ CODE_SAMPLE
 
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
-        $hasChanged = $this->refactorParam($node, $phpDocInfo, $paramName, $modelClass);
-        $hasChanged = $this->refactorReturn($node, $phpDocInfo, $modelClass) || $hasChanged;
+        $hasChanged = $this->refactorParam($phpDocInfo, $paramName, $classReflection);
+        $hasChanged = $this->refactorReturn($node, $phpDocInfo, $classReflection) || $hasChanged;
 
         if (! $hasChanged) {
             return null;
@@ -149,17 +148,16 @@ CODE_SAMPLE
     }
 
     private function refactorParam(
-        ClassMethod $classMethod,
         PhpDocInfo $phpDocInfo,
         string $paramName,
-        string $modelClass
+        ClassReflection $classReflection
     ): bool {
-        $genericTypeNode = $this->createBuilderGenericTypeNode($modelClass);
+        $genericTypeNode = $this->createBuilderGenericTypeNode($classReflection);
 
         $existingParamTag = $phpDocInfo->getParamTagValueByName($paramName);
 
         if ($existingParamTag instanceof ParamTagValueNode) {
-            if ($this->isGenericTypeAlreadyCorrect($existingParamTag->type, $modelClass, $classMethod)) {
+            if ($this->isGenericTypeAlreadyCorrect($existingParamTag->type, $classReflection)) {
                 return false;
             }
 
@@ -182,7 +180,7 @@ CODE_SAMPLE
     private function refactorReturn(
         ClassMethod $classMethod,
         PhpDocInfo $phpDocInfo,
-        string $modelClass
+        ClassReflection $classReflection
     ): bool {
         $methodReturnType = $classMethod->getReturnType();
 
@@ -194,12 +192,12 @@ CODE_SAMPLE
             return false;
         }
 
-        $genericTypeNode = $this->createBuilderGenericTypeNode($modelClass);
+        $genericTypeNode = $this->createBuilderGenericTypeNode($classReflection);
 
         $existingReturnTag = $phpDocInfo->getReturnTagValue();
 
         if ($existingReturnTag instanceof ReturnTagValueNode) {
-            if ($this->isGenericTypeAlreadyCorrect($existingReturnTag->type, $modelClass, $classMethod)) {
+            if ($this->isGenericTypeAlreadyCorrect($existingReturnTag->type, $classReflection)) {
                 return false;
             }
 
@@ -236,36 +234,31 @@ CODE_SAMPLE
 
     private function isGenericTypeAlreadyCorrect(
         TypeNode $typeNode,
-        string $modelClass,
-        Node $node
+        ClassReflection $classReflection
     ): bool {
         if (! $typeNode instanceof GenericTypeNode) {
             return false;
         }
 
-        $phpStanType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType(
-            $typeNode,
-            $node
-        );
-
-        if (! $phpStanType instanceof GenericObjectType) {
+        if (count($typeNode->genericTypes) !== 1) {
             return false;
         }
 
-        $types = $phpStanType->getTypes();
+        $param = $typeNode->genericTypes[0];
+        $expectedName = $classReflection->isFinal() ? 'self' : 'static';
 
-        if ($types === []) {
-            return false;
-        }
-
-        return $this->typeComparator->areTypesEqual($types[0], new ObjectType($modelClass));
+        return $param instanceof IdentifierTypeNode && $param->name === $expectedName;
     }
 
-    private function createBuilderGenericTypeNode(string $modelClass): GenericTypeNode
+    private function createBuilderGenericTypeNode(ClassReflection $classReflection): GenericTypeNode
     {
+        $typeParam = $classReflection->isFinal()
+            ? new IdentifierTypeNode('self')
+            : new IdentifierTypeNode('static');
+
         return new GenericTypeNode(
             new FullyQualifiedIdentifierTypeNode('Illuminate\Database\Eloquent\Builder'),
-            [new FullyQualifiedIdentifierTypeNode($modelClass)]
+            [$typeParam]
         );
     }
 

--- a/src/Rector/ClassMethod/AddGenericBuilderToScopesRector.php
+++ b/src/Rector/ClassMethod/AddGenericBuilderToScopesRector.php
@@ -22,10 +22,10 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\ValueObject\Type\FullyQualifiedIdentifierTypeNode;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
-use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use RectorLaravel\AbstractRector;
+use RectorLaravel\NodeAnalyzer\ScopeAnalyzer;
 use RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\AddGenericBuilderToScopesRectorTest;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -41,7 +41,7 @@ class AddGenericBuilderToScopesRector extends AbstractRector
         private readonly DocBlockUpdater $docBlockUpdater,
         private readonly StaticTypeMapper $staticTypeMapper,
         private readonly ReflectionProvider $reflectionProvider,
-        private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
+        private readonly ScopeAnalyzer $scopeAnalyzer,
     ) {}
 
     public function getRuleDefinition(): RuleDefinition
@@ -106,17 +106,11 @@ CODE_SAMPLE
             return null;
         }
 
-        if (count($node->params) < 1) {
+        if (! $this->scopeAnalyzer->isScopeMethod($node)) {
             return null;
         }
 
-        $methodName = $this->getName($node);
-        $hasScopeAttribute = $this->phpAttributeAnalyzer->hasPhpAttribute(
-            $node,
-            'Illuminate\Database\Eloquent\Attributes\Scope',
-        );
-
-        if (! $hasScopeAttribute && ($methodName === null || ! str_starts_with($methodName, 'scope'))) {
+        if (count($node->params) < 1) {
             return null;
         }
 

--- a/src/Rector/ClassMethod/AddGenericBuilderToScopesRector.php
+++ b/src/Rector/ClassMethod/AddGenericBuilderToScopesRector.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\ObjectType;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\BetterPhpDocParser\ValueObject\Type\FullyQualifiedIdentifierTypeNode;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
+use Rector\PHPStan\ScopeFetcher;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use RectorLaravel\AbstractRector;
+use RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\AddGenericBuilderToScopesRectorTest;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see AddGenericBuilderToScopesRectorTest
+ */
+class AddGenericBuilderToScopesRector extends AbstractRector
+{
+    public function __construct(
+        private readonly TypeComparator $typeComparator,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {}
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add generic Builder return type to scopes in child of Illuminate\Database\Eloquent\Model',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use App\Post;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class Post extends Model
+{
+    public function scopePopular(Builder $query): Builder
+    {
+        return $query->where('votes', '>', 100);
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use App\Post;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class Post extends Model
+{
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder<\App\Post> $query
+     * @return \Illuminate\Database\Eloquent\Builder<\App\Post>
+     */
+    public function scopePopular(Builder $query): Builder
+    {
+        return $query->where('votes', '>', 100);
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node instanceof ClassMethod) {
+            return null;
+        }
+
+        $scope = ScopeFetcher::fetch($node);
+
+        if ($this->shouldSkipNode($node, $scope)) {
+            return null;
+        }
+
+        $methodName = $this->getName($node);
+
+        if ($methodName === null || ! str_starts_with($methodName, 'scope')) {
+            return null;
+        }
+
+        if (count($node->params) < 1) {
+            return null;
+        }
+
+        $classReflection = $scope->getClassReflection();
+
+        if (! $classReflection instanceof ClassReflection) {
+            return null;
+        }
+
+        $modelClass = $classReflection->getName();
+
+        $firstParam = $node->params[0];
+        $paramName = $this->getName($firstParam->var);
+
+        if ($paramName === null) {
+            return null;
+        }
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+
+        $hasChanged = false;
+
+        $hasChanged = $this->refactorParam($node, $phpDocInfo, $paramName, $modelClass) || $hasChanged;
+        $hasChanged = $this->refactorReturn($node, $phpDocInfo, $modelClass) || $hasChanged;
+
+        if (! $hasChanged) {
+            return null;
+        }
+
+        $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
+
+        return $node;
+    }
+
+    private function refactorParam(
+        ClassMethod $classMethod,
+        PhpDocInfo $phpDocInfo,
+        string $paramName,
+        string $modelClass
+    ): bool {
+        $builderTypeNode = $this->createBuilderGenericTypeNode($modelClass);
+
+        $existingParamTag = $phpDocInfo->getParamTagValueByName($paramName);
+
+        if ($existingParamTag instanceof ParamTagValueNode) {
+            if ($this->isGenericTypeAlreadyCorrect($existingParamTag->type, $modelClass, $classMethod)) {
+                return false;
+            }
+
+            $existingParamTag->type = $builderTypeNode;
+
+            return true;
+        }
+
+        $phpDocInfo->addTagValueNode(new ParamTagValueNode(
+            $builderTypeNode,
+            false,
+            '$' . $paramName,
+            '',
+            false
+        ));
+
+        return true;
+    }
+
+    private function refactorReturn(
+        ClassMethod $classMethod,
+        PhpDocInfo $phpDocInfo,
+        string $modelClass
+    ): bool {
+        $methodReturnType = $classMethod->getReturnType();
+
+        if (! $methodReturnType instanceof Name) {
+            return false;
+        }
+
+        if (! $this->isObjectType($methodReturnType, new ObjectType('Illuminate\Database\Eloquent\Builder'))) {
+            return false;
+        }
+
+        $builderTypeNode = $this->createBuilderGenericTypeNode($modelClass);
+
+        $existingReturnTag = $phpDocInfo->getReturnTagValue();
+
+        if ($existingReturnTag instanceof ReturnTagValueNode) {
+            if ($this->isGenericTypeAlreadyCorrect($existingReturnTag->type, $modelClass, $classMethod)) {
+                return false;
+            }
+
+            $existingReturnTag->type = $builderTypeNode;
+
+            return true;
+        }
+
+        if ($this->areNativeTypeAndPhpDocReturnTypeDifferent($classMethod, $methodReturnType, $phpDocInfo)) {
+            return false;
+        }
+
+        $phpDocInfo->addTagValueNode(new ReturnTagValueNode($builderTypeNode, ''));
+
+        return true;
+    }
+
+    private function shouldSkipNode(ClassMethod $classMethod, Scope $scope): bool
+    {
+        if ($classMethod->stmts === null) {
+            return true;
+        }
+
+        $classReflection = $scope->getClassReflection();
+
+        if (! $classReflection instanceof ClassReflection || $classReflection->isAnonymous()) {
+            return true;
+        }
+
+        return ! $classReflection->isSubclassOfClass(
+            $this->reflectionProvider->getClass('Illuminate\Database\Eloquent\Model')
+        );
+    }
+
+    private function isGenericTypeAlreadyCorrect(
+        TypeNode $typeNode,
+        string $modelClass,
+        Node $node
+    ): bool {
+        if (! $typeNode instanceof GenericTypeNode) {
+            return false;
+        }
+
+        $phpStanType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType(
+            $typeNode,
+            $node
+        );
+
+        if (! $phpStanType instanceof GenericObjectType) {
+            return false;
+        }
+
+        $types = $phpStanType->getTypes();
+
+        if ($types === []) {
+            return false;
+        }
+
+        return $this->typeComparator->areTypesEqual($types[0], new ObjectType($modelClass));
+    }
+
+    private function createBuilderGenericTypeNode(string $modelClass): GenericTypeNode
+    {
+        return new GenericTypeNode(
+            new FullyQualifiedIdentifierTypeNode('Illuminate\Database\Eloquent\Builder'),
+            [new FullyQualifiedIdentifierTypeNode($modelClass)]
+        );
+    }
+
+    private function areNativeTypeAndPhpDocReturnTypeDifferent(
+        ClassMethod $classMethod,
+        Node $methodReturnType,
+        PhpDocInfo $phpDocInfo
+    ): bool {
+        $returnTagValue = $phpDocInfo->getReturnTagValue();
+
+        if (! $returnTagValue instanceof ReturnTagValueNode) {
+            return false;
+        }
+
+        $phpDocPHPStanType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType(
+            $returnTagValue->type,
+            $classMethod
+        );
+
+        $phpDocPHPStanTypeWithoutGenerics = $phpDocPHPStanType;
+        if ($phpDocPHPStanType instanceof GenericObjectType) {
+            $phpDocPHPStanTypeWithoutGenerics = new ObjectType($phpDocPHPStanType->getClassName());
+        }
+
+        $methodReturnTypePHPStanType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($methodReturnType);
+
+        return ! $this->typeComparator->areTypesEqual(
+            $methodReturnTypePHPStanType,
+            $phpDocPHPStanTypeWithoutGenerics,
+        );
+    }
+}

--- a/src/Rector/ClassMethod/AddGenericBuilderToScopesRector.php
+++ b/src/Rector/ClassMethod/AddGenericBuilderToScopesRector.php
@@ -136,9 +136,7 @@ CODE_SAMPLE
 
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
-        $hasChanged = false;
-
-        $hasChanged = $this->refactorParam($node, $phpDocInfo, $paramName, $modelClass) || $hasChanged;
+        $hasChanged = $this->refactorParam($node, $phpDocInfo, $paramName, $modelClass);
         $hasChanged = $this->refactorReturn($node, $phpDocInfo, $modelClass) || $hasChanged;
 
         if (! $hasChanged) {
@@ -156,7 +154,7 @@ CODE_SAMPLE
         string $paramName,
         string $modelClass
     ): bool {
-        $builderTypeNode = $this->createBuilderGenericTypeNode($modelClass);
+        $genericTypeNode = $this->createBuilderGenericTypeNode($modelClass);
 
         $existingParamTag = $phpDocInfo->getParamTagValueByName($paramName);
 
@@ -165,13 +163,13 @@ CODE_SAMPLE
                 return false;
             }
 
-            $existingParamTag->type = $builderTypeNode;
+            $existingParamTag->type = $genericTypeNode;
 
             return true;
         }
 
         $phpDocInfo->addTagValueNode(new ParamTagValueNode(
-            $builderTypeNode,
+            $genericTypeNode,
             false,
             '$' . $paramName,
             '',
@@ -196,7 +194,7 @@ CODE_SAMPLE
             return false;
         }
 
-        $builderTypeNode = $this->createBuilderGenericTypeNode($modelClass);
+        $genericTypeNode = $this->createBuilderGenericTypeNode($modelClass);
 
         $existingReturnTag = $phpDocInfo->getReturnTagValue();
 
@@ -205,7 +203,7 @@ CODE_SAMPLE
                 return false;
             }
 
-            $existingReturnTag->type = $builderTypeNode;
+            $existingReturnTag->type = $genericTypeNode;
 
             return true;
         }
@@ -214,7 +212,7 @@ CODE_SAMPLE
             return false;
         }
 
-        $phpDocInfo->addTagValueNode(new ReturnTagValueNode($builderTypeNode, ''));
+        $phpDocInfo->addTagValueNode(new ReturnTagValueNode($genericTypeNode, ''));
 
         return true;
     }

--- a/src/Rector/ClassMethod/AddGenericBuilderToScopesRector.php
+++ b/src/Rector/ClassMethod/AddGenericBuilderToScopesRector.php
@@ -21,6 +21,7 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\ValueObject\Type\FullyQualifiedIdentifierTypeNode;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use RectorLaravel\AbstractRector;
@@ -39,6 +40,7 @@ class AddGenericBuilderToScopesRector extends AbstractRector
         private readonly DocBlockUpdater $docBlockUpdater,
         private readonly StaticTypeMapper $staticTypeMapper,
         private readonly ReflectionProvider $reflectionProvider,
+        private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
     ) {}
 
     public function getRuleDefinition(): RuleDefinition
@@ -103,13 +105,17 @@ CODE_SAMPLE
             return null;
         }
 
-        $methodName = $this->getName($node);
-
-        if ($methodName === null || ! str_starts_with($methodName, 'scope')) {
+        if (count($node->params) < 1) {
             return null;
         }
 
-        if (count($node->params) < 1) {
+        $methodName = $this->getName($node);
+        $hasScopeAttribute = $this->phpAttributeAnalyzer->hasPhpAttribute(
+            $node,
+            'Illuminate\Database\Eloquent\Attributes\Scope',
+        );
+
+        if (! $hasScopeAttribute && ($methodName === null || ! str_starts_with($methodName, 'scope'))) {
             return null;
         }
 

--- a/src/Rector/FuncCall/DispatchNonShouldQueueToDispatchSyncRector.php
+++ b/src/Rector/FuncCall/DispatchNonShouldQueueToDispatchSyncRector.php
@@ -116,7 +116,7 @@ CODE_SAMPLE
 
         // Queued closures can only be dispatched from the helper
         if (
-            ! ($call instanceof StaticCall && $this->isCallOnBusFacade($call)) && (
+            (! $call instanceof StaticCall || ! $this->isCallOnBusFacade($call)) && (
                 $this->getType(
                     $call->args[0]->value,
                 ) instanceof ClosureType ||

--- a/src/Rector/MethodCall/EloquentWhereRelationTypeHintingParameterRector.php
+++ b/src/Rector/MethodCall/EloquentWhereRelationTypeHintingParameterRector.php
@@ -93,8 +93,7 @@ CODE_SAMPLE
 
         $position = $this->getPosition($node);
 
-        return ! (! ($node->getArgs()[$position]->value ?? null) instanceof Closure &&
-        ! ($node->getArgs()[$position]->value ?? null) instanceof ArrowFunction);
+        return ($node->getArgs()[$position]->value ?? null) instanceof Closure || ($node->getArgs()[$position]->value ?? null) instanceof ArrowFunction;
     }
 
     private function changeClosureParamType(MethodCall|StaticCall $node): ?Node

--- a/src/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector.php
+++ b/src/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector.php
@@ -89,8 +89,7 @@ CODE_SAMPLE
             return false;
         }
 
-        return ! (! ($node->getArgs()[0]->value ?? null) instanceof Closure &&
-        ! ($node->getArgs()[0]->value ?? null) instanceof ArrowFunction);
+        return ($node->getArgs()[0]->value ?? null) instanceof Closure || ($node->getArgs()[0]->value ?? null) instanceof ArrowFunction;
     }
 
     private function changeClosureParamType(MethodCall|StaticCall $node): ?Node

--- a/src/Rector/MethodCall/JsonCallToExplicitJsonCallRector.php
+++ b/src/Rector/MethodCall/JsonCallToExplicitJsonCallRector.php
@@ -140,7 +140,7 @@ final class JsonCallToExplicitJsonCallRector extends AbstractRector
 
         $secondArg = $methodCallArgs[1]->value;
 
-        if (! ($secondArg instanceof FuncCall && $this->isName($secondArg, 'route'))) {
+        if (! $secondArg instanceof FuncCall || ! $this->isName($secondArg, 'route')) {
             return false;
         }
 

--- a/src/ValueObject/ExpectedClassMethodMethodCalls.php
+++ b/src/ValueObject/ExpectedClassMethodMethodCalls.php
@@ -31,7 +31,7 @@ final readonly class ExpectedClassMethodMethodCalls
 
     public function isActionable(): bool
     {
-        return ! ($this->expectedMethodCalls === [] && $this->notExpectedMethodCalls === []);
+        return $this->expectedMethodCalls !== [] || $this->notExpectedMethodCalls !== [];
     }
 
     /**

--- a/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/AddGenericBuilderToScopesRectorTest.php
+++ b/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/AddGenericBuilderToScopesRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddGenericBuilderToScopesRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/final-class-scope.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/final-class-scope.php.inc
@@ -5,11 +5,11 @@ namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 
-class Comment extends Model
+final class Team extends Model
 {
-    public function scopeApproved(Builder $query)
+    public function scopeActive(Builder $query): Builder
     {
-        return $query->where('approved', true);
+        return $query->where('active', true);
     }
 }
 
@@ -22,14 +22,15 @@ namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 
-class Comment extends Model
+final class Team extends Model
 {
     /**
-     * @param \Illuminate\Database\Eloquent\Builder<static> $query
+     * @param \Illuminate\Database\Eloquent\Builder<self> $query
+     * @return \Illuminate\Database\Eloquent\Builder<self>
      */
-    public function scopeApproved(Builder $query)
+    public function scopeActive(Builder $query): Builder
     {
-        return $query->where('approved', true);
+        return $query->where('active', true);
     }
 }
 

--- a/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/final-class-with-scope-attribute.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/final-class-with-scope-attribute.php.inc
@@ -6,12 +6,12 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 
-class User extends Model
+final class Team extends Model
 {
     #[Scope]
-    public function popular(Builder $query): Builder
+    public function active(Builder $query): Builder
     {
-        return $query->where('votes', '>', 100);
+        return $query->where('active', true);
     }
 }
 
@@ -25,16 +25,16 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 
-class User extends Model
+final class Team extends Model
 {
     /**
-     * @param \Illuminate\Database\Eloquent\Builder<static> $query
-     * @return \Illuminate\Database\Eloquent\Builder<static>
+     * @param \Illuminate\Database\Eloquent\Builder<self> $query
+     * @return \Illuminate\Database\Eloquent\Builder<self>
      */
     #[Scope]
-    public function popular(Builder $query): Builder
+    public function active(Builder $query): Builder
     {
-        return $query->where('votes', '>', 100);
+        return $query->where('active', true);
     }
 }
 

--- a/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/no-phpdoc.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/no-phpdoc.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class User extends Model
+{
+    public function scopePopular(Builder $query): Builder
+    {
+        return $query->where('votes', '>', 100);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class User extends Model
+{
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\User> $query
+     * @return \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\User>
+     */
+    public function scopePopular(Builder $query): Builder
+    {
+        return $query->where('votes', '>', 100);
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/no-phpdoc.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/no-phpdoc.php.inc
@@ -25,8 +25,8 @@ use Illuminate\Database\Eloquent\Builder;
 class User extends Model
 {
     /**
-     * @param \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\User> $query
-     * @return \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\User>
+     * @param \Illuminate\Database\Eloquent\Builder<static> $query
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function scopePopular(Builder $query): Builder
     {

--- a/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/param-already-correct-add-return.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/param-already-correct-add-return.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class Post extends Model
+{
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\Post> $query
+     */
+    public function scopePopular(Builder $query): Builder
+    {
+        return $query->where('votes', '>', 100);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class Post extends Model
+{
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\Post> $query
+     * @return \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\Post>
+     */
+    public function scopePopular(Builder $query): Builder
+    {
+        return $query->where('votes', '>', 100);
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/param-already-correct-add-return.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/param-already-correct-add-return.php.inc
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Builder;
 class Post extends Model
 {
     /**
-     * @param \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\Post> $query
+     * @param \Illuminate\Database\Eloquent\Builder<static> $query
      */
     public function scopePopular(Builder $query): Builder
     {
@@ -28,8 +28,8 @@ use Illuminate\Database\Eloquent\Builder;
 class Post extends Model
 {
     /**
-     * @param \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\Post> $query
-     * @return \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\Post>
+     * @param \Illuminate\Database\Eloquent\Builder<static> $query
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function scopePopular(Builder $query): Builder
     {

--- a/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/scope-with-different-param-name.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/scope-with-different-param-name.php.inc
@@ -25,8 +25,8 @@ use Illuminate\Database\Eloquent\Builder;
 class Product extends Model
 {
     /**
-     * @param \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\Product> $builder
-     * @return \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\Product>
+     * @param \Illuminate\Database\Eloquent\Builder<static> $builder
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function scopeActive(Builder $builder): Builder
     {

--- a/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/scope-with-different-param-name.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/scope-with-different-param-name.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class Product extends Model
+{
+    public function scopeActive(Builder $builder): Builder
+    {
+        return $builder->where(...);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class Product extends Model
+{
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\Product> $builder
+     * @return \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\Product>
+     */
+    public function scopeActive(Builder $builder): Builder
+    {
+        return $builder->where(...);
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/scope-without-native-return-type.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/scope-without-native-return-type.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class Comment extends Model
+{
+    public function scopeApproved(Builder $query)
+    {
+        return $query->where('approved', true);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class Comment extends Model
+{
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\Comment> $query
+     */
+    public function scopeApproved(Builder $query)
+    {
+        return $query->where('approved', true);
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/skip-already-correct-generic.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/skip-already-correct-generic.php.inc
@@ -8,8 +8,8 @@ use Illuminate\Database\Eloquent\Builder;
 class User extends Model
 {
     /**
-     * @param \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\User> $query
-     * @return \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\User>
+     * @param \Illuminate\Database\Eloquent\Builder<static> $query
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function scopePopular(Builder $query): Builder
     {

--- a/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/skip-already-correct-generic.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/skip-already-correct-generic.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class User extends Model
+{
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\User> $query
+     * @return \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\User>
+     */
+    public function scopePopular(Builder $query): Builder
+    {
+        return $query->where('votes', '>', 100);
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/skip-non-model.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/skip-non-model.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture;
+
+use Illuminate\Database\Eloquent\Builder;
+
+class NotAModel
+{
+    public function scopeFoo(Builder $query): Builder
+    {
+        return $query->where(...);
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/skip-non-scope.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/skip-non-scope.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class Post extends Model
+{
+    public function getActivePosts(Builder $query): Builder
+    {
+        return $this->query->where(...);
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/with-existing-param-without-generic.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/with-existing-param-without-generic.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class Account extends Model
+{
+    /**
+     * @param Builder $query
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $this->query->where(...);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class Account extends Model
+{
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\Account> $query
+     * @return \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\Account>
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $this->query->where(...);
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/with-existing-param-without-generic.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/with-existing-param-without-generic.php.inc
@@ -28,8 +28,8 @@ use Illuminate\Database\Eloquent\Builder;
 class Account extends Model
 {
     /**
-     * @param \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\Account> $query
-     * @return \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\Account>
+     * @param \Illuminate\Database\Eloquent\Builder<static> $query
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function scopeActive(Builder $query): Builder
     {

--- a/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/with-scope-attribute-without-return-type.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/with-scope-attribute-without-return-type.php.inc
@@ -28,7 +28,7 @@ use Illuminate\Database\Eloquent\Attributes\Scope;
 class User extends Model
 {
     /**
-     * @param \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\User> $query
+     * @param \Illuminate\Database\Eloquent\Builder<static> $query
      */
     #[Scope]
     public function popular(Builder $query)

--- a/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/with-scope-attribute-without-return-type.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/with-scope-attribute-without-return-type.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+
+class User extends Model
+{
+    #[Scope]
+    public function popular(Builder $query)
+    {
+        return $query->where('votes', '>', 100);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+
+class User extends Model
+{
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\User> $query
+     */
+    #[Scope]
+    public function popular(Builder $query)
+    {
+        return $query->where('votes', '>', 100);
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/with-scope-attribute.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/Fixture/with-scope-attribute.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+
+class User extends Model
+{
+    #[Scope]
+    public function popular(Builder $query): Builder
+    {
+        return $query->where('votes', '>', 100);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+
+class User extends Model
+{
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\User> $query
+     * @return \Illuminate\Database\Eloquent\Builder<\RectorLaravel\Tests\Rector\ClassMethod\AddGenericBuilderToScopesRector\Fixture\User>
+     */
+    #[Scope]
+    public function popular(Builder $query): Builder
+    {
+        return $query->where('votes', '>', 100);
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/config/configured_rule.php
+++ b/tests/Rector/ClassMethod/AddGenericBuilderToScopesRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\ClassMethod\AddGenericBuilderToScopesRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(AddGenericBuilderToScopesRector::class);
+};


### PR DESCRIPTION
This rule will simply add generic phpdocs to Laravel scopes.

```diff
class User extends Model
{
    /**
+    * @param Builder<User> $query
+    * @return Builder<User>
     */
    public function scopePopular(Builder $query): Builder
    {
        return $query->where('votes', '>', 100);
    }
}
```