### PR TITLE
Add UnlinkFuncCallToFileFacadeDeleteRector

### DIFF
--- a/config/sets/laravel-code-quality.php
+++ b/config/sets/laravel-code-quality.php
@@ -20,6 +20,7 @@ use RectorLaravel\Rector\FuncCall\RemoveRedundantValueCallsRector;
 use RectorLaravel\Rector\FuncCall\RemoveRedundantWithCallsRector;
 use RectorLaravel\Rector\FuncCall\SleepFuncToSleepStaticCallRector;
 use RectorLaravel\Rector\FuncCall\ThrowIfAndThrowUnlessExceptionsToUseClassStringRector;
+use RectorLaravel\Rector\FuncCall\UnlinkFuncCallToFileFacadeDeleteRector;
 use RectorLaravel\Rector\MethodCall\EloquentOrderByToLatestOrOldestRector;
 use RectorLaravel\Rector\MethodCall\RedirectBackToBackHelperRector;
 use RectorLaravel\Rector\MethodCall\RedirectRouteToToRouteHelperRector;
@@ -56,4 +57,5 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(NotFilledBlankFuncCallToBlankFilledFuncCallRector::class);
     $rectorConfig->rule(EloquentOrderByToLatestOrOldestRector::class);
     $rectorConfig->rule(AppToResolveRector::class);
+    $rectorConfig->rule(UnlinkFuncCallToFileFacadeDeleteRector::class);
 };

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 128 Rules Overview
+# 129 Rules Overview
 
 ## AbortIfRector
 
@@ -2455,6 +2455,19 @@ Changes the uniqueFor property to use the UniqueFor attribute
  {
 -    public $uniqueFor = 1800;
  }
+```
+
+<br>
+
+## UnlinkFuncCallToFileFacadeDeleteRector
+
+Use the File facade instead of the `unlink()` function.
+
+- class: [`RectorLaravel\Rector\FuncCall\UnlinkFuncCallToFileFacadeDeleteRector`](../src/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector.php)
+
+```diff
+-unlink($path);
++\Illuminate\Support\Facades\File::delete($path);
 ```
 
 <br>

--- a/src/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector.php
+++ b/src/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector.php
@@ -6,9 +6,11 @@ namespace RectorLaravel\Rector\FuncCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ErrorSuppress;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Identifier;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\VariadicPlaceholder;
 use RectorLaravel\AbstractRector;
 use RectorLaravel\Tests\Rector\FuncCall\UnlinkFuncCallToFileFacadeDeleteRector\UnlinkFuncCallToFileFacadeDeleteRectorTest;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -45,29 +47,49 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [FuncCall::class];
+        return [ErrorSuppress::class, FuncCall::class];
     }
 
     /**
-     * @param  FuncCall  $node
+     * @param  ErrorSuppress|FuncCall  $node
      */
     public function refactor(Node $node): ?StaticCall
     {
-        if (! $this->isName($node->name, 'unlink')) {
+        // File::delete() suppresses the failure itself, so the suppressor is dropped
+        $funcCall = $node instanceof ErrorSuppress ? $node->expr : $node;
+
+        if (! $funcCall instanceof FuncCall) {
             return null;
+        }
+
+        if (! $this->isName($funcCall->name, 'unlink')) {
+            return null;
+        }
+
+        if ($funcCall->isFirstClassCallable()) {
+            return $this->createFileDeleteCall([new VariadicPlaceholder]);
         }
 
         // the stream context argument has no equivalent on the facade
-        if (count($node->args) !== 1) {
+        if (count($funcCall->args) !== 1) {
             return null;
         }
 
-        $arg = $node->getArg('filename', 0);
+        $arg = $funcCall->getArg('filename', 0);
 
         if (! $arg instanceof Arg) {
             return null;
         }
 
-        return $this->nodeFactory->createStaticCall('Illuminate\Support\Facades\File', 'delete', [$arg->value]);
+        // the facade parameter is named $paths, so a filename: argument is passed positionally
+        return $this->createFileDeleteCall([new Arg($arg->value)]);
+    }
+
+    /**
+     * @param  array<Arg|VariadicPlaceholder>  $args
+     */
+    private function createFileDeleteCall(array $args): StaticCall
+    {
+        return new StaticCall(new FullyQualified('Illuminate\Support\Facades\File'), 'delete', $args);
     }
 }

--- a/src/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector.php
+++ b/src/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use RectorLaravel\AbstractRector;
+use RectorLaravel\Tests\Rector\FuncCall\UnlinkFuncCallToFileFacadeDeleteRector\UnlinkFuncCallToFileFacadeDeleteRectorTest;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://laravel.com/docs/filesystem
+ *
+ * @see UnlinkFuncCallToFileFacadeDeleteRectorTest
+ */
+final class UnlinkFuncCallToFileFacadeDeleteRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Use the File facade instead of the unlink() function.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+unlink($path);
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+\Illuminate\Support\Facades\File::delete($path);
+CODE_SAMPLE
+                    ,
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param  FuncCall  $node
+     */
+    public function refactor(Node $node): ?StaticCall
+    {
+        if (! $this->isName($node->name, 'unlink')) {
+            return null;
+        }
+
+        // the stream context argument has no equivalent on the facade
+        if (count($node->args) !== 1) {
+            return null;
+        }
+
+        $arg = $node->args[0];
+
+        // skips first class callables and unpacked arguments
+        if (! $arg instanceof Arg || $arg->unpack) {
+            return null;
+        }
+
+        if ($arg->name instanceof Identifier && ! $this->isName($arg->name, 'filename')) {
+            return null;
+        }
+
+        return $this->nodeFactory->createStaticCall(
+            'Illuminate\Support\Facades\File',
+            'delete',
+            [$arg->value],
+        );
+    }
+}

--- a/src/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector.php
+++ b/src/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector.php
@@ -62,21 +62,12 @@ CODE_SAMPLE
             return null;
         }
 
-        $arg = $node->args[0];
+        $arg = $node->getArg('filename', 0);
 
-        // skips first class callables and unpacked arguments
-        if (! $arg instanceof Arg || $arg->unpack) {
+        if (! $arg instanceof Arg) {
             return null;
         }
 
-        if ($arg->name instanceof Identifier && ! $this->isName($arg->name, 'filename')) {
-            return null;
-        }
-
-        return $this->nodeFactory->createStaticCall(
-            'Illuminate\Support\Facades\File',
-            'delete',
-            [$arg->value],
-        );
+        return $this->nodeFactory->createStaticCall('Illuminate\Support\Facades\File', 'delete', [$arg->value]);
     }
 }

--- a/tests/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector/Fixture/error_suppressed.php.inc
+++ b/tests/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector/Fixture/error_suppressed.php.inc
@@ -20,7 +20,7 @@ class ErrorSuppressed
 {
     public function run(string $path)
     {
-        @\Illuminate\Support\Facades\File::delete($path);
+        \Illuminate\Support\Facades\File::delete($path);
     }
 }
 

--- a/tests/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector/Fixture/error_suppressed.php.inc
+++ b/tests/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector/Fixture/error_suppressed.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\UnlinkFuncCallToFileFacadeDeleteRector\Fixture;
+
+class ErrorSuppressed
+{
+    public function run(string $path)
+    {
+        @unlink($path);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\UnlinkFuncCallToFileFacadeDeleteRector\Fixture;
+
+class ErrorSuppressed
+{
+    public function run(string $path)
+    {
+        @\Illuminate\Support\Facades\File::delete($path);
+    }
+}
+
+?>

--- a/tests/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector/Fixture/first_class_callable.php.inc
+++ b/tests/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector/Fixture/first_class_callable.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\UnlinkFuncCallToFileFacadeDeleteRector\Fixture;
+
+class FirstClassCallable
+{
+    public function run(array $paths)
+    {
+        array_map(unlink(...), $paths);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\UnlinkFuncCallToFileFacadeDeleteRector\Fixture;
+
+class FirstClassCallable
+{
+    public function run(array $paths)
+    {
+        array_map(\Illuminate\Support\Facades\File::delete(...), $paths);
+    }
+}
+
+?>

--- a/tests/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector/Fixture/fixture.php.inc
+++ b/tests/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector/Fixture/fixture.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\UnlinkFuncCallToFileFacadeDeleteRector\Fixture;
+
+class Fixture
+{
+    public function run(string $path)
+    {
+        unlink($path);
+        unlink(storage_path('app/temp.txt'));
+
+        if (! unlink($path)) {
+            return false;
+        }
+
+        return \unlink($path);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\UnlinkFuncCallToFileFacadeDeleteRector\Fixture;
+
+class Fixture
+{
+    public function run(string $path)
+    {
+        \Illuminate\Support\Facades\File::delete($path);
+        \Illuminate\Support\Facades\File::delete(storage_path('app/temp.txt'));
+
+        if (! \Illuminate\Support\Facades\File::delete($path)) {
+            return false;
+        }
+
+        return \Illuminate\Support\Facades\File::delete($path);
+    }
+}
+
+?>

--- a/tests/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector/Fixture/named_argument.php.inc
+++ b/tests/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector/Fixture/named_argument.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\UnlinkFuncCallToFileFacadeDeleteRector\Fixture;
+
+class NamedArgument
+{
+    public function run(string $path)
+    {
+        unlink(filename: $path);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\UnlinkFuncCallToFileFacadeDeleteRector\Fixture;
+
+class NamedArgument
+{
+    public function run(string $path)
+    {
+        \Illuminate\Support\Facades\File::delete($path);
+    }
+}
+
+?>

--- a/tests/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector/Fixture/skip_stream_context.php.inc
+++ b/tests/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector/Fixture/skip_stream_context.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\UnlinkFuncCallToFileFacadeDeleteRector\Fixture;
+
+class SkipStreamContext
+{
+    public function run(string $path, $context)
+    {
+        unlink($path, $context);
+    }
+}
+
+?>

--- a/tests/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector/Fixture/skip_unpacked_and_first_class_callable.php.inc
+++ b/tests/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector/Fixture/skip_unpacked_and_first_class_callable.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\FuncCall\UnlinkFuncCallToFileFacadeDeleteRector\Fixture;
+
+class SkipUnpackedAndFirstClassCallable
+{
+    public function run(array $arguments, array $paths)
+    {
+        unlink(...$arguments);
+
+        array_map(unlink(...), $paths);
+    }
+}
+
+?>

--- a/tests/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector/Fixture/skip_unpacked_argument.php.inc
+++ b/tests/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector/Fixture/skip_unpacked_argument.php.inc
@@ -2,13 +2,11 @@
 
 namespace RectorLaravel\Tests\Rector\FuncCall\UnlinkFuncCallToFileFacadeDeleteRector\Fixture;
 
-class SkipUnpackedAndFirstClassCallable
+class SkipUnpackedArgument
 {
-    public function run(array $arguments, array $paths)
+    public function run(array $arguments)
     {
         unlink(...$arguments);
-
-        array_map(unlink(...), $paths);
     }
 }
 

--- a/tests/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector/UnlinkFuncCallToFileFacadeDeleteRectorTest.php
+++ b/tests/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector/UnlinkFuncCallToFileFacadeDeleteRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorLaravel\Tests\Rector\FuncCall\UnlinkFuncCallToFileFacadeDeleteRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class UnlinkFuncCallToFileFacadeDeleteRectorTest extends AbstractRectorTestCase
+{
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @test
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector/config/configured_rule.php
+++ b/tests/Rector/FuncCall/UnlinkFuncCallToFileFacadeDeleteRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\FuncCall\UnlinkFuncCallToFileFacadeDeleteRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(UnlinkFuncCallToFileFacadeDeleteRector::class);
+};


### PR DESCRIPTION
Adds a rule that replaces raw `unlink()` calls with the `File` facade's `delete()` method, so applications go through the framework filesystem API rather than the bare PHP function.

```diff
-unlink($path);
+\Illuminate\Support\Facades\File::delete($path);
```

Registered in the `laravel-code-quality` set.

## Scope

`File::delete()` is a close wrapper around `@unlink()` and returns `bool`, the same as `unlink()`, so the rule refactors in any expression position rather than statement position only. `if (! unlink($path))` and `return unlink($path);` both convert safely.

First class callables convert too, so `array_map(unlink(...), $paths)` becomes `array_map(\Illuminate\Support\Facades\File::delete(...), $paths)`.

The error suppressor is **not** carried over:

```diff
-@unlink($path);
+\Illuminate\Support\Facades\File::delete($path);
```

`File::delete()` calls `@unlink()` internally and catches the resulting `ErrorException`, so no warning escapes and the `@` is redundant. This is why `ErrorSuppress` is one of the rule's node types — returning a node from the inner `FuncCall` alone would replace only the call and leave the `@` behind.

Two cases are skipped, where the swap would not be equivalent:

- **`unlink($path, $context)`** — the stream context argument has no facade equivalent, so the two argument form is left alone rather than silently dropping the context.
- **`unlink(...$args)`** — an unpacked argument may itself carry that stream context.

A `filename:` named argument is converted to a positional one, since the facade parameter is named `$paths`.

## Caveats for reviewers

**Warning behaviour changes.** `unlink()` emits a PHP warning on failure, whereas `File::delete()` suppresses it internally and returns `false`. Code relying on an error handler to convert that warning into an `ErrorException` will stop throwing after this rewrite, and will need to check the return value instead. This is inherent to the target API rather than to the rule, but it is a real behavioural difference and the reason the rule lives in a code quality set rather than an upgrade set.

**`File` resolves through the container.** The facade needs a booted application, so `unlink()` calls in code that runs outside the framework lifecycle are worth reviewing in the `--dry-run` diff before applying.

**Callable arity differs.** `unlink(...)` accepts an optional second stream context argument that `File::delete(...)` does not. A converted callable invoked with two arguments would behave differently, though passing a stream context through a callable reference is an unlikely shape in practice.

## Tests

Six fixtures covering the basic conversion across expression positions, error suppressed calls, first class callables, the named argument form, and the two skip cases. `composer rector`, `composer lint`, `composer phpstan`, `composer docs`, and `composer structarmed` are all clean.

Note that the suite has 8 pre-existing failures on `main` in the `ArrayDimFetch` and `PropertyFetch` rules, unrelated to this change. They reproduce on a clean checkout and are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
