### PR TITLE
Scope legacy string event upgrades to the event dispatcher

### DIFF
--- a/config/sets/composer-based.php
+++ b/config/sets/composer-based.php
@@ -27,7 +27,6 @@ use Rector\Renaming\ValueObject\RenameProperty;
 use Rector\Renaming\ValueObject\RenameStaticMethod;
 use Rector\Transform\Rector\FuncCall\FuncCallToStaticCallRector;
 use Rector\Transform\Rector\StaticCall\StaticCallToFuncCallRector;
-use Rector\Transform\Rector\String_\StringToClassConstantRector;
 use Rector\Transform\ValueObject\FuncCallToStaticCall;
 use Rector\Transform\ValueObject\StaticCallToFuncCall;
 use Rector\Transform\ValueObject\StringToClassConstant;
@@ -97,6 +96,7 @@ use RectorLaravel\Rector\MethodCall\ReplaceWithoutJobsEventsAndNotificationsWith
 use RectorLaravel\Rector\New_\AddGuardToLoginEventRector;
 use RectorLaravel\Rector\PropertyFetch\ReplaceFakerInstanceWithHelperRector;
 use RectorLaravel\Rector\PropertyFetch\ReplaceFakerPropertyFetchWithMethodCallRector;
+use RectorLaravel\Rector\StaticCall\EventStringToClassConstantRector;
 use RectorLaravel\Rector\StaticCall\Redirect301ToPermanentRedirectRector;
 use RectorLaravel\Rector\StaticCall\ReplaceAssertTimesSendWithAssertSentTimesRector;
 use RectorLaravel\ValueObject\AddArgumentDefaultValue;
@@ -149,7 +149,7 @@ return static function (RectorConfig $rectorConfig): void {
         'Illuminate\Foundation\Composer' => 'Illuminate\Support\Composer',
     ], 'laravel/framework', '>=5.2 <6.0');
 
-    $rectorConfig->ruleWithConfigurationComposerVersionBound(StringToClassConstantRector::class, [
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(EventStringToClassConstantRector::class, [
         new StringToClassConstant('artisan.start', 'Illuminate\Console\Events\ArtisanStarting', 'class'),
         new StringToClassConstant('auth.attempting', 'Illuminate\Auth\Events\Attempting', 'class'),
         new StringToClassConstant('auth.login', 'Illuminate\Auth\Events\Login', 'class'),
@@ -198,7 +198,7 @@ return static function (RectorConfig $rectorConfig): void {
     // ---------------------------------------------------------------------------------------------
     // Laravel 5.4 — see https://laravel.com/docs/5.4/upgrade
     // ---------------------------------------------------------------------------------------------
-    $rectorConfig->ruleWithConfigurationComposerVersionBound(StringToClassConstantRector::class, [
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(EventStringToClassConstantRector::class, [
         new StringToClassConstant('kernel.handled', 'Illuminate\Foundation\Http\Events\RequestHandled', 'class'),
         new StringToClassConstant('locale.changed', 'Illuminate\Foundation\Events\LocaleUpdated', 'class'),
         new StringToClassConstant('illuminate.log', 'Illuminate\Log\Events\MessageLogged', 'class'),

--- a/config/sets/laravel52.php
+++ b/config/sets/laravel52.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Name\RenameClassRector;
-use Rector\Transform\Rector\String_\StringToClassConstantRector;
 use Rector\Transform\ValueObject\StringToClassConstant;
+use RectorLaravel\Rector\StaticCall\EventStringToClassConstantRector;
 
 // see: https://laravel.com/docs/5.2/upgrade
 return static function (RectorConfig $rectorConfig): void {
@@ -19,7 +19,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig
         ->ruleWithConfiguration(
-            StringToClassConstantRector::class,
+            EventStringToClassConstantRector::class,
             [new StringToClassConstant('artisan.start', 'Illuminate\Console\Events\ArtisanStarting', 'class'),
                 new StringToClassConstant('auth.attempting', 'Illuminate\Auth\Events\Attempting', 'class'),
                 new StringToClassConstant('auth.login', 'Illuminate\Auth\Events\Login', 'class'),

--- a/config/sets/laravel54.php
+++ b/config/sets/laravel54.php
@@ -6,15 +6,15 @@ use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
-use Rector\Transform\Rector\String_\StringToClassConstantRector;
 use Rector\Transform\ValueObject\StringToClassConstant;
+use RectorLaravel\Rector\StaticCall\EventStringToClassConstantRector;
 
 // see: https://laravel.com/docs/5.4/upgrade
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../config.php');
     $rectorConfig
-        ->ruleWithConfiguration(StringToClassConstantRector::class, [new StringToClassConstant(
+        ->ruleWithConfiguration(EventStringToClassConstantRector::class, [new StringToClassConstant(
             'kernel.handled',
             'Illuminate\Foundation\Http\Events\RequestHandled',
             'class'

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 128 Rules Overview
+# 129 Rules Overview
 
 ## AbortIfRector
 
@@ -1179,6 +1179,21 @@ Changes the errorBag property to use the ErrorBag attribute
  {
 -    protected $errorBag = 'custom';
  }
+```
+
+<br>
+
+## EventStringToClassConstantRector
+
+Turns a string event name into a class constant, but only where the event dispatcher is used
+
+:wrench: **configure it!**
+
+- class: [`RectorLaravel\Rector\StaticCall\EventStringToClassConstantRector`](../src/Rector/StaticCall/EventStringToClassConstantRector.php)
+
+```diff
+-\Illuminate\Support\Facades\Event::listen('auth.login', function () {});
++\Illuminate\Support\Facades\Event::listen(\Illuminate\Auth\Events\Login::class, function () {});
 ```
 
 <br>

--- a/src/Rector/StaticCall/EventStringToClassConstantRector.php
+++ b/src/Rector/StaticCall/EventStringToClassConstantRector.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\StaticCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Type\ObjectType;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Transform\ValueObject\StringToClassConstant;
+use RectorLaravel\AbstractRector;
+use RectorLaravel\Tests\Rector\StaticCall\EventStringToClassConstantRector\EventStringToClassConstantRectorTest;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see EventStringToClassConstantRectorTest
+ */
+final class EventStringToClassConstantRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * Dispatcher methods that take the event name as their first argument.
+     *
+     * @var string[]
+     */
+    private const array EVENT_NAME_METHODS = [
+        'dispatch',
+        'fire',
+        'flush',
+        'forget',
+        'hasListeners',
+        'listen',
+        'push',
+        'until',
+    ];
+
+    /**
+     * @var StringToClassConstant[]
+     */
+    private array $stringToClassConstants = [];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Turns a string event name into a class constant, but only where the event dispatcher is used',
+            [new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+\Illuminate\Support\Facades\Event::listen('auth.login', function () {});
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+\Illuminate\Support\Facades\Event::listen(\Illuminate\Auth\Events\Login::class, function () {});
+CODE_SAMPLE,
+                [new StringToClassConstant('auth.login', 'Illuminate\Auth\Events\Login', 'class')]
+            )]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [StaticCall::class, MethodCall::class, FuncCall::class];
+    }
+
+    public function configure(array $configuration): void
+    {
+        Assert::allIsInstanceOf($configuration, StringToClassConstant::class);
+
+        $this->stringToClassConstants = $configuration;
+    }
+
+    /**
+     * @param  StaticCall|MethodCall|FuncCall  $node
+     */
+    public function refactor(Node $node): StaticCall|MethodCall|FuncCall|null
+    {
+        if (! $this->isEventDispatchingCall($node)) {
+            return null;
+        }
+
+        $firstArg = $node->args[0] ?? null;
+
+        if (! $firstArg instanceof Arg) {
+            return null;
+        }
+
+        if ($firstArg->value instanceof Array_) {
+            return $this->refactorArray($node, $firstArg->value);
+        }
+
+        $classConstFetch = $this->matchClassConstFetch($firstArg->value);
+
+        if (! $classConstFetch instanceof ClassConstFetch) {
+            return null;
+        }
+
+        $firstArg->value = $classConstFetch;
+
+        return $node;
+    }
+
+    private function refactorArray(StaticCall|MethodCall|FuncCall $node, Array_ $array): StaticCall|MethodCall|FuncCall|null
+    {
+        $hasChanged = false;
+
+        foreach ($array->items as $arrayItem) {
+            if ($arrayItem->key !== null) {
+                continue;
+            }
+
+            $classConstFetch = $this->matchClassConstFetch($arrayItem->value);
+
+            if (! $classConstFetch instanceof ClassConstFetch) {
+                continue;
+            }
+
+            $arrayItem->value = $classConstFetch;
+            $hasChanged = true;
+        }
+
+        return $hasChanged ? $node : null;
+    }
+
+    private function matchClassConstFetch(Node $node): ?ClassConstFetch
+    {
+        if (! $node instanceof String_) {
+            return null;
+        }
+
+        foreach ($this->stringToClassConstants as $stringToClassConstant) {
+            if ($node->value !== $stringToClassConstant->getString()) {
+                continue;
+            }
+
+            return new ClassConstFetch(
+                new FullyQualified($stringToClassConstant->getClass()),
+                $stringToClassConstant->getConstant()
+            );
+        }
+
+        return null;
+    }
+
+    private function isEventDispatchingCall(StaticCall|MethodCall|FuncCall $node): bool
+    {
+        if ($node instanceof FuncCall) {
+            return $node->name instanceof Name && $this->isName($node->name, 'event');
+        }
+
+        if (! $node->name instanceof Identifier) {
+            return false;
+        }
+
+        if (! $this->isNames($node->name, self::EVENT_NAME_METHODS)) {
+            return false;
+        }
+
+        [$callerNode, $className] = match (true) {
+            $node instanceof StaticCall => [$node->class, 'Illuminate\Support\Facades\Event'],
+            $node instanceof MethodCall => [$node->var, 'Illuminate\Contracts\Events\Dispatcher'],
+        };
+
+        return $this->isObjectType($callerNode, new ObjectType($className));
+    }
+}

--- a/stubs/Illuminate/Support/Facades/Event.php
+++ b/stubs/Illuminate/Support/Facades/Event.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Support\Facades;
+
+if (class_exists('\Illuminate\Support\Facades\Event')) {
+    return;
+}
+
+require_once __DIR__ . '/Facade.php';
+
+/**
+ * @method static void listen(string|array $events, mixed $listener = null)
+ * @method static bool hasListeners(string $eventName)
+ * @method static array|null dispatch(string|object $event, mixed $payload = [], bool $halt = false)
+ * @method static mixed until(string|object $event, mixed $payload = [])
+ * @method static void push(string $event, array $payload = [])
+ * @method static void flush(string $event)
+ * @method static void forget(string $event)
+ */
+class Event extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'events';
+    }
+}

--- a/tests/Rector/StaticCall/EventStringToClassConstantRector/EventStringToClassConstantRectorTest.php
+++ b/tests/Rector/StaticCall/EventStringToClassConstantRector/EventStringToClassConstantRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EventStringToClassConstantRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class EventStringToClassConstantRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/StaticCall/EventStringToClassConstantRector/Fixture/dispatcher_method_call.php.inc
+++ b/tests/Rector/StaticCall/EventStringToClassConstantRector/Fixture/dispatcher_method_call.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EventStringToClassConstantRector\Fixture;
+
+function boot(\Illuminate\Contracts\Events\Dispatcher $events)
+{
+    $events->listen('auth.login', function () {});
+    $events->dispatch('auth.logout');
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EventStringToClassConstantRector\Fixture;
+
+function boot(\Illuminate\Contracts\Events\Dispatcher $events)
+{
+    $events->listen(\Illuminate\Auth\Events\Login::class, function () {});
+    $events->dispatch(\Illuminate\Auth\Events\Logout::class);
+}
+
+?>

--- a/tests/Rector/StaticCall/EventStringToClassConstantRector/Fixture/event_facade.php.inc
+++ b/tests/Rector/StaticCall/EventStringToClassConstantRector/Fixture/event_facade.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EventStringToClassConstantRector\Fixture;
+
+\Illuminate\Support\Facades\Event::listen('auth.login', function () {});
+\Illuminate\Support\Facades\Event::listen(['auth.login', 'auth.logout'], function () {});
+\Illuminate\Support\Facades\Event::fire('auth.login');
+\Illuminate\Support\Facades\Event::forget('auth.logout');
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EventStringToClassConstantRector\Fixture;
+
+\Illuminate\Support\Facades\Event::listen(\Illuminate\Auth\Events\Login::class, function () {});
+\Illuminate\Support\Facades\Event::listen([\Illuminate\Auth\Events\Login::class, \Illuminate\Auth\Events\Logout::class], function () {});
+\Illuminate\Support\Facades\Event::fire(\Illuminate\Auth\Events\Login::class);
+\Illuminate\Support\Facades\Event::forget(\Illuminate\Auth\Events\Logout::class);
+
+?>

--- a/tests/Rector/StaticCall/EventStringToClassConstantRector/Fixture/event_helper.php.inc
+++ b/tests/Rector/StaticCall/EventStringToClassConstantRector/Fixture/event_helper.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EventStringToClassConstantRector\Fixture;
+
+event('auth.login');
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EventStringToClassConstantRector\Fixture;
+
+event(\Illuminate\Auth\Events\Login::class);
+
+?>

--- a/tests/Rector/StaticCall/EventStringToClassConstantRector/Fixture/skip_non_event_context.php.inc
+++ b/tests/Rector/StaticCall/EventStringToClassConstantRector/Fixture/skip_non_event_context.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EventStringToClassConstantRector\Fixture;
+
+view('auth.login');
+route('auth.login');
+redirect()->route('auth.logout');
+
+$viewName = 'auth.login';
+
+class SomeController
+{
+    public function show()
+    {
+        return view('auth.login');
+    }
+}
+
+?>

--- a/tests/Rector/StaticCall/EventStringToClassConstantRector/Fixture/skip_unconfigured_event.php.inc
+++ b/tests/Rector/StaticCall/EventStringToClassConstantRector/Fixture/skip_unconfigured_event.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EventStringToClassConstantRector\Fixture;
+
+\Illuminate\Support\Facades\Event::listen('some.unknown.event', function () {});
+
+?>

--- a/tests/Rector/StaticCall/EventStringToClassConstantRector/Fixture/skip_unrelated_listen_call.php.inc
+++ b/tests/Rector/StaticCall/EventStringToClassConstantRector/Fixture/skip_unrelated_listen_call.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\EventStringToClassConstantRector\Fixture;
+
+class SomeSocket
+{
+    public function listen(string $channel): void
+    {
+    }
+}
+
+function listenOnSocket(SomeSocket $socket)
+{
+    $socket->listen('auth.login');
+}
+
+?>

--- a/tests/Rector/StaticCall/EventStringToClassConstantRector/config/configured_rule.php
+++ b/tests/Rector/StaticCall/EventStringToClassConstantRector/config/configured_rule.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Transform\ValueObject\StringToClassConstant;
+use RectorLaravel\Rector\StaticCall\EventStringToClassConstantRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->ruleWithConfiguration(EventStringToClassConstantRector::class, [
+        new StringToClassConstant('auth.login', 'Illuminate\Auth\Events\Login', 'class'),
+        new StringToClassConstant('auth.logout', 'Illuminate\Auth\Events\Logout', 'class'),
+    ]);
+};


### PR DESCRIPTION
Fixes #535 (also the earlier reports #467 and #520).

## Problem

`config/sets/laravel52.php` / `laravel54.php` (and the matching blocks in the composer-based set) configure Rector core's `StringToClassConstantRector`, which matches **any** string literal in a file. `'auth.login'` is both a legacy Laravel 5 event name and the Breeze/UI default Blade view name, so running the set rewrote:

```php
return view('auth.login');
// into
return view(\Illuminate\Auth\Events\Login::class);
```

…which breaks the login page.

The `<6.0` version caps added in #555 stop this under `withComposerBased()` on Laravel 6+, but they don't help the still-shipping `LaravelLevelSetList` sets, and a genuine 5.x app with an `auth.login` view is still mangled.

## Fix

Add `RectorLaravel\Rector\StaticCall\EventStringToClassConstantRector` and use it in place of the core rule in `laravel52.php`, `laravel54.php` and `composer-based.php`. It reuses core's `StringToClassConstant` value object, so the set configurations are unchanged apart from the rule class name.

It only rewrites the first argument of an actual event dispatch:

- `Illuminate\Support\Facades\Event::listen|dispatch|fire|until|push|flush|forget|hasListeners(...)`
- the same methods on an `Illuminate\Contracts\Events\Dispatcher` instance (`$events->listen(...)` in a service provider)
- the `event()` helper
- including the array form, `Event::listen(['auth.login', 'auth.logout'], ...)`

Everything else — `view()`, `route()`, plain strings — is left alone.

```php
// changed
\Illuminate\Support\Facades\Event::listen('auth.login', function () {});
// -> \Illuminate\Support\Facades\Event::listen(\Illuminate\Auth\Events\Login::class, function () {});

// skipped
view('auth.login');
```

## Notes

- `EventServiceProvider::$listen` array keys are deliberately not handled — 5.x apps registered these string events through `Event::listen()`, and matching property arrays would reintroduce false-positive risk. Happy to add it if you'd prefer.
- Fixtures cover the facade, dispatcher instance, `event()` helper, and skip cases for view/route context, an unrelated `listen()` method, and unconfigured event names.
- `composer lint`, `composer phpstan`, `composer structarmed` and `composer docs` are clean; the new rule's tests pass. The 8 failures in the full `composer test` run are pre-existing on `main` (unrelated `ArrayDimFetch`/`PropertyFetch` fixtures; they pass in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
