### PR TITLE
Drop removed RectorConfig::tag(), rely on contract discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Rector upgrades rules for Laravel Framework",
     "require": {
         "php": ">=8.3",
-        "rector/rector": "^2.6.3",
+        "rector/rector": "^3.0",
         "webmozart/assert": "^1.11 || ^2.0",
         "symplify/rule-doc-generator-contracts": "^11.2"
     },

--- a/config/config.php
+++ b/config/config.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Contract\PhpParser\DecoratingNodeVisitorInterface;
 use RectorLaravel\NodeVisitor\ArrayDimFetchContextNodeVisitor;
 use RectorLaravel\NodeVisitor\RandomEnumContextNodeVisitor;
 
@@ -11,9 +10,8 @@ use RectorLaravel\NodeVisitor\RandomEnumContextNodeVisitor;
  * to be imported, don't use RectorConfigBuilder for safe usage
  */
 return static function (RectorConfig $rectorConfig): void {
+    // the entropy container discovers these by the DecoratingNodeVisitorInterface
+    // contract, so a plain singleton() registration is enough
     $rectorConfig->singleton(ArrayDimFetchContextNodeVisitor::class);
-    $rectorConfig->tag(ArrayDimFetchContextNodeVisitor::class, DecoratingNodeVisitorInterface::class);
-
     $rectorConfig->singleton(RandomEnumContextNodeVisitor::class);
-    $rectorConfig->tag(RandomEnumContextNodeVisitor::class, DecoratingNodeVisitorInterface::class);
 };


### PR DESCRIPTION
## Problem

Rector 3 swaps its DI container from `illuminate/container` to [`entropy/entropy`](https://github.com/TomasVotruba/entropy) (rectorphp/rector-src#8362) and removes `RectorConfig::tag()`. Against `rector/rector:dev-main`, `config/config.php` fatals:

```
Error: Call to undefined method Rector\Config\RectorConfig::tag()
config/config.php:15
```

Seen in rector-src's downstream rector-laravel job (rectorphp/rector-src#8364): 421 errored tests, all the same undefined-method error.

## Fix

Entropy discovers collaborators by the interfaces they implement: a service registered via `singleton()` that implements `DecoratingNodeVisitorInterface` is found by contract, so the explicit `tag()` layer is gone. This mirrors what rector-src did internally (its own `registerTagged()` now only calls `singleton()`).

```diff
-use Rector\Contract\PhpParser\DecoratingNodeVisitorInterface;
 use RectorLaravel\NodeVisitor\ArrayDimFetchContextNodeVisitor;
 use RectorLaravel\NodeVisitor\RandomEnumContextNodeVisitor;

 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->singleton(ArrayDimFetchContextNodeVisitor::class);
-    $rectorConfig->tag(ArrayDimFetchContextNodeVisitor::class, DecoratingNodeVisitorInterface::class);
-
     $rectorConfig->singleton(RandomEnumContextNodeVisitor::class);
-    $rectorConfig->tag(RandomEnumContextNodeVisitor::class, DecoratingNodeVisitorInterface::class);
 };
```

`rector/rector` constraint is bumped `^2.6.3` -> `^3.0`, since `tag()` only disappears in the entropy-based major.

## Draft — blocked on the rector 3 release

`tag()` still exists in stable rector (2.6.3), where these two visitors are collected through the tag; dropping it only works on rector 3. Kept as a **draft** until rector 3 is tagged — the `^3.0` constraint can't resolve on Packagist before then, so CI here stays red meanwhile. Adjust the constraint if the entropy container ships under a different version number.
