### PR TITLE
Update rules overview count to 130

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 129 Rules Overview
+# 130 Rules Overview
 
 ## AbortIfRector
 


### PR DESCRIPTION
Running `composer docs` produces this one-line change: the rules overview header still says 129 while the file documents 130 rules.

`UnlinkFuncCallToFileFacadeDeleteRector` (#559) added its section to `docs/rector_rules_overview.md` but the count in the heading wasn't bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)