### PR TITLE
Fix Request static method transformation

### DIFF
--- a/src/Rector/StaticCall/RequestStaticValidateToInjectRector.php
+++ b/src/Rector/StaticCall/RequestStaticValidateToInjectRector.php
@@ -128,7 +128,8 @@ CODE_SAMPLE
         }
 
         if ($node instanceof StaticCall) {
-            return ! $this->nodeTypeResolver->isObjectTypes($node->class, $this->requestObjectTypes);
+            return ! $this->nodeTypeResolver->isObjectTypes($node->class, $this->requestObjectTypes)
+                || ! $this->isName($node->name, 'validate');
         }
 
         $classMethodReflection = $this->reflectionResolver->resolveMethodReflectionFromClassMethod(

--- a/tests/Rector/StaticCall/RequestStaticValidateToInjectRector/Fixture/skip_form_request.php.inc
+++ b/tests/Rector/StaticCall/RequestStaticValidateToInjectRector/Fixture/skip_form_request.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\RequestStaticValidateToInjectRector\Fixture;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class AppServiceProvider
+{
+    public function boot(): void
+    {
+        FormRequest::failOnUnknownFields();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\RequestStaticValidateToInjectRector\Fixture;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class AppServiceProvider
+{
+    public function boot(): void
+    {
+        FormRequest::failOnUnknownFields();
+    }
+}
+
+?>


### PR DESCRIPTION
Fixes #496

## Summary

- restrict `RequestStaticValidateToInjectRector` to static `validate()` calls
- leave other valid static APIs on `FormRequest` and Request-like classes unchanged
- add a regression fixture for `FormRequest::failOnUnknownFields()`

## Root cause

The rule matched every static call on Request-like types. That transformed valid APIs such as `FormRequest::failOnUnknownFields()` into an invalid instance call on `Illuminate\Http\Request`, even though the rule's documented purpose is only to rewrite static validation.

## Validation

- focused rector rule suite - 8 passed, 9 assertions
- targeted PHPStan analysis - passed
- targeted Duster lint on both changed files - passed
- `git diff --check` - passed

## AI disclosure

This change was prepared with OpenAI Codex assistance and reviewed and validated locally by the contributor.
