### PR TITLE
Fix WhereNullComparisonToWhereNullRector rewriting possibly-null values

### DIFF
--- a/src/Rector/MethodCall/WhereNullComparisonToWhereNullRector.php
+++ b/src/Rector/MethodCall/WhereNullComparisonToWhereNullRector.php
@@ -90,7 +90,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($type->isNull()->no()) {
+        if (! $type->isNull()->yes()) {
             return null;
         }
 

--- a/tests/Rector/MethodCall/WhereNullComparisonToWhereNullRector/Fixture/skip_possibly_null_value.php.inc
+++ b/tests/Rector/MethodCall/WhereNullComparisonToWhereNullRector/Fixture/skip_possibly_null_value.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\AssertStatusToAssertMethodRector\Fixture;
+
+use Illuminate\Contracts\Database\Query\Builder;
+
+class SkipPossiblyNullValue
+{
+    public function test(Builder $query, ?int $userId, mixed $value)
+    {
+        $query
+            ->where('user_id', $userId)
+            ->where('foo', '=', $value)
+            ->where('bar', '!=', $userId);
+    }
+}
+?>


### PR DESCRIPTION
Fixes #531

## Problem

`WhereNullComparisonToWhereNullRector` skipped the rewrite only when the compared value was *provably* not null:

```php
if ($type->isNull()->no()) {
    return null;
}
```

`Type::isNull()` returns a `TrinaryLogic`, so `->no()` is only `true` for values that are definitely not null. Any value that is merely *possibly* null (`mixed`, `int|string|null`, etc.) yields `maybe`, falls through, and gets rewritten. This silently changes query semantics:

```php
$query->where('user_id', $user->getAuthIdentifier()); // getAuthIdentifier(): mixed
```

became

```php
$query->whereNull('user_id');
```

## Fix

Only rewrite when the value is *definitely* null:

```php
if (! $type->isNull()->yes()) {
    return null;
}
```

## Tests

Added `skip_possibly_null_value.php.inc`, which exercises a `?int` parameter and a `mixed` parameter across the 2-arg, `=`, and `!=` forms, all of which must now be left untouched. The existing fixture (literal `null`) still transforms as before. PHPStan and the linter are clean.