### PR TITLE
[2.x] Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,6 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 banner.png export-ignore
-build export-ignore
 commands export-ignore
 docs export-ignore
 duster.json export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 banner.png export-ignore
+commands export-ignore
 docs export-ignore
 duster.json export-ignore
 phpstan.neon export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,15 @@
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+banner.png export-ignore
+build export-ignore
+commands export-ignore
+docs export-ignore
 duster.json export-ignore
 phpstan.neon export-ignore
 phpunit.xml export-ignore
+rector.php export-ignore
 stubs export-ignore
+structarmed.php export-ignore
+templates export-ignore
 tests export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,6 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 banner.png export-ignore
-commands export-ignore
 docs export-ignore
 duster.json export-ignore
 phpstan.neon export-ignore


### PR DESCRIPTION
Auditing vendor packages, and noticed rector-laravel includes a bunch of stuff we dont need as an end user

<img width="389" height="266" alt="image" src="https://github.com/user-attachments/assets/7d659000-35fd-493f-9498-9e03bc53f8ed" />

I've updated the .gitattributes to export-ignore a bunch of stuff like the `banner.png` etc... as I wouldn't need these in my vendor folder.