### PR TITLE
Bump to StructArmed ^0.15 and enable MustBeFinalRule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "tightenco/duster": "^3.1",
         "nette/utils": "^4.0",
         "tracy/tracy": "^2.10",
-        "boundwize/structarmed": "^0.14"
+        "boundwize/structarmed": "^0.15"
     },
     "autoload": {
         "psr-4": {

--- a/src/NodeAnalyzer/ApplicationAnalyzer.php
+++ b/src/NodeAnalyzer/ApplicationAnalyzer.php
@@ -5,7 +5,7 @@ namespace RectorLaravel\NodeAnalyzer;
 use ReflectionClassConstant;
 use RuntimeException;
 
-class ApplicationAnalyzer
+final class ApplicationAnalyzer
 {
     private ?string $version = null;
 

--- a/src/NodeAnalyzer/ModelAnalyzer.php
+++ b/src/NodeAnalyzer/ModelAnalyzer.php
@@ -12,7 +12,7 @@ use PHPStan\Type\ObjectType;
 use ReflectionException;
 use Throwable;
 
-class ModelAnalyzer
+final class ModelAnalyzer
 {
     public function __construct(
         private readonly ReflectionProvider $reflectionProvider,

--- a/src/NodeAnalyzer/ModelAnalyzer.php
+++ b/src/NodeAnalyzer/ModelAnalyzer.php
@@ -12,10 +12,10 @@ use PHPStan\Type\ObjectType;
 use ReflectionException;
 use Throwable;
 
-final class ModelAnalyzer
+final readonly class ModelAnalyzer
 {
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider,
+        private ReflectionProvider $reflectionProvider,
     ) {}
 
     protected static function relationType(): ObjectType

--- a/src/NodeAnalyzer/RelationshipAnalyzer.php
+++ b/src/NodeAnalyzer/RelationshipAnalyzer.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 
-class RelationshipAnalyzer
+final class RelationshipAnalyzer
 {
     protected static function relationType(): ObjectType
     {

--- a/src/NodeFactory/DispatchableTestsMethodsFactory.php
+++ b/src/NodeFactory/DispatchableTestsMethodsFactory.php
@@ -13,7 +13,7 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Expression;
 
-class DispatchableTestsMethodsFactory
+final class DispatchableTestsMethodsFactory
 {
     /**
      * @param  array<int<0, max>, ClassConstFetch|String_>  $items

--- a/src/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector.php
+++ b/src/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector.php
@@ -15,7 +15,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see EnvVariableToEnvHelperRectorTest
  */
-class EnvVariableToEnvHelperRector extends AbstractRector
+final class EnvVariableToEnvHelperRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector.php
+++ b/src/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector.php
@@ -23,7 +23,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see RequestVariablesToRequestFacadeRectorTest
  */
-class RequestVariablesToRequestFacadeRector extends AbstractRector
+final class RequestVariablesToRequestFacadeRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector.php
+++ b/src/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector.php
@@ -16,7 +16,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see ServerVariableToRequestFacadeRectorTest
  */
-class ServerVariableToRequestFacadeRector extends AbstractRector
+final class ServerVariableToRequestFacadeRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector.php
+++ b/src/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector.php
@@ -21,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see SessionVariableToSessionFacadeRectorTest
  */
-class SessionVariableToSessionFacadeRector extends AbstractRector
+final class SessionVariableToSessionFacadeRector extends AbstractRector
 {
     private const string IS_INSIDE_ARRAY_DIM_FETCH_WITH_DIM_NOT_EXPR = 'is_inside_array_dim_fetch_with_dim_not_expr';
 

--- a/src/Rector/ClassMethod/AddGenericBuilderToScopesRector.php
+++ b/src/Rector/ClassMethod/AddGenericBuilderToScopesRector.php
@@ -33,7 +33,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see AddGenericBuilderToScopesRectorTest
  */
-class AddGenericBuilderToScopesRector extends AbstractRector
+final class AddGenericBuilderToScopesRector extends AbstractRector
 {
     public function __construct(
         private readonly TypeComparator $typeComparator,

--- a/src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php
+++ b/src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php
@@ -36,7 +36,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see AddGenericReturnTypeToRelationsRectorNewGenericsTest
  * @see AddGenericReturnTypeToRelationsRectorOldGenericsTest
  */
-class AddGenericReturnTypeToRelationsRector extends AbstractRector
+final class AddGenericReturnTypeToRelationsRector extends AbstractRector
 {
     // Relation methods which are supported by this Rector.
     private const array RELATION_METHODS = [

--- a/src/Rector/ClassMethod/MakeModelAttributesAndScopesProtectedRector.php
+++ b/src/Rector/ClassMethod/MakeModelAttributesAndScopesProtectedRector.php
@@ -20,7 +20,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see MakeModelAttributesAndScopesProtectedRectorTest
  */
-class MakeModelAttributesAndScopesProtectedRector extends AbstractRector
+final class MakeModelAttributesAndScopesProtectedRector extends AbstractRector
 {
     public function __construct(
         private readonly VisibilityManipulator $visibilityManipulator,

--- a/src/Rector/Class_/ModelCastsPropertyToCastsMethodRector.php
+++ b/src/Rector/Class_/ModelCastsPropertyToCastsMethodRector.php
@@ -22,7 +22,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see ModelCastsPropertyToCastsMethodRectorTest
  */
-class ModelCastsPropertyToCastsMethodRector extends AbstractRector
+final class ModelCastsPropertyToCastsMethodRector extends AbstractRector
 {
     public function __construct(
         protected BuilderFactory $builderFactory,

--- a/src/Rector/Class_/ReplaceExpectsMethodsInTestsRector.php
+++ b/src/Rector/Class_/ReplaceExpectsMethodsInTestsRector.php
@@ -24,7 +24,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see ReplaceExpectsMethodsInTestsRectorTest
  */
-class ReplaceExpectsMethodsInTestsRector extends AbstractRector
+final class ReplaceExpectsMethodsInTestsRector extends AbstractRector
 {
     public function __construct(
         private readonly ExpectedClassMethodAnalyzer $expectedClassMethodAnalyzer,

--- a/src/Rector/Empty_/EmptyToBlankAndFilledFuncRector.php
+++ b/src/Rector/Empty_/EmptyToBlankAndFilledFuncRector.php
@@ -15,7 +15,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see EmptyToBlankAndFilledFuncRectorTest
  */
-class EmptyToBlankAndFilledFuncRector extends AbstractRector
+final class EmptyToBlankAndFilledFuncRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/Expr/AppEnvironmentComparisonToParameterRector.php
+++ b/src/Rector/Expr/AppEnvironmentComparisonToParameterRector.php
@@ -27,7 +27,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see AppEnvironmentComparisonToParameterRectorTest
  */
-class AppEnvironmentComparisonToParameterRector extends AbstractRector
+final class AppEnvironmentComparisonToParameterRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/SubStrToStartsWithOrEndsWithStaticMethodCallRector.php
+++ b/src/Rector/Expr/SubStrToStartsWithOrEndsWithStaticMethodCallRector/SubStrToStartsWithOrEndsWithStaticMethodCallRector.php
@@ -19,7 +19,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see SubStrToStartsWithOrEndsWithStaticMethodCallRectorTest
  */
-class SubStrToStartsWithOrEndsWithStaticMethodCallRector extends AbstractRector
+final class SubStrToStartsWithOrEndsWithStaticMethodCallRector extends AbstractRector
 {
     public function __construct(
         private readonly ValueResolver $valueResolver,

--- a/src/Rector/FuncCall/AppToResolveRector.php
+++ b/src/Rector/FuncCall/AppToResolveRector.php
@@ -13,7 +13,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see AppToResolveRectorTest
  */
-class AppToResolveRector extends AbstractRector
+final class AppToResolveRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/FuncCall/DispatchNonShouldQueueToDispatchSyncRector.php
+++ b/src/Rector/FuncCall/DispatchNonShouldQueueToDispatchSyncRector.php
@@ -24,7 +24,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see DispatchNonShouldQueueToDispatchSyncRectorTest
  */
-class DispatchNonShouldQueueToDispatchSyncRector extends AbstractRector
+final class DispatchNonShouldQueueToDispatchSyncRector extends AbstractRector
 {
     private const string SHOULD_QUEUE_INTERFACE = 'Illuminate\Contracts\Queue\ShouldQueue';
 

--- a/src/Rector/FuncCall/NotFilledBlankFuncCallToBlankFilledFuncCallRector.php
+++ b/src/Rector/FuncCall/NotFilledBlankFuncCallToBlankFilledFuncCallRector.php
@@ -15,7 +15,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see NotFilledBlankFuncCallToBlankFilledFuncCallRectorTest
  */
-class NotFilledBlankFuncCallToBlankFilledFuncCallRector extends AbstractRector
+final class NotFilledBlankFuncCallToBlankFilledFuncCallRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector.php
+++ b/src/Rector/FuncCall/NowFuncWithStartOfDayMethodCallToTodayFuncRector.php
@@ -15,7 +15,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see NowFuncWithStartOfDayMethodCallToTodayFuncRectorTest
  */
-class NowFuncWithStartOfDayMethodCallToTodayFuncRector extends AbstractRector
+final class NowFuncWithStartOfDayMethodCallToTodayFuncRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/FuncCall/RemoveRedundantValueCallsRector.php
+++ b/src/Rector/FuncCall/RemoveRedundantValueCallsRector.php
@@ -15,7 +15,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see RemoveRedundantValueCallsRectorTest
  */
-class RemoveRedundantValueCallsRector extends AbstractRector
+final class RemoveRedundantValueCallsRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/FuncCall/RemoveRedundantWithCallsRector.php
+++ b/src/Rector/FuncCall/RemoveRedundantWithCallsRector.php
@@ -13,7 +13,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see RemoveRedundantWithCallsRectorTest
  */
-class RemoveRedundantWithCallsRector extends AbstractRector
+final class RemoveRedundantWithCallsRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/FuncCall/SleepFuncToSleepStaticCallRector.php
+++ b/src/Rector/FuncCall/SleepFuncToSleepStaticCallRector.php
@@ -15,7 +15,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see SleepFuncToSleepStaticCallRectorTest
  */
-class SleepFuncToSleepStaticCallRector extends AbstractRector
+final class SleepFuncToSleepStaticCallRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/FuncCall/ThrowIfAndThrowUnlessExceptionsToUseClassStringRector.php
+++ b/src/Rector/FuncCall/ThrowIfAndThrowUnlessExceptionsToUseClassStringRector.php
@@ -16,7 +16,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see ThrowIfAndThrowUnlessExceptionsToUseClassStringRectorTest
  */
-class ThrowIfAndThrowUnlessExceptionsToUseClassStringRector extends AbstractRector
+final class ThrowIfAndThrowUnlessExceptionsToUseClassStringRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/FuncCall/TypeHintTappableCallRector.php
+++ b/src/Rector/FuncCall/TypeHintTappableCallRector.php
@@ -19,7 +19,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see TypeHintTappableCallRectorTest
  */
-class TypeHintTappableCallRector extends AbstractRector
+final class TypeHintTappableCallRector extends AbstractRector
 {
     private const string TAPPABLE_TRAIT = 'Illuminate\Support\Traits\Tappable';
 

--- a/src/Rector/If_/AbortIfRector.php
+++ b/src/Rector/If_/AbortIfRector.php
@@ -25,7 +25,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see AbortIfRectorTest
  */
-class AbortIfRector extends AbstractRector
+final class AbortIfRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/If_/ReportIfRector.php
+++ b/src/Rector/If_/ReportIfRector.php
@@ -25,7 +25,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see ReportIfRectorTest
  */
-class ReportIfRector extends AbstractRector
+final class ReportIfRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/If_/ThrowIfRector.php
+++ b/src/Rector/If_/ThrowIfRector.php
@@ -32,7 +32,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see ThrowIfRectorTest
  */
-class ThrowIfRector extends AbstractRector
+final class ThrowIfRector extends AbstractRector
 {
     public function __construct(private readonly BetterNodeFinder $betterNodeFinder) {}
 

--- a/src/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector.php
+++ b/src/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector.php
@@ -22,7 +22,7 @@ use Webmozart\Assert\Assert;
 /**
  * @see EloquentOrderByToLatestOrOldestRectorTest
  */
-class EloquentOrderByToLatestOrOldestRector extends AbstractRector implements ConfigurableRectorInterface
+final class EloquentOrderByToLatestOrOldestRector extends AbstractRector implements ConfigurableRectorInterface
 {
     final public const string ALLOWED_PATTERNS = 'allowed_patterns';
 

--- a/src/Rector/MethodCall/EloquentWhereRelationTypeHintingParameterRector.php
+++ b/src/Rector/MethodCall/EloquentWhereRelationTypeHintingParameterRector.php
@@ -20,7 +20,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see EloquentWhereRelationTypeHintingParameterRectorTest
  */
-class EloquentWhereRelationTypeHintingParameterRector extends AbstractRector
+final class EloquentWhereRelationTypeHintingParameterRector extends AbstractRector
 {
     /**
      * @var string[]

--- a/src/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector.php
+++ b/src/Rector/MethodCall/EloquentWhereTypeHintClosureParameterRector.php
@@ -21,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see EloquentWhereTypeHintClosureParameterRectorTest
  */
-class EloquentWhereTypeHintClosureParameterRector extends AbstractRector
+final class EloquentWhereTypeHintClosureParameterRector extends AbstractRector
 {
     public function __construct(private readonly QueryBuilderAnalyzer $queryBuilderAnalyzer) {}
 

--- a/src/Rector/MethodCall/RefactorBlueprintGeometryColumnsRector.php
+++ b/src/Rector/MethodCall/RefactorBlueprintGeometryColumnsRector.php
@@ -16,7 +16,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see RefactorBlueprintGeometryColumnsRectorTest
  */
-class RefactorBlueprintGeometryColumnsRector extends AbstractRector
+final class RefactorBlueprintGeometryColumnsRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/MethodCall/ReplaceServiceContainerCallArgRector.php
+++ b/src/Rector/MethodCall/ReplaceServiceContainerCallArgRector.php
@@ -24,7 +24,7 @@ use Webmozart\Assert\Assert;
 /**
  * @see ReplaceServiceContainerCallArgRectorTest
  */
-class ReplaceServiceContainerCallArgRector extends AbstractRector implements ConfigurableRectorInterface
+final class ReplaceServiceContainerCallArgRector extends AbstractRector implements ConfigurableRectorInterface
 {
     /**
      * @var ReplaceServiceContainerCallArg[]

--- a/src/Rector/MethodCall/ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector.php
+++ b/src/Rector/MethodCall/ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector.php
@@ -15,7 +15,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRectorTest
  */
-class ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector extends AbstractRector
+final class ReplaceWithoutJobsEventsAndNotificationsWithFacadeFakeRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/MethodCall/ReverseConditionableMethodCallRector.php
+++ b/src/Rector/MethodCall/ReverseConditionableMethodCallRector.php
@@ -16,7 +16,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see ReverseConditionableMethodCallRectorTest
  */
-class ReverseConditionableMethodCallRector extends AbstractRector
+final class ReverseConditionableMethodCallRector extends AbstractRector
 {
     private const string CONDITIONABLE_TRAIT = 'Illuminate\Support\Traits\Conditionable';
 

--- a/src/Rector/MethodCall/UseComponentPropertyWithinCommandsRector.php
+++ b/src/Rector/MethodCall/UseComponentPropertyWithinCommandsRector.php
@@ -21,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see UseComponentPropertyWithinCommandsRectorTest
  */
-class UseComponentPropertyWithinCommandsRector extends AbstractRector
+final class UseComponentPropertyWithinCommandsRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector.php
+++ b/src/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector.php
@@ -24,7 +24,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see ValidationRuleArrayStringValueToArrayRectorTest
  */
-class ValidationRuleArrayStringValueToArrayRector extends AbstractRector
+final class ValidationRuleArrayStringValueToArrayRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/MethodCall/WhereNullComparisonToWhereNullRector.php
+++ b/src/Rector/MethodCall/WhereNullComparisonToWhereNullRector.php
@@ -11,7 +11,7 @@ use RectorLaravel\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-class WhereNullComparisonToWhereNullRector extends AbstractRector
+final class WhereNullComparisonToWhereNullRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/StaticCall/ReplaceAssertTimesSendWithAssertSentTimesRector.php
+++ b/src/Rector/StaticCall/ReplaceAssertTimesSendWithAssertSentTimesRector.php
@@ -14,7 +14,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see ReplaceAssertTimesSendWithAssertSentTimesRectorTest
  */
-class ReplaceAssertTimesSendWithAssertSentTimesRector extends AbstractRector
+final class ReplaceAssertTimesSendWithAssertSentTimesRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/structarmed.php
+++ b/structarmed.php
@@ -4,6 +4,16 @@ declare(strict_types=1);
 
 use Boundwize\StructArmed\Architecture;
 use Boundwize\StructArmed\Preset\Preset;
+use Boundwize\StructArmed\Rule\Rules\Class_\MustBeFinalRule;
 
 return Architecture::define()
+    ->rule(
+        'source.must_be_final',
+        new MustBeFinalRule(layer: 'Source'),
+    )
+    ->skip([
+        'source.must_be_final' => [
+            '*/Source/*',
+        ],
+    ])
     ->withPreset(Preset::PSR4());

--- a/tests/NodeAnalyzer/LaravelServiceAnalyzerTest.php
+++ b/tests/NodeAnalyzer/LaravelServiceAnalyzerTest.php
@@ -14,7 +14,7 @@ use Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocatorProvider\Dy
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
 use RectorLaravel\NodeAnalyzer\LaravelServiceAnalyzer;
 
-class LaravelServiceAnalyzerTest extends AbstractLazyTestCase
+final class LaravelServiceAnalyzerTest extends AbstractLazyTestCase
 {
     protected function setUp(): void
     {

--- a/tests/NodeAnalyzer/ModelAnalyzerTest.php
+++ b/tests/NodeAnalyzer/ModelAnalyzerTest.php
@@ -7,7 +7,7 @@ use Rector\NodeTypeResolver\PHPStan\Scope\ScopeFactory;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
 use RectorLaravel\NodeAnalyzer\ModelAnalyzer;
 
-class ModelAnalyzerTest extends AbstractLazyTestCase
+final class ModelAnalyzerTest extends AbstractLazyTestCase
 {
     /**
      * @test

--- a/tests/NodeAnalyzer/QueryBuilderAnalyzerTest.php
+++ b/tests/NodeAnalyzer/QueryBuilderAnalyzerTest.php
@@ -21,7 +21,7 @@ use Rector\PHPStan\ScopeFetcher;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
 use RectorLaravel\NodeAnalyzer\QueryBuilderAnalyzer;
 
-class QueryBuilderAnalyzerTest extends AbstractLazyTestCase
+final class QueryBuilderAnalyzerTest extends AbstractLazyTestCase
 {
     /**
      * @test

--- a/tests/NodeAnalyzer/RelationshipAnalyzerTest.php
+++ b/tests/NodeAnalyzer/RelationshipAnalyzerTest.php
@@ -16,7 +16,7 @@ use Rector\PHPStan\ScopeFetcher;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
 use RectorLaravel\NodeAnalyzer\RelationshipAnalyzer;
 
-class RelationshipAnalyzerTest extends AbstractLazyTestCase
+final class RelationshipAnalyzerTest extends AbstractLazyTestCase
 {
     /**
      * @test

--- a/tests/Rector/ClassMethod/MigrateToSimplifiedAttributeRector/MigrateToSimplifiedAttributeRectorTest.php
+++ b/tests/Rector/ClassMethod/MigrateToSimplifiedAttributeRector/MigrateToSimplifiedAttributeRectorTest.php
@@ -8,7 +8,7 @@ use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
-class MigrateToSimplifiedAttributeRectorTest extends AbstractRectorTestCase
+final class MigrateToSimplifiedAttributeRectorTest extends AbstractRectorTestCase
 {
     /**
      * @return Iterator<string>

--- a/tests/Rector/StaticCall/DispatchToHelperFunctionsRector/DispatchToHelperFunctionsRectorTest.php
+++ b/tests/Rector/StaticCall/DispatchToHelperFunctionsRector/DispatchToHelperFunctionsRectorTest.php
@@ -8,7 +8,7 @@ use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
-class DispatchToHelperFunctionsRectorTest extends AbstractRectorTestCase
+final class DispatchToHelperFunctionsRectorTest extends AbstractRectorTestCase
 {
     public static function provideData(): Iterator
     {


### PR DESCRIPTION
StructArmed 0.15.0 introduce `ExtendedClassAwareRuleInterface` that makes `MustBeFinalRule` safely be used to skip if there is class that extend target class.

This PR bump StructArmed to `^0.15` and apply the `MustBeFinalRule` with single command:

```bash
vendor/bin/structarmed analyze --fix
```