### PR TITLE
Move Cashier to composer-based set, deprecate Cashier + Livewire set lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ return RectorConfig::configure()
     ->withComposerBased(laravel: true, /** other options */);
 ```
 
-This registers `RectorLaravel\Set\LaravelSetList::COMPOSER_BASED`, which applies the version sets of Laravel (and of Faker and Livewire, when installed) up to the installed version.
+This registers `RectorLaravel\Set\LaravelSetList::COMPOSER_BASED`, which applies the version sets of Laravel (and of Faker, Livewire, and Cashier, when installed) up to the installed version.
 
-### Manual Configuration
+### Manual Configuration (deprecated)
+
+> **Deprecated:** the version set lists below are deprecated in favor of `withComposerBased(laravel: true)` above, which detects the installed version for you. They will be removed in a future major version.
 
 To manually add a version set to your config, use `RectorLaravel\Set\LaravelLevelSetList` and pick the constant that matches your target version.
 Sets for higher versions include sets for lower versions.
@@ -57,7 +59,7 @@ return RectorConfig::configure()
     ]);
 ```
 
-The sets in `RectorLaravel\Set\LaravelSetList` only contain changes related to a specific version upgrade.
+The version sets in `RectorLaravel\Set\LaravelSetList` only contain changes related to a specific version upgrade.
 For example, the rules in `LaravelSetList::LARAVEL_130` apply when upgrading from Laravel 12 to Laravel 13.
 
 ## Additional Sets

--- a/config/sets/composer-based.php
+++ b/config/sets/composer-based.php
@@ -44,6 +44,7 @@ use RectorLaravel\Rector\Class_\AddMockConsoleOutputFalseToConsoleTestsRector;
 use RectorLaravel\Rector\Class_\AliasesPropertyToAliasesAttributeRector;
 use RectorLaravel\Rector\Class_\AppendsPropertyToAppendsAttributeRector;
 use RectorLaravel\Rector\Class_\BackoffPropertyToBackoffAttributeRector;
+use RectorLaravel\Rector\Class_\CashierStripeOptionsToStripeRector;
 use RectorLaravel\Rector\Class_\CollectedByPropertyToCollectedByAttributeRector;
 use RectorLaravel\Rector\Class_\CollectsPropertyToCollectsAttributeRector;
 use RectorLaravel\Rector\Class_\CommandHiddenPropertyToHiddenAttributeRector;
@@ -587,4 +588,35 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfigurationComposerVersionBound(RenameClassRector::class, [
         'Livewire\Volt\Component' => 'Livewire\Component',
     ], 'livewire/livewire', '>=4.0');
+
+    // ---------------------------------------------------------------------------------------------
+    // laravel/cashier 13.0
+    // @see https://github.com/laravel/cashier-stripe/blob/master/UPGRADE.md#upgrading-to-130-from-12x
+    // ---------------------------------------------------------------------------------------------
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(RenameMethodRector::class, [
+        new MethodCallRename('Laravel\Cashier\Billable', 'subscribedToPlan', 'subscribedToPrice'),
+        new MethodCallRename('Laravel\Cashier\Billable', 'onPlan', 'onPrice'),
+        new MethodCallRename('Laravel\Cashier\Billable', 'planTaxRates', 'priceTaxRates'),
+        new MethodCallRename('Laravel\Cashier\SubscriptionBuilder', 'plan', 'price'),
+        new MethodCallRename('Laravel\Cashier\SubscriptionBuilder', 'meteredPlan', 'meteredPrice'),
+        new MethodCallRename('Laravel\Cashier\Subscription', 'hasMultiplePlans', 'hasMultiplePrices'),
+        new MethodCallRename('Laravel\Cashier\Subscription', 'hasSinglePlan', 'hasSinglePrice'),
+        new MethodCallRename('Laravel\Cashier\Subscription', 'hasPlan', 'hasPrice'),
+        new MethodCallRename('Laravel\Cashier\Subscription', 'addPlan', 'addPrice'),
+        new MethodCallRename('Laravel\Cashier\Subscription', 'addPlanAndInvoice', 'addPriceAndInvoice'),
+        new MethodCallRename('Laravel\Cashier\Subscription', 'removePlan', 'removePrice'),
+    ], 'laravel/cashier', '>=13.0');
+
+    $rectorConfig->rule(CashierStripeOptionsToStripeRector::class);
+
+    // ---------------------------------------------------------------------------------------------
+    // laravel/cashier 14.0
+    // @see https://github.com/laravel/cashier-stripe/blob/master/UPGRADE.md#upgrading-to-140-from-13x
+    // ---------------------------------------------------------------------------------------------
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(RenameMethodRector::class, [
+        new MethodCallRename('Laravel\Cashier\Billable', 'removePaymentMethod', 'deletePaymentMethod'),
+        new MethodCallRename('Laravel\Cashier\Payment', 'isCancelled', 'isCanceled'),
+        new MethodCallRename('Laravel\Cashier\Subscription', 'cancelled', 'canceled'),
+        new MethodCallRename('Laravel\Cashier\Subscription', 'markAsCancelled', 'markAsCanceled'),
+    ], 'laravel/cashier', '>=14.0');
 };

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -32,9 +32,11 @@ parameters:
             identifier: classConstant.deprecated
             paths:
                 - config/sets/level/*
+                - config/sets/packages/*/level/*
                 - tests/Sets/*/config/configured_rule.php
 
         -
             identifier: classConstant.deprecatedClass
             paths:
                 - config/sets/level/*
+                - config/sets/packages/*/level/*

--- a/src/Rector/Class_/CashierStripeOptionsToStripeRector.php
+++ b/src/Rector/Class_/CashierStripeOptionsToStripeRector.php
@@ -12,6 +12,8 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\ObjectType;
 use Rector\PHPStan\ScopeFetcher;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use RectorLaravel\AbstractRector;
 use RectorLaravel\Tests\Rector\Class_\CashierStripeOptionsToStripeRector\CashierStripeOptionsToStripeRectorTest;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -22,7 +24,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see CashierStripeOptionsToStripeRectorTest
  */
-final class CashierStripeOptionsToStripeRector extends AbstractRector
+final class CashierStripeOptionsToStripeRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {
@@ -66,6 +68,14 @@ CODE_SAMPLE
     public function getNodeTypes(): array
     {
         return [Class_::class];
+    }
+
+    /**
+     * @return ComposerPackageConstraint
+     */
+    public function provideComposerPackageConstraint()
+    {
+        return new ComposerPackageConstraint('laravel/cashier', '>=13.0');
     }
 
     public function refactor(Node $node): ?Node

--- a/src/Set/Packages/Cashier/CashierLevelSetList.php
+++ b/src/Set/Packages/Cashier/CashierLevelSetList.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace RectorLaravel\Set\Packages\Cashier;
 
+/**
+ * @deprecated Use RectorConfig::configure()->withComposerBased(laravel: true) instead, which registers the
+ *             Cashier upgrade rules for the installed laravel/cashier version automatically.
+ */
 final class CashierLevelSetList
 {
     public const string UP_TO_LARAVEL_CASHIER_130 = __DIR__ . '/../../../../config/sets/packages/cashier/level/up-to-cashier-13.php';

--- a/src/Set/Packages/Cashier/CashierSetList.php
+++ b/src/Set/Packages/Cashier/CashierSetList.php
@@ -6,7 +6,13 @@ namespace RectorLaravel\Set\Packages\Cashier;
 
 final class CashierSetList
 {
+    /**
+     * @deprecated Use RectorConfig::configure()->withComposerBased(laravel: true) instead.
+     */
     public const string LARAVEL_CASHIER_130 = __DIR__ . '/../../../../config/sets/packages/cashier/cashier-13.php';
 
+    /**
+     * @deprecated Use RectorConfig::configure()->withComposerBased(laravel: true) instead.
+     */
     public const string LARAVEL_CASHIER_140 = __DIR__ . '/../../../../config/sets/packages/cashier/cashier-14.php';
 }

--- a/src/Set/Packages/Livewire/LivewireLevelSetList.php
+++ b/src/Set/Packages/Livewire/LivewireLevelSetList.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace RectorLaravel\Set\Packages\Livewire;
 
+/**
+ * @deprecated Use RectorConfig::configure()->withComposerBased(laravel: true) instead, which registers the
+ *             Livewire upgrade rules for the installed livewire/livewire version automatically.
+ */
 final class LivewireLevelSetList
 {
     public const string UP_TO_LIVEWIRE = __DIR__ . '/../../../../config/sets/packages/livewire/level/up-to-livewire-30.php';

--- a/src/Set/Packages/Livewire/LivewireSetList.php
+++ b/src/Set/Packages/Livewire/LivewireSetList.php
@@ -6,7 +6,13 @@ namespace RectorLaravel\Set\Packages\Livewire;
 
 final class LivewireSetList
 {
+    /**
+     * @deprecated Use RectorConfig::configure()->withComposerBased(laravel: true) instead.
+     */
     public const string LIVEWIRE_30 = __DIR__ . '/../../../../config/sets/packages/livewire/livewire-30.php';
 
+    /**
+     * @deprecated Use RectorConfig::configure()->withComposerBased(laravel: true) instead.
+     */
     public const string LIVEWIRE_40 = __DIR__ . '/../../../../config/sets/packages/livewire/livewire-40.php';
 }

--- a/tests/Rector/Class_/CashierStripeOptionsToStripeRector/CashierStripeOptionsToStripeRectorTest.php
+++ b/tests/Rector/Class_/CashierStripeOptionsToStripeRector/CashierStripeOptionsToStripeRectorTest.php
@@ -28,4 +28,9 @@ final class CashierStripeOptionsToStripeRectorTest extends AbstractRectorTestCas
     {
         return __DIR__ . '/config/configured_rule.php';
     }
+
+    protected function provideComposerJsonFilePath(): string
+    {
+        return __DIR__ . '/composer.json';
+    }
 }

--- a/tests/Rector/Class_/CashierStripeOptionsToStripeRector/composer.json
+++ b/tests/Rector/Class_/CashierStripeOptionsToStripeRector/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "laravel/cashier": "^13.0"
+    }
+}


### PR DESCRIPTION
Smaller brother to #545, now the rest of packages are also handled by composer version too.

Extends the composer-based set to Cashier, and deprecates the remaining hand-maintained package version set lists now covered by `withComposerBased(laravel: true)`.

Let me know if you'll come across any trigger issues. Will make sure to handle those before release :+1: 