### PR TITLE
Bump structarmed to ^0.17 and enable CodeQuality preset

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "tightenco/duster": "^3.1",
         "nette/utils": "^4.0",
         "tracy/tracy": "^2.10",
-        "boundwize/structarmed": "^0.16"
+        "boundwize/structarmed": "^0.17"
     },
     "autoload": {
         "psr-4": {

--- a/src/NodeAnalyzer/CallUserFuncAnalyzer.php
+++ b/src/NodeAnalyzer/CallUserFuncAnalyzer.php
@@ -95,7 +95,7 @@ final readonly class CallUserFuncAnalyzer
     private function argsToArray(array $args): Array_
     {
         return new Array_(
-            array_map(fn (Arg $arg) => new ArrayItem($arg->value), $args)
+            array_map(static fn (Arg $arg) => new ArrayItem($arg->value), $args)
         );
     }
 }

--- a/src/NodeFactory/DispatchableTestsMethodsFactory.php
+++ b/src/NodeFactory/DispatchableTestsMethodsFactory.php
@@ -23,7 +23,7 @@ final class DispatchableTestsMethodsFactory
         return new StaticCall(
             new FullyQualified($facade),
             'fake',
-            [new Arg(new Array_(array_map(fn (String_|ClassConstFetch $item): ArrayItem => new ArrayItem($item), $items)))]
+            [new Arg(new Array_(array_map(static fn (String_|ClassConstFetch $item): ArrayItem => new ArrayItem($item), $items)))]
         );
     }
 
@@ -33,7 +33,7 @@ final class DispatchableTestsMethodsFactory
      */
     public function assertStatements(array $items, string $facade): array
     {
-        return array_map(fn (String_|ClassConstFetch $item): Expression => new Expression(new StaticCall(
+        return array_map(static fn (String_|ClassConstFetch $item): Expression => new Expression(new StaticCall(
             new FullyQualified($facade),
             'assertDispatched',
             [new Arg($item)],
@@ -46,7 +46,7 @@ final class DispatchableTestsMethodsFactory
      */
     public function assertNotStatements(array $items, string $facade): array
     {
-        return array_map(fn (String_|ClassConstFetch $item): Expression => new Expression(new StaticCall(
+        return array_map(static fn (String_|ClassConstFetch $item): Expression => new Expression(new StaticCall(
             new FullyQualified($facade),
             'assertNotDispatched',
             [new Arg($item)],

--- a/src/NodeVisitor/ArrayDimFetchContextNodeVisitor.php
+++ b/src/NodeVisitor/ArrayDimFetchContextNodeVisitor.php
@@ -67,7 +67,7 @@ final class ArrayDimFetchContextNodeVisitor extends NodeVisitorAbstract implemen
         if (! $node instanceof ArrayDimFetch) {
             if (in_array($node::class, [Assign::class, Isset_::class, Unset_::class, InterpolatedString::class], true)
                 && (! $node instanceof Assign || $this->isSuperglobalAssign($node))) {
-                SimpleCallableNodeTraverser::traverseNodesWithCallable($node, function (Node $subNode) {
+                SimpleCallableNodeTraverser::traverseNodesWithCallable($node, static function (Node $subNode) {
                     if ($subNode instanceof ArrayDimFetch || $subNode instanceof Variable) {
                         $subNode->setAttribute(self::IS_IN_SUPERGLOBAL_ASSIGN, true);
                     }
@@ -80,7 +80,7 @@ final class ArrayDimFetchContextNodeVisitor extends NodeVisitorAbstract implemen
         }
 
         if (! $node->dim instanceof Expr) {
-            SimpleCallableNodeTraverser::traverseNodesWithCallable($node, function (Node $subNode) {
+            SimpleCallableNodeTraverser::traverseNodesWithCallable($node, static function (Node $subNode) {
                 if (! $subNode instanceof Variable) {
                     return null;
                 }
@@ -95,7 +95,7 @@ final class ArrayDimFetchContextNodeVisitor extends NodeVisitorAbstract implemen
             return null;
         }
 
-        SimpleCallableNodeTraverser::traverseNodesWithCallable($node, function (Node $subSubNode) {
+        SimpleCallableNodeTraverser::traverseNodesWithCallable($node, static function (Node $subSubNode) {
             if ($subSubNode instanceof Variable) {
                 $subSubNode->setAttribute(self::IS_INSIDE_ARRAY_DIM_FETCH_WITH_DIM_NOT_SCALAR, true);
 

--- a/src/NodeVisitor/RandomEnumContextNodeVisitor.php
+++ b/src/NodeVisitor/RandomEnumContextNodeVisitor.php
@@ -31,7 +31,7 @@ final class RandomEnumContextNodeVisitor extends NodeVisitorAbstract implements 
         // see https://github.com/spatie/laravel-enum#faker-provider
         if ($this->nodeNameResolver->isName($node->name, 'randomEnum')) {
             $node->setAttribute(self::IS_IN_RANDOM_ENUM, true);
-            SimpleCallableNodeTraverser::traverseNodesWithCallable($node, function (Node $subNode) {
+            SimpleCallableNodeTraverser::traverseNodesWithCallable($node, static function (Node $subNode) {
                 if (! $subNode instanceof PropertyFetch && ! $subNode instanceof InterpolatedString) {
                     return null;
                 }

--- a/src/Rector/ArrayDimFetch/ArrayToArrGetRector.php
+++ b/src/Rector/ArrayDimFetch/ArrayToArrGetRector.php
@@ -242,7 +242,7 @@ CODE_SAMPLE
 
     private function markArrayDimFetchNodes(Node $node): void
     {
-        $this->traverseNodesWithCallable($node, function (Node $subNode) use ($node): ?int {
+        $this->traverseNodesWithCallable($node, static function (Node $subNode) use ($node): ?int {
             // first visit is current node itself
             if ($node === $subNode) {
                 return null;
@@ -261,7 +261,7 @@ CODE_SAMPLE
         $found = false;
 
         $originalNode = $node;
-        $this->traverseNodesWithCallable($node, function (Node $subNode) use (&$found, $originalNode): ?int {
+        $this->traverseNodesWithCallable($node, static function (Node $subNode) use (&$found, $originalNode): ?int {
             // first visit is current node itself
             if ($originalNode === $subNode) {
                 return null;

--- a/src/Rector/ClassMethod/AbstractAddGenericReturnTypeToRelationsRector.php
+++ b/src/Rector/ClassMethod/AbstractAddGenericReturnTypeToRelationsRector.php
@@ -187,7 +187,7 @@ abstract class AbstractAddGenericReturnTypeToRelationsRector extends AbstractRec
     {
         $node = $this->betterNodeFinder->findFirstInFunctionLikeScoped(
             $classMethod,
-            fn (Node $subNode): bool => $subNode instanceof Return_
+            static fn (Node $subNode): bool => $subNode instanceof Return_
         );
 
         if (! $node instanceof Return_) {

--- a/src/Rector/Class_/LivewireComponentQueryStringToUrlAttributeRector.php
+++ b/src/Rector/Class_/LivewireComponentQueryStringToUrlAttributeRector.php
@@ -178,7 +178,7 @@ CODE_SAMPLE
         // we remove the array properties which will be converted
         $array->items = array_filter(
             $array->items,
-            fn (?ArrayItem $arrayItem): bool => ! in_array($arrayItem, $toFilter, true),
+            static fn (?ArrayItem $arrayItem): bool => ! in_array($arrayItem, $toFilter, true),
         );
 
         return $properties;
@@ -228,7 +228,7 @@ CODE_SAMPLE
         $array = $property->props[0]->default;
 
         if ($array instanceof Array_ && $array->items === []) {
-            $class->stmts = array_filter($class->stmts, fn (Node $node) => $node !== $property);
+            $class->stmts = array_filter($class->stmts, static fn (Node $node) => $node !== $property);
         }
     }
 }

--- a/src/Rector/If_/ThrowIfRector.php
+++ b/src/Rector/If_/ThrowIfRector.php
@@ -134,7 +134,7 @@ CODE_SAMPLE
     {
         $firstShortCircuitOperator = $this->betterNodeFinder->findFirst(
             $expr,
-            fn (Node $node): bool => $node instanceof BooleanAnd || $node instanceof BooleanOr
+            static fn (Node $node): bool => $node instanceof BooleanAnd || $node instanceof BooleanOr
         );
         if (! $firstShortCircuitOperator instanceof Node) {
             return true;

--- a/src/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector.php
+++ b/src/Rector/MethodCall/ValidationRuleArrayStringValueToArrayRector.php
@@ -127,7 +127,7 @@ CODE_SAMPLE
             $allRuleParts[] = $currentParts;
         }
 
-        return new Array_(array_map(fn ($parts) => new ArrayItem(new InterpolatedString($parts)), $allRuleParts));
+        return new Array_(array_map(static fn ($parts) => new ArrayItem(new InterpolatedString($parts)), $allRuleParts));
     }
 
     private function refactorCall(StaticCall|MethodCall $node): StaticCall|MethodCall|null

--- a/src/Rector/PropertyFetch/ReplaceFakerInstanceWithHelperRector.php
+++ b/src/Rector/PropertyFetch/ReplaceFakerInstanceWithHelperRector.php
@@ -141,7 +141,7 @@ CODE_SAMPLE
 
         return array_reduce(
             $parts,
-            fn (?Expr $carry, Expr $part) => $carry instanceof Expr ? new Concat($carry, $part) : $part,
+            static fn (?Expr $carry, Expr $part) => $carry instanceof Expr ? new Concat($carry, $part) : $part,
         );
     }
 

--- a/structarmed.php
+++ b/structarmed.php
@@ -16,4 +16,4 @@ return Architecture::define()
             '*/Source/*',
         ],
     ])
-    ->withPreset(Preset::PSR4());
+    ->withPresets(Preset::PSR4(), Preset::CODEQUALITY());


### PR DESCRIPTION
This PR bump structarmed to ^0.17 and enable CodeQuality preset. The CodeQuality preset applied rule on this PR:

- _MustBeStaticAnonymousFunctionRule_: add static to closure/arrow function when possible

they are FixableInterface instance rules and applied with:

```bash
vendor/bin/structarmed analyze --fix
```

If you need separate PR, just let me know :)