### PR TITLE
Add RouteKeyMethodToRouteKeyAttributeRector 

### DIFF
--- a/config/sets/laravel130-attributes.php
+++ b/config/sets/laravel130-attributes.php
@@ -24,6 +24,7 @@ use RectorLaravel\Rector\Class_\JobConnectionPropertyToJobConnectionAttributeRec
 use RectorLaravel\Rector\Class_\MaxExceptionsPropertyToMaxExceptionsAttributeRector;
 use RectorLaravel\Rector\Class_\PreserveKeysPropertyToPreserveKeysAttributeRector;
 use RectorLaravel\Rector\Class_\QueuePropertyToQueueAttributeRector;
+use RectorLaravel\Rector\Class_\RouteKeyMethodToRouteKeyAttributeRector;
 use RectorLaravel\Rector\Class_\SignaturePropertyToSignatureAttributeRector;
 use RectorLaravel\Rector\Class_\StopOnFirstFailurePropertyToStopOnFirstFailureAttributeRector;
 use RectorLaravel\Rector\Class_\TablePropertyToTableAttributeRector;
@@ -53,6 +54,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(FillablePropertyToFillableAttributeRector::class);
     $rectorConfig->rule(GuardedPropertyToGuardedAttributeRector::class);
     $rectorConfig->rule(HiddenPropertyToHiddenAttributeRector::class);
+    $rectorConfig->rule(RouteKeyMethodToRouteKeyAttributeRector::class);
     $rectorConfig->rule(TablePropertyToTableAttributeRector::class);
     $rectorConfig->rule(TouchesPropertyToTouchesAttributeRector::class);
     $rectorConfig->rule(VisiblePropertyToVisibleAttributeRector::class);

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 122 Rules Overview
+# 123 Rules Overview
 
 ## AbortIfRector
 
@@ -69,7 +69,7 @@ Add generic Builder return type to scopes in child of `Illuminate\Database\Eloqu
  use App\Post;
  use Illuminate\Database\Eloquent\Model;
  use Illuminate\Database\Eloquent\Builder;
- 
+
  class Post extends Model
  {
 +    /**
@@ -995,7 +995,7 @@ Add type hinting to where relation has methods e.g. `whereHas`, `orWhereHas`, `w
 +User::whereHas('posts', function (\Illuminate\Contracts\Database\Query\Builder $query) {
      $query->where('is_published', true);
  });
- 
+
 -$query->whereHas('posts', function ($query) {
 +$query->whereHas('posts', function (\Illuminate\Contracts\Database\Query\Builder $query) {
      $query->where('is_published', true);
@@ -1974,6 +1974,27 @@ Use PHP callable syntax instead of string syntax for controller route declaratio
 -    Route::get('/users', 'UserController@index');
 +    Route::get('/users', [\App\Http\Controllers\Admin\UserController::class, 'index']);
  })
+```
+
+<br>
+
+## RouteKeyMethodToRouteKeyAttributeRector
+
+Changes model `getRouteKeyName()` method to use the RouteKey attribute
+
+- class: [`RectorLaravel\Rector\Class_\RouteKeyMethodToRouteKeyAttributeRector`](../src/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector.php)
+
+```diff
+ use Illuminate\Database\Eloquent\Model;
+
++#[\Illuminate\Database\Eloquent\Attributes\RouteKey('slug')]
+ class Post extends Model
+ {
+-    public function getRouteKeyName(): string
+-    {
+-        return 'slug';
+-    }
+ }
 ```
 
 <br>

--- a/src/Rector/ClassMethod/AddArgumentDefaultValueRector.php
+++ b/src/Rector/ClassMethod/AddArgumentDefaultValueRector.php
@@ -22,7 +22,7 @@ use Webmozart\Assert\Assert;
  */
 final class AddArgumentDefaultValueRector extends AbstractRector implements ConfigurableRectorInterface
 {
-    final public const string ADDED_ARGUMENTS = 'added_arguments';
+    public const string ADDED_ARGUMENTS = 'added_arguments';
 
     /**
      * @var AddArgumentDefaultValue[]

--- a/src/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector.php
+++ b/src/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Return_;
+use PHPStan\Type\ObjectType;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
+use RectorLaravel\AbstractRector;
+use RectorLaravel\Tests\Rector\Class_\RouteKeyMethodToRouteKeyAttributeRector\RouteKeyMethodToRouteKeyAttributeRectorTest;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see RouteKeyMethodToRouteKeyAttributeRectorTest
+ */
+final class RouteKeyMethodToRouteKeyAttributeRector extends AbstractRector
+{
+    public function __construct(private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer) {}
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes model getRouteKeyName() method to use the RouteKey attribute',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+}
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\RouteKey('slug')]
+class Post extends Model
+{
+}
+CODE_SAMPLE
+            )]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param  Class_  $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isObjectType($node, new ObjectType('Illuminate\Database\Eloquent\Model'))) {
+            return null;
+        }
+
+        if ($this->phpAttributeAnalyzer->hasPhpAttribute($node, 'Illuminate\Database\Eloquent\Attributes\RouteKey')) {
+            return null;
+        }
+
+        $routeKeyMethod = $node->getMethod('getRouteKeyName');
+        if (! $routeKeyMethod instanceof ClassMethod) {
+            return null;
+        }
+
+        $returnExpr = $this->resolveReturnString($routeKeyMethod);
+        if (! $returnExpr instanceof String_) {
+            return null;
+        }
+
+        $node->attrGroups[] = new AttributeGroup([
+            new Attribute(new FullyQualified('Illuminate\Database\Eloquent\Attributes\RouteKey'), [new Arg($returnExpr)]),
+        ]);
+
+        foreach ($node->stmts as $key => $stmt) {
+            if ($stmt === $routeKeyMethod) {
+                unset($node->stmts[$key]);
+                break;
+            }
+        }
+
+        return $node;
+    }
+
+    private function resolveReturnString(ClassMethod $classMethod): ?String_
+    {
+        if ($classMethod->stmts === null || count($classMethod->stmts) !== 1) {
+            return null;
+        }
+
+        $onlyStmt = $classMethod->stmts[0];
+        if (! $onlyStmt instanceof Return_ || ! $onlyStmt->expr instanceof String_) {
+            return null;
+        }
+
+        return $onlyStmt->expr;
+    }
+}

--- a/src/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector.php
+++ b/src/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector.php
@@ -12,9 +12,9 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Return_;
 use PHPStan\Type\ObjectType;
 use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
+use Rector\TypeDeclarationDocblocks\NodeFinder\ReturnNodeFinder;
 use RectorLaravel\AbstractRector;
 use RectorLaravel\Tests\Rector\Class_\RouteKeyMethodToRouteKeyAttributeRector\RouteKeyMethodToRouteKeyAttributeRectorTest;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -25,7 +25,10 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RouteKeyMethodToRouteKeyAttributeRector extends AbstractRector
 {
-    public function __construct(private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer) {}
+    public function __construct(
+        private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
+        private readonly ReturnNodeFinder $returnNodeFinder,
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -81,13 +84,13 @@ CODE_SAMPLE
             return null;
         }
 
-        $returnExpr = $this->resolveReturnString($routeKeyMethod);
-        if (! $returnExpr instanceof String_) {
+        $returnExpr = $this->returnNodeFinder->findOnlyReturnWithExpr($routeKeyMethod);
+        if (! $returnExpr?->expr instanceof String_) {
             return null;
         }
 
         $node->attrGroups[] = new AttributeGroup([
-            new Attribute(new FullyQualified('Illuminate\Database\Eloquent\Attributes\RouteKey'), [new Arg($returnExpr)]),
+            new Attribute(new FullyQualified('Illuminate\Database\Eloquent\Attributes\RouteKey'), [new Arg($returnExpr->expr)]),
         ]);
 
         foreach ($node->stmts as $key => $stmt) {
@@ -98,19 +101,5 @@ CODE_SAMPLE
         }
 
         return $node;
-    }
-
-    private function resolveReturnString(ClassMethod $classMethod): ?String_
-    {
-        if ($classMethod->stmts === null || count($classMethod->stmts) !== 1) {
-            return null;
-        }
-
-        $onlyStmt = $classMethod->stmts[0];
-        if (! $onlyStmt instanceof Return_ || ! $onlyStmt->expr instanceof String_) {
-            return null;
-        }
-
-        return $onlyStmt->expr;
     }
 }

--- a/src/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector.php
+++ b/src/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector.php
@@ -15,6 +15,8 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Type\ObjectType;
 use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\TypeDeclarationDocblocks\NodeFinder\ReturnNodeFinder;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use RectorLaravel\AbstractRector;
 use RectorLaravel\Tests\Rector\Class_\RouteKeyMethodToRouteKeyAttributeRector\RouteKeyMethodToRouteKeyAttributeRectorTest;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -23,12 +25,17 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see RouteKeyMethodToRouteKeyAttributeRectorTest
  */
-final class RouteKeyMethodToRouteKeyAttributeRector extends AbstractRector
+final class RouteKeyMethodToRouteKeyAttributeRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
         private readonly ReturnNodeFinder $returnNodeFinder,
     ) {}
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('laravel/framework', '>=13.21');
+    }
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/Expr/AppEnvironmentComparisonToParameterRector.php
+++ b/src/Rector/Expr/AppEnvironmentComparisonToParameterRector.php
@@ -68,7 +68,7 @@ CODE_SAMPLE
             [$methodCall, $otherNode] = $this->handleBinaryOp($node);
         }
 
-        if ($methodCall === null || $otherNode === null) {
+        if ($methodCall === null || ! $otherNode instanceof Expr) {
             return null;
         }
 

--- a/src/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector.php
+++ b/src/Rector/MethodCall/EloquentOrderByToLatestOrOldestRector.php
@@ -24,7 +24,7 @@ use Webmozart\Assert\Assert;
  */
 final class EloquentOrderByToLatestOrOldestRector extends AbstractRector implements ConfigurableRectorInterface
 {
-    final public const string ALLOWED_PATTERNS = 'allowed_patterns';
+    public const string ALLOWED_PATTERNS = 'allowed_patterns';
 
     /**
      * @var string[]

--- a/src/Rector/PropertyFetch/OptionalToNullsafeOperatorRector.php
+++ b/src/Rector/PropertyFetch/OptionalToNullsafeOperatorRector.php
@@ -35,7 +35,7 @@ use Webmozart\Assert\Assert;
  */
 final class OptionalToNullsafeOperatorRector extends AbstractRector implements ConfigurableRectorInterface, MinPhpVersionInterface
 {
-    final public const string EXCLUDE_METHODS = 'exclude_methods';
+    public const string EXCLUDE_METHODS = 'exclude_methods';
 
     /**
      * @var array<class-string<Expr>>

--- a/src/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector.php
+++ b/src/Rector/StaticCall/EloquentMagicMethodToQueryBuilderRector.php
@@ -26,7 +26,7 @@ use Webmozart\Assert\Assert;
  */
 final class EloquentMagicMethodToQueryBuilderRector extends AbstractRector implements ConfigurableRectorInterface
 {
-    final public const string EXCLUDE_METHODS = 'exclude_methods';
+    public const string EXCLUDE_METHODS = 'exclude_methods';
 
     /**
      * @var string[]

--- a/src/Rector/StaticCall/MinutesToSecondsInCacheRector.php
+++ b/src/Rector/StaticCall/MinutesToSecondsInCacheRector.php
@@ -34,7 +34,7 @@ final class MinutesToSecondsInCacheRector extends AbstractRector
     /**
      * @var TypeToTimeMethodAndPosition[]
      */
-    private array $typeToTimeMethodsAndPositions = [];
+    private readonly array $typeToTimeMethodsAndPositions;
 
     public function __construct()
     {

--- a/src/Rector/StaticCall/Redirect301ToPermanentRedirectRector.php
+++ b/src/Rector/StaticCall/Redirect301ToPermanentRedirectRector.php
@@ -25,7 +25,7 @@ final class Redirect301ToPermanentRedirectRector extends AbstractRector
     /**
      * @var ObjectType[]
      */
-    private array $routerObjectTypes = [];
+    private readonly array $routerObjectTypes;
 
     public function __construct(
         private readonly ValueResolver $valueResolver,

--- a/src/Rector/StaticCall/RequestStaticValidateToInjectRector.php
+++ b/src/Rector/StaticCall/RequestStaticValidateToInjectRector.php
@@ -33,7 +33,7 @@ final class RequestStaticValidateToInjectRector extends AbstractRector
     /**
      * @var ObjectType[]
      */
-    private array $requestObjectTypes = [];
+    private readonly array $requestObjectTypes;
 
     public function __construct(
         private readonly ReflectionResolver $reflectionResolver

--- a/src/Rector/StaticCall/RouteActionCallableRector.php
+++ b/src/Rector/StaticCall/RouteActionCallableRector.php
@@ -33,11 +33,11 @@ use Webmozart\Assert\Assert;
  */
 final class RouteActionCallableRector extends AbstractRector implements ConfigurableRectorInterface
 {
-    final public const string ROUTES = 'routes';
+    public const string ROUTES = 'routes';
 
-    final public const string NAMESPACE = 'namespace';
+    public const string NAMESPACE = 'namespace';
 
-    final public const string NAMESPACE_ATTRIBUTE = 'laravel_route_group_namespace';
+    public const string NAMESPACE_ATTRIBUTE = 'laravel_route_group_namespace';
 
     private const string DEFAULT_NAMESPACE = 'App\Http\Controllers';
 

--- a/src/Set/LaravelLevelSetList.php
+++ b/src/Set/LaravelLevelSetList.php
@@ -6,37 +6,37 @@ namespace RectorLaravel\Set;
 
 final class LaravelLevelSetList
 {
-    final public const string UP_TO_LARAVEL_51 = __DIR__ . '/../../config/sets/level/up-to-laravel-51.php';
+    public const string UP_TO_LARAVEL_51 = __DIR__ . '/../../config/sets/level/up-to-laravel-51.php';
 
-    final public const string UP_TO_LARAVEL_52 = __DIR__ . '/../../config/sets/level/up-to-laravel-52.php';
+    public const string UP_TO_LARAVEL_52 = __DIR__ . '/../../config/sets/level/up-to-laravel-52.php';
 
-    final public const string UP_TO_LARAVEL_53 = __DIR__ . '/../../config/sets/level/up-to-laravel-53.php';
+    public const string UP_TO_LARAVEL_53 = __DIR__ . '/../../config/sets/level/up-to-laravel-53.php';
 
-    final public const string UP_TO_LARAVEL_54 = __DIR__ . '/../../config/sets/level/up-to-laravel-54.php';
+    public const string UP_TO_LARAVEL_54 = __DIR__ . '/../../config/sets/level/up-to-laravel-54.php';
 
-    final public const string UP_TO_LARAVEL_55 = __DIR__ . '/../../config/sets/level/up-to-laravel-55.php';
+    public const string UP_TO_LARAVEL_55 = __DIR__ . '/../../config/sets/level/up-to-laravel-55.php';
 
-    final public const string UP_TO_LARAVEL_56 = __DIR__ . '/../../config/sets/level/up-to-laravel-56.php';
+    public const string UP_TO_LARAVEL_56 = __DIR__ . '/../../config/sets/level/up-to-laravel-56.php';
 
-    final public const string UP_TO_LARAVEL_57 = __DIR__ . '/../../config/sets/level/up-to-laravel-57.php';
+    public const string UP_TO_LARAVEL_57 = __DIR__ . '/../../config/sets/level/up-to-laravel-57.php';
 
-    final public const string UP_TO_LARAVEL_58 = __DIR__ . '/../../config/sets/level/up-to-laravel-58.php';
+    public const string UP_TO_LARAVEL_58 = __DIR__ . '/../../config/sets/level/up-to-laravel-58.php';
 
-    final public const string UP_TO_LARAVEL_60 = __DIR__ . '/../../config/sets/level/up-to-laravel-60.php';
+    public const string UP_TO_LARAVEL_60 = __DIR__ . '/../../config/sets/level/up-to-laravel-60.php';
 
-    final public const string UP_TO_LARAVEL_70 = __DIR__ . '/../../config/sets/level/up-to-laravel-70.php';
+    public const string UP_TO_LARAVEL_70 = __DIR__ . '/../../config/sets/level/up-to-laravel-70.php';
 
-    final public const string UP_TO_LARAVEL_80 = __DIR__ . '/../../config/sets/level/up-to-laravel-80.php';
+    public const string UP_TO_LARAVEL_80 = __DIR__ . '/../../config/sets/level/up-to-laravel-80.php';
 
-    final public const string UP_TO_LARAVEL_90 = __DIR__ . '/../../config/sets/level/up-to-laravel-90.php';
+    public const string UP_TO_LARAVEL_90 = __DIR__ . '/../../config/sets/level/up-to-laravel-90.php';
 
-    final public const string UP_TO_LARAVEL_100 = __DIR__ . '/../../config/sets/level/up-to-laravel-100.php';
+    public const string UP_TO_LARAVEL_100 = __DIR__ . '/../../config/sets/level/up-to-laravel-100.php';
 
-    final public const string UP_TO_LARAVEL_110 = __DIR__ . '/../../config/sets/level/up-to-laravel-110.php';
+    public const string UP_TO_LARAVEL_110 = __DIR__ . '/../../config/sets/level/up-to-laravel-110.php';
 
-    final public const string UP_TO_LARAVEL_120 = __DIR__ . '/../../config/sets/level/up-to-laravel-120.php';
+    public const string UP_TO_LARAVEL_120 = __DIR__ . '/../../config/sets/level/up-to-laravel-120.php';
 
-    final public const string UP_TO_LARAVEL_130 = __DIR__ . '/../../config/sets/level/up-to-laravel-130.php';
+    public const string UP_TO_LARAVEL_130 = __DIR__ . '/../../config/sets/level/up-to-laravel-130.php';
 
-    final public const string UP_TO_LARAVEL_130_WITHOUT_ATTRIBUTES = __DIR__ . '/../../config/sets/level/up-to-laravel-130-without-attributes.php';
+    public const string UP_TO_LARAVEL_130_WITHOUT_ATTRIBUTES = __DIR__ . '/../../config/sets/level/up-to-laravel-130-without-attributes.php';
 }

--- a/src/Set/LaravelSetList.php
+++ b/src/Set/LaravelSetList.php
@@ -6,69 +6,69 @@ namespace RectorLaravel\Set;
 
 final class LaravelSetList
 {
-    final public const string ARRAY_STR_FUNCTIONS_TO_STATIC_CALL = __DIR__ . '/../../config/sets/laravel-array-str-functions-to-static-call.php';
+    public const string ARRAY_STR_FUNCTIONS_TO_STATIC_CALL = __DIR__ . '/../../config/sets/laravel-array-str-functions-to-static-call.php';
 
-    final public const string LARAVEL_50 = __DIR__ . '/../../config/sets/laravel50.php';
+    public const string LARAVEL_50 = __DIR__ . '/../../config/sets/laravel50.php';
 
-    final public const string LARAVEL_51 = __DIR__ . '/../../config/sets/laravel51.php';
+    public const string LARAVEL_51 = __DIR__ . '/../../config/sets/laravel51.php';
 
-    final public const string LARAVEL_52 = __DIR__ . '/../../config/sets/laravel52.php';
+    public const string LARAVEL_52 = __DIR__ . '/../../config/sets/laravel52.php';
 
-    final public const string LARAVEL_53 = __DIR__ . '/../../config/sets/laravel53.php';
+    public const string LARAVEL_53 = __DIR__ . '/../../config/sets/laravel53.php';
 
-    final public const string LARAVEL_54 = __DIR__ . '/../../config/sets/laravel54.php';
+    public const string LARAVEL_54 = __DIR__ . '/../../config/sets/laravel54.php';
 
-    final public const string LARAVEL_55 = __DIR__ . '/../../config/sets/laravel55.php';
+    public const string LARAVEL_55 = __DIR__ . '/../../config/sets/laravel55.php';
 
-    final public const string LARAVEL_56 = __DIR__ . '/../../config/sets/laravel56.php';
+    public const string LARAVEL_56 = __DIR__ . '/../../config/sets/laravel56.php';
 
-    final public const string LARAVEL_57 = __DIR__ . '/../../config/sets/laravel57.php';
+    public const string LARAVEL_57 = __DIR__ . '/../../config/sets/laravel57.php';
 
-    final public const string LARAVEL_58 = __DIR__ . '/../../config/sets/laravel58.php';
+    public const string LARAVEL_58 = __DIR__ . '/../../config/sets/laravel58.php';
 
-    final public const string LARAVEL_60 = __DIR__ . '/../../config/sets/laravel60.php';
+    public const string LARAVEL_60 = __DIR__ . '/../../config/sets/laravel60.php';
 
-    final public const string LARAVEL_70 = __DIR__ . '/../../config/sets/laravel70.php';
+    public const string LARAVEL_70 = __DIR__ . '/../../config/sets/laravel70.php';
 
-    final public const string LARAVEL_80 = __DIR__ . '/../../config/sets/laravel80.php';
+    public const string LARAVEL_80 = __DIR__ . '/../../config/sets/laravel80.php';
 
-    final public const string LARAVEL_90 = __DIR__ . '/../../config/sets/laravel90.php';
+    public const string LARAVEL_90 = __DIR__ . '/../../config/sets/laravel90.php';
 
-    final public const string LARAVEL_100 = __DIR__ . '/../../config/sets/laravel100.php';
+    public const string LARAVEL_100 = __DIR__ . '/../../config/sets/laravel100.php';
 
-    final public const string LARAVEL_110 = __DIR__ . '/../../config/sets/laravel110.php';
+    public const string LARAVEL_110 = __DIR__ . '/../../config/sets/laravel110.php';
 
-    final public const string LARAVEL_120 = __DIR__ . '/../../config/sets/laravel120.php';
+    public const string LARAVEL_120 = __DIR__ . '/../../config/sets/laravel120.php';
 
-    final public const string LARAVEL_130 = __DIR__ . '/../../config/sets/laravel130.php';
+    public const string LARAVEL_130 = __DIR__ . '/../../config/sets/laravel130.php';
 
-    final public const string LARAVEL_130_WITHOUT_ATTRIBUTES = __DIR__ . '/../../config/sets/laravel130-without-attributes.php';
+    public const string LARAVEL_130_WITHOUT_ATTRIBUTES = __DIR__ . '/../../config/sets/laravel130-without-attributes.php';
 
-    final public const string LARAVEL_ARRAYACCESS_TO_METHOD_CALL = __DIR__ . '/../../config/sets/laravel-arrayaccess-to-method-call.php';
+    public const string LARAVEL_ARRAYACCESS_TO_METHOD_CALL = __DIR__ . '/../../config/sets/laravel-arrayaccess-to-method-call.php';
 
-    final public const string LARAVEL_ARRAY_STR_FUNCTION_TO_STATIC_CALL = __DIR__ . '/../../config/sets/laravel-array-str-functions-to-static-call.php';
+    public const string LARAVEL_ARRAY_STR_FUNCTION_TO_STATIC_CALL = __DIR__ . '/../../config/sets/laravel-array-str-functions-to-static-call.php';
 
-    final public const string LARAVEL_CODE_QUALITY = __DIR__ . '/../../config/sets/laravel-code-quality.php';
+    public const string LARAVEL_CODE_QUALITY = __DIR__ . '/../../config/sets/laravel-code-quality.php';
 
-    final public const string LARAVEL_COLLECTION = __DIR__ . '/../../config/sets/laravel-collection.php';
+    public const string LARAVEL_COLLECTION = __DIR__ . '/../../config/sets/laravel-collection.php';
 
-    final public const string LARAVEL_CONTAINER_STRING_TO_FULLY_QUALIFIED_NAME = __DIR__ . '/../../config/sets/laravel-container-string-to-fully-qualified-name.php';
+    public const string LARAVEL_CONTAINER_STRING_TO_FULLY_QUALIFIED_NAME = __DIR__ . '/../../config/sets/laravel-container-string-to-fully-qualified-name.php';
 
-    final public const string LARAVEL_ELOQUENT_MAGIC_METHOD_TO_QUERY_BUILDER = __DIR__ . '/../../config/sets/laravel-eloquent-magic-method-to-query-builder.php';
+    public const string LARAVEL_ELOQUENT_MAGIC_METHOD_TO_QUERY_BUILDER = __DIR__ . '/../../config/sets/laravel-eloquent-magic-method-to-query-builder.php';
 
-    final public const string LARAVEL_FACADE_ALIASES_TO_FULL_NAMES = __DIR__ . '/../../config/sets/laravel-facade-aliases-to-full-names.php';
+    public const string LARAVEL_FACADE_ALIASES_TO_FULL_NAMES = __DIR__ . '/../../config/sets/laravel-facade-aliases-to-full-names.php';
 
-    final public const string LARAVEL_FACTORIES = __DIR__ . '/../../config/sets/laravel-factories.php';
+    public const string LARAVEL_FACTORIES = __DIR__ . '/../../config/sets/laravel-factories.php';
 
-    final public const string LARAVEL_IF_HELPERS = __DIR__ . '/../../config/sets/laravel-if-helpers.php';
+    public const string LARAVEL_IF_HELPERS = __DIR__ . '/../../config/sets/laravel-if-helpers.php';
 
-    final public const string LARAVEL_LEGACY_FACTORIES_TO_CLASSES = __DIR__ . '/../../config/sets/laravel-legacy-factories-to-classes.php';
+    public const string LARAVEL_LEGACY_FACTORIES_TO_CLASSES = __DIR__ . '/../../config/sets/laravel-legacy-factories-to-classes.php';
 
-    final public const string LARAVEL_STATIC_TO_INJECTION = __DIR__ . '/../../config/sets/laravel-static-to-injection.php';
+    public const string LARAVEL_STATIC_TO_INJECTION = __DIR__ . '/../../config/sets/laravel-static-to-injection.php';
 
-    final public const string LARAVEL_TESTING = __DIR__ . '/../../config/sets/laravel-testing.php';
+    public const string LARAVEL_TESTING = __DIR__ . '/../../config/sets/laravel-testing.php';
 
-    final public const string LARAVEL_TYPE_DECLARATIONS = __DIR__ . '/../../config/sets/laravel-type-declarations.php';
+    public const string LARAVEL_TYPE_DECLARATIONS = __DIR__ . '/../../config/sets/laravel-type-declarations.php';
 
-    final public const string LUMEN = __DIR__ . '/../../config/sets/lumen.php';
+    public const string LUMEN = __DIR__ . '/../../config/sets/lumen.php';
 }

--- a/src/Set/Packages/Cashier/CashierLevelSetList.php
+++ b/src/Set/Packages/Cashier/CashierLevelSetList.php
@@ -6,7 +6,7 @@ namespace RectorLaravel\Set\Packages\Cashier;
 
 final class CashierLevelSetList
 {
-    final public const string UP_TO_LARAVEL_CASHIER_130 = __DIR__ . '/../../../../config/sets/packages/cashier/level/up-to-cashier-13.php';
+    public const string UP_TO_LARAVEL_CASHIER_130 = __DIR__ . '/../../../../config/sets/packages/cashier/level/up-to-cashier-13.php';
 
-    final public const string UP_TO_LARAVEL_CASHIER_140 = __DIR__ . '/../../../../config/sets/packages/cashier/level/up-to-cashier-14.php';
+    public const string UP_TO_LARAVEL_CASHIER_140 = __DIR__ . '/../../../../config/sets/packages/cashier/level/up-to-cashier-14.php';
 }

--- a/src/Set/Packages/Cashier/CashierSetList.php
+++ b/src/Set/Packages/Cashier/CashierSetList.php
@@ -6,7 +6,7 @@ namespace RectorLaravel\Set\Packages\Cashier;
 
 final class CashierSetList
 {
-    final public const string LARAVEL_CASHIER_130 = __DIR__ . '/../../../../config/sets/packages/cashier/cashier-13.php';
+    public const string LARAVEL_CASHIER_130 = __DIR__ . '/../../../../config/sets/packages/cashier/cashier-13.php';
 
-    final public const string LARAVEL_CASHIER_140 = __DIR__ . '/../../../../config/sets/packages/cashier/cashier-14.php';
+    public const string LARAVEL_CASHIER_140 = __DIR__ . '/../../../../config/sets/packages/cashier/cashier-14.php';
 }

--- a/src/Set/Packages/Faker/FakerSetList.php
+++ b/src/Set/Packages/Faker/FakerSetList.php
@@ -6,5 +6,5 @@ namespace RectorLaravel\Set\Packages\Faker;
 
 final class FakerSetList
 {
-    final public const string FAKER_10 = __DIR__ . '/../../../../config/sets/packages/faker/faker-10.php';
+    public const string FAKER_10 = __DIR__ . '/../../../../config/sets/packages/faker/faker-10.php';
 }

--- a/src/Set/Packages/Livewire/LivewireLevelSetList.php
+++ b/src/Set/Packages/Livewire/LivewireLevelSetList.php
@@ -6,5 +6,5 @@ namespace RectorLaravel\Set\Packages\Livewire;
 
 final class LivewireLevelSetList
 {
-    final public const string UP_TO_LIVEWIRE = __DIR__ . '/../../../../config/sets/packages/livewire/level/up-to-livewire-30.php';
+    public const string UP_TO_LIVEWIRE = __DIR__ . '/../../../../config/sets/packages/livewire/level/up-to-livewire-30.php';
 }

--- a/src/Set/Packages/Livewire/LivewireSetList.php
+++ b/src/Set/Packages/Livewire/LivewireSetList.php
@@ -6,7 +6,7 @@ namespace RectorLaravel\Set\Packages\Livewire;
 
 final class LivewireSetList
 {
-    final public const string LIVEWIRE_30 = __DIR__ . '/../../../../config/sets/packages/livewire/livewire-30.php';
+    public const string LIVEWIRE_30 = __DIR__ . '/../../../../config/sets/packages/livewire/livewire-30.php';
 
-    final public const string LIVEWIRE_40 = __DIR__ . '/../../../../config/sets/packages/livewire/livewire-40.php';
+    public const string LIVEWIRE_40 = __DIR__ . '/../../../../config/sets/packages/livewire/livewire-40.php';
 }

--- a/tests/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector/Fixture/fixture.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\RouteKeyMethodToRouteKeyAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\RouteKeyMethodToRouteKeyAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\RouteKey('slug')]
+class Post extends Model
+{
+}
+
+?>

--- a/tests/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector/Fixture/skip_existing_attribute.php.inc
+++ b/tests/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector/Fixture/skip_existing_attribute.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\RouteKeyMethodToRouteKeyAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+#[\Illuminate\Database\Eloquent\Attributes\RouteKey('slug')]
+class PostWithExistingAttribute extends Model
+{
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+}
+
+?>

--- a/tests/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector/Fixture/skip_multiple_statements.php.inc
+++ b/tests/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector/Fixture/skip_multiple_statements.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\RouteKeyMethodToRouteKeyAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PostWithMultipleStatements extends Model
+{
+    public function getRouteKeyName(): string
+    {
+        if ($this->slug) {
+            return $this->slug;
+        }
+
+        return 'id';
+    }
+}
+
+?>

--- a/tests/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector/Fixture/skip_non_string_return.php.inc
+++ b/tests/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector/Fixture/skip_non_string_return.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\RouteKeyMethodToRouteKeyAttributeRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PostWithVariableReturn extends Model
+{
+    public function getRouteKeyName(): string
+    {
+        return $this->routeKey;
+    }
+}
+
+?>

--- a/tests/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector/Fixture/skip_not_a_model.php.inc
+++ b/tests/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector/Fixture/skip_not_a_model.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\Class_\RouteKeyMethodToRouteKeyAttributeRector\Fixture;
+
+class NotAModel
+{
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+}
+
+?>

--- a/tests/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector/RouteKeyMethodToRouteKeyAttributeRectorTest.php
+++ b/tests/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector/RouteKeyMethodToRouteKeyAttributeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\Class_\RouteKeyMethodToRouteKeyAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RouteKeyMethodToRouteKeyAttributeRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector/RouteKeyMethodToRouteKeyAttributeRectorTest.php
+++ b/tests/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector/RouteKeyMethodToRouteKeyAttributeRectorTest.php
@@ -28,4 +28,9 @@ final class RouteKeyMethodToRouteKeyAttributeRectorTest extends AbstractRectorTe
     {
         return __DIR__ . '/config/configured_rule.php';
     }
+
+    protected function provideComposerJsonFilePath(): ?string
+    {
+        return __DIR__ . '/composer.json';
+    }
 }

--- a/tests/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector/RouteKeyMethodToRouteKeyAttributeRectorTest.php
+++ b/tests/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector/RouteKeyMethodToRouteKeyAttributeRectorTest.php
@@ -29,7 +29,7 @@ final class RouteKeyMethodToRouteKeyAttributeRectorTest extends AbstractRectorTe
         return __DIR__ . '/config/configured_rule.php';
     }
 
-    protected function provideComposerJsonFilePath(): ?string
+    protected function provideComposerJsonFilePath(): string
     {
         return __DIR__ . '/composer.json';
     }

--- a/tests/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector/composer.json
+++ b/tests/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "laravel/framework": "^13.21"
+    }
+}

--- a/tests/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector/config/configured_rule.php
+++ b/tests/Rector/Class_/RouteKeyMethodToRouteKeyAttributeRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\Class_\RouteKeyMethodToRouteKeyAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(RouteKeyMethodToRouteKeyAttributeRector::class);
+};


### PR DESCRIPTION
This PR adds a rule to apply the new RouteKey rule.

Example.
```diff
 use Illuminate\Database\Eloquent\Model;

+#[\Illuminate\Database\Eloquent\Attributes\RouteKey('slug')]
 class Post extends Model
 {
-    public function getRouteKeyName(): string
-    {
-        return 'slug';
-    }
 }
```