### PR TITLE
Add composer keywords so Composer suggests --dev on require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,13 @@
     "type": "rector-extension",
     "license": "MIT",
     "description": "Rector upgrades rules for Laravel Framework",
+    "keywords": [
+        "rector",
+        "laravel",
+        "refactoring",
+        "upgrade",
+        "dev"
+    ],
     "require": {
         "php": ">=8.3",
         "rector/rector": "^2.6.4",


### PR DESCRIPTION
## Problem

`composer require driftingly/rector-laravel` installs into `require`
without any hint that this is a dev-only tool, unlike e.g.
`composer require laravel/pint`, which prompts:

> The package you required is recommended to be placed in require-dev
> (because it is tagged as "dev") but you did not use --dev.
> Do you want to re-run the command with --dev? [yes]?

## Cause

Composer's `RequireCommand` decides this from the package's `keywords`,
intersecting them with a hardcoded list:

```php
$devTags = ['dev', 'testing', 'static analysis'];
...
$pkgDevTags = array_intersect($devTags, array_map('strtolower', $pkg->getKeywords()));
```

`laravel/pint` ships `["php","linter","formatter","format","lint","dev"]`.
This package has no `keywords` field at all, so the prompt never fires.

## Change

Adds a `keywords` list containing `"dev"`, so the prompt matches the
install instructions already in the README (`composer require --dev
driftingly/rector-laravel`). The other keywords are ordinary Packagist
search metadata.

## Notes

The prompt is a nudge, not enforcement — it only appears in an
interactive TTY, only when the package isn't already required, and only
when every package on the command line is dev-tagged. Keywords are read
from the tagged release, so this takes effect for users from the next
tag onward. `composer validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

