### PR TITLE
Skip variable-only contexts in ArrayDimFetch rules

### DIFF
--- a/src/NodeVisitor/ArrayDimFetchContextNodeVisitor.php
+++ b/src/NodeVisitor/ArrayDimFetchContextNodeVisitor.php
@@ -5,15 +5,31 @@ declare(strict_types=1);
 namespace RectorLaravel\NodeVisitor;
 
 use PhpParser\Node;
+use PhpParser\Node\ArrayItem;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\AssignOp;
+use PhpParser\Node\Expr\AssignRef;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Isset_;
+use PhpParser\Node\Expr\List_;
+use PhpParser\Node\Expr\PostDec;
+use PhpParser\Node\Expr\PostInc;
+use PhpParser\Node\Expr\PreDec;
+use PhpParser\Node\Expr\PreInc;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Scalar;
 use PhpParser\Node\Scalar\InterpolatedString;
+use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Stmt\Unset_;
 use PhpParser\NodeVisitorAbstract;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\ReflectionProvider;
 use Rector\Contract\PhpParser\DecoratingNodeVisitorInterface;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
@@ -24,14 +40,30 @@ final class ArrayDimFetchContextNodeVisitor extends NodeVisitorAbstract implemen
     public const string IS_IN_SUPERGLOBAL_ASSIGN = 'is_in_superglobal_assign';
     public const string IS_INSIDE_ARRAY_DIM_FETCH_WITH_DIM_NOT_EXPR = 'is_inside_array_dim_fetch_with_dim_not_expr';
 
+    /**
+     * Marks nodes that PHP only accepts as a variable, so replacing them with a function or
+     * method call would be a fatal error: assignment targets (including compound, reference,
+     * destructuring and nested dimensions), increment/decrement, foreach targets, by-reference
+     * arguments, and the operands of isset()/unset().
+     */
+    public const string IS_IN_WRITE_CONTEXT = 'is_in_write_context';
+
+    /**
+     * Marks nodes inside a "$string {$interpolation}", where a call cannot be written either.
+     */
+    public const string IS_IN_INTERPOLATED_STRING = 'is_in_interpolated_string';
+
     private const array SUPERGLOBAL_NAMES = ['_SERVER', '_GET', '_POST', '_REQUEST', '_ENV'];
 
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver
+        private readonly NodeNameResolver $nodeNameResolver,
+        private readonly ReflectionProvider $reflectionProvider,
     ) {}
 
     public function enterNode(Node $node)
     {
+        $this->markWriteContext($node);
+
         if (! $node instanceof ArrayDimFetch) {
             if (in_array($node::class, [Assign::class, Isset_::class, Unset_::class, InterpolatedString::class], true)
                 && (! $node instanceof Assign || $this->isSuperglobalAssign($node))) {
@@ -72,6 +104,139 @@ final class ArrayDimFetchContextNodeVisitor extends NodeVisitorAbstract implemen
 
             return null;
         });
+
+        return null;
+    }
+
+    private function markWriteContext(Node $node): void
+    {
+        if ($node instanceof InterpolatedString) {
+            SimpleCallableNodeTraverser::traverseNodesWithCallable($node, static function (Node $subNode) {
+                if ($subNode instanceof ArrayDimFetch || $subNode instanceof Variable) {
+                    $subNode->setAttribute(self::IS_IN_INTERPOLATED_STRING, true);
+                }
+
+                return null;
+            });
+
+            return;
+        }
+
+        if ($node instanceof Assign || $node instanceof AssignOp) {
+            $this->markWriteTarget($node->var);
+
+            return;
+        }
+
+        if ($node instanceof AssignRef) {
+            $this->markWriteTarget($node->var);
+            $this->markWriteTarget($node->expr);
+
+            return;
+        }
+
+        if ($node instanceof PreInc || $node instanceof PostInc || $node instanceof PreDec || $node instanceof PostDec) {
+            $this->markWriteTarget($node->var);
+
+            return;
+        }
+
+        if ($node instanceof Foreach_) {
+            if ($node->keyVar instanceof Expr) {
+                $this->markWriteTarget($node->keyVar);
+            }
+
+            $this->markWriteTarget($node->valueVar);
+
+            return;
+        }
+
+        if ($node instanceof Isset_ || $node instanceof Unset_) {
+            foreach ($node->vars as $var) {
+                $this->markWriteTarget($var);
+            }
+
+            return;
+        }
+
+        if ($node instanceof FuncCall) {
+            $this->markByRefArgs($node);
+        }
+    }
+
+    /**
+     * Marks the variable chain of a write target, e.g. both $_ENV['a']['b'] and $_ENV['a'] in
+     * $_ENV['a']['b'] = 1, while leaving the dimensions themselves - which stay reads - alone.
+     */
+    private function markWriteTarget(Expr $expr): void
+    {
+        if ($expr instanceof List_ || $expr instanceof Array_) {
+            foreach ($expr->items as $item) {
+                if ($item instanceof ArrayItem) {
+                    $this->markWriteTarget($item->value);
+                }
+            }
+
+            return;
+        }
+
+        while ($expr instanceof ArrayDimFetch) {
+            $expr->setAttribute(self::IS_IN_WRITE_CONTEXT, true);
+            $expr = $expr->var;
+        }
+
+        if ($expr instanceof Variable) {
+            $expr->setAttribute(self::IS_IN_WRITE_CONTEXT, true);
+        }
+    }
+
+    private function markByRefArgs(FuncCall $funcCall): void
+    {
+        if ($funcCall->isFirstClassCallable()) {
+            return;
+        }
+
+        if (! $funcCall->name instanceof Name) {
+            return;
+        }
+
+        if (! $this->reflectionProvider->hasFunction($funcCall->name, null)) {
+            return;
+        }
+
+        $parameters = ParametersAcceptorSelector::combineAcceptors(
+            $this->reflectionProvider->getFunction($funcCall->name, null)->getVariants()
+        )->getParameters();
+
+        $lastParameter = $parameters === [] ? null : $parameters[count($parameters) - 1];
+
+        foreach ($funcCall->getArgs() as $position => $arg) {
+            $parameter = $arg->name instanceof Identifier
+                ? $this->findParameterByName($parameters, $arg->name->toString())
+                : ($parameters[$position] ?? ($lastParameter?->isVariadic() === true ? $lastParameter : null));
+
+            if ($parameter === null) {
+                continue;
+            }
+
+            if (! $parameter->passedByReference()->yes()) {
+                continue;
+            }
+
+            $this->markWriteTarget($arg->value);
+        }
+    }
+
+    /**
+     * @param  ParameterReflection[]  $parameters
+     */
+    private function findParameterByName(array $parameters, string $name): ?ParameterReflection
+    {
+        foreach ($parameters as $parameter) {
+            if ($parameter->getName() === $name) {
+                return $parameter;
+            }
+        }
 
         return null;
     }

--- a/src/Rector/ArrayDimFetch/ArrayToArrGetRector.php
+++ b/src/Rector/ArrayDimFetch/ArrayToArrGetRector.php
@@ -22,6 +22,7 @@ use PhpParser\NodeVisitor;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PHPStan\ScopeFetcher;
 use RectorLaravel\AbstractRector;
+use RectorLaravel\NodeVisitor\ArrayDimFetchContextNodeVisitor;
 use RectorLaravel\Tests\Rector\ArrayDimFetch\ArrayToArrGetRector\ArrayToArrGetRectorTest;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -101,6 +102,11 @@ CODE_SAMPLE
         }
 
         if ($node->getAttribute(AttributeKey::IS_BEING_ASSIGNED) === true) {
+            return null;
+        }
+
+        // skip contexts that require a variable, e.g. $array['key']++ or sort($array['key'])
+        if ($node->getAttribute(ArrayDimFetchContextNodeVisitor::IS_IN_WRITE_CONTEXT) === true) {
             return null;
         }
 

--- a/src/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector.php
+++ b/src/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\StaticCall;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use RectorLaravel\AbstractRector;
+use RectorLaravel\NodeVisitor\ArrayDimFetchContextNodeVisitor;
 use RectorLaravel\Tests\Rector\ArrayDimFetch\EnvVariableToEnvHelperRector\EnvVariableToEnvHelperRectorTest;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -43,6 +44,15 @@ CODE_SAMPLE
     public function refactor(Node $node): ?StaticCall
     {
         if ($node->getAttribute(AttributeKey::IS_BEING_ASSIGNED) === true) {
+            return null;
+        }
+
+        // skip contexts that require a variable, e.g. unset($_ENV['KEY']) or $_ENV['KEY'] .= 'x'
+        if ($node->getAttribute(ArrayDimFetchContextNodeVisitor::IS_IN_WRITE_CONTEXT) === true) {
+            return null;
+        }
+
+        if ($node->getAttribute(ArrayDimFetchContextNodeVisitor::IS_IN_INTERPOLATED_STRING) === true) {
             return null;
         }
 

--- a/src/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector.php
+++ b/src/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector.php
@@ -79,6 +79,11 @@ CODE_SAMPLE
             return null;
         }
 
+        // skip contexts that require a variable, e.g. $_GET['key'] .= 'x' or sort($_GET['key'])
+        if ($node->getAttribute(ArrayDimFetchContextNodeVisitor::IS_IN_WRITE_CONTEXT) === true) {
+            return null;
+        }
+
         if ($node instanceof Variable) {
             if ($node->getAttribute(ArrayDimFetchContextNodeVisitor::IS_INSIDE_ARRAY_DIM_FETCH_WITH_DIM_NOT_SCALAR) === true) {
                 return null;

--- a/src/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector.php
+++ b/src/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector.php
@@ -55,6 +55,11 @@ CODE_SAMPLE
             return null;
         }
 
+        // skip contexts that require a variable, e.g. $_SERVER['KEY'] .= 'x' or sort($_SERVER['KEY'])
+        if ($node->getAttribute(ArrayDimFetchContextNodeVisitor::IS_IN_WRITE_CONTEXT) === true) {
+            return null;
+        }
+
         return $this->nodeFactory->createStaticCall('Illuminate\Support\Facades\Request', 'server', [
             new Arg($node->dim),
         ]);

--- a/src/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector.php
+++ b/src/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Unset_;
 use RectorLaravel\AbstractRector;
+use RectorLaravel\NodeVisitor\ArrayDimFetchContextNodeVisitor;
 use RectorLaravel\Tests\Rector\ArrayDimFetch\SessionVariableToSessionFacadeRector\SessionVariableToSessionFacadeRectorTest;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -103,6 +104,16 @@ CODE_SAMPLE
 
     public function processDimFetch(ArrayDimFetch $arrayDimFetch): ?StaticCall
     {
+        // skip contexts that require a variable, e.g. $_SESSION['key'] .= 'x'; plain assignments
+        // are handled on the Assign node itself
+        if ($arrayDimFetch->getAttribute(ArrayDimFetchContextNodeVisitor::IS_IN_WRITE_CONTEXT) === true) {
+            return null;
+        }
+
+        if ($arrayDimFetch->getAttribute(ArrayDimFetchContextNodeVisitor::IS_IN_INTERPOLATED_STRING) === true) {
+            return null;
+        }
+
         if (! $this->isName($arrayDimFetch->var, '_SESSION')) {
             return null;
         }
@@ -214,6 +225,14 @@ CODE_SAMPLE
     private function processVariable(Variable $variable): ?StaticCall
     {
         if ($variable->getAttribute(self::IS_INSIDE_ARRAY_DIM_FETCH_WITH_DIM_NOT_EXPR) === true) {
+            return null;
+        }
+
+        if ($variable->getAttribute(ArrayDimFetchContextNodeVisitor::IS_IN_WRITE_CONTEXT) === true) {
+            return null;
+        }
+
+        if ($variable->getAttribute(ArrayDimFetchContextNodeVisitor::IS_IN_INTERPOLATED_STRING) === true) {
             return null;
         }
 

--- a/tests/Rector/ArrayDimFetch/ArrayToArrGetRector/Fixture/skip_write_contexts.php.inc
+++ b/tests/Rector/ArrayDimFetch/ArrayToArrGetRector/Fixture/skip_write_contexts.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\ArrayToArrGetRector\Fixture;
+
+function skipWriteContexts(array $array, array $list)
+{
+    $array['counter']++;
+    --$array['counter'];
+    $reference = &$array['key'];
+    foreach ($list as $array['key']) {
+    }
+    [$array['key']] = ['value'];
+    sort($array['list']);
+    preg_match('/key/', 'key', $array['matches']);
+}
+
+?>

--- a/tests/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector/Fixture/skip_interpolated_string.php.inc
+++ b/tests/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector/Fixture/skip_interpolated_string.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\EnvVariableToEnvHelperRector\Fixture;
+
+echo "app {$_ENV['APP_NAME']}";
+echo "app $_ENV[APP_NAME]";
+
+?>

--- a/tests/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector/Fixture/skip_write_contexts.php.inc
+++ b/tests/Rector/ArrayDimFetch/EnvVariableToEnvHelperRector/Fixture/skip_write_contexts.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\EnvVariableToEnvHelperRector\Fixture;
+
+function skipWriteContexts(string $key, $value, array $list)
+{
+    $_ENV['APP_NAME'] .= 'suffix';
+    $_ENV['APP_NAME'] ??= 'MyApp';
+    $_ENV['COUNTER']++;
+    --$_ENV['COUNTER'];
+    $reference = &$_ENV['APP_NAME'];
+    foreach ($list as $_ENV['APP_NAME']) {
+    }
+    [$_ENV['APP_NAME']] = ['MyApp'];
+    sort($_ENV['LIST']);
+    preg_match('/name/', 'name', $_ENV['MATCHES']);
+    unset($_ENV[$key]);
+    isset($_ENV['APP_NAME']);
+    $_ENV['nested']['key'] = $value;
+}
+
+?>

--- a/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/Fixture/skip_write_contexts.php.inc
+++ b/tests/Rector/ArrayDimFetch/RequestVariablesToRequestFacadeRector/Fixture/skip_write_contexts.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\RequestVariablesToRequestFacadeRector\Fixture;
+
+function skipWriteContexts($value, array $list)
+{
+    $_GET['key'] .= 'suffix';
+    $_POST['key'] ??= 'value';
+    $_REQUEST['counter']++;
+    --$_GET['counter'];
+    $reference = &$_POST['key'];
+    foreach ($list as $_GET['key']) {
+    }
+    [$_POST['key']] = ['value'];
+    sort($_GET['list']);
+    preg_match('/key/', 'key', $_POST['matches']);
+    $_GET['nested']['key'] = $value;
+}
+
+?>

--- a/tests/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector/Fixture/skip_write_contexts.php.inc
+++ b/tests/Rector/ArrayDimFetch/ServerVariableToRequestFacadeRector/Fixture/skip_write_contexts.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\ServerVariableToRequestFacadeRector\Fixture;
+
+function skipWriteContexts($value, array $list)
+{
+    $_SERVER['APP_ENV'] .= 'suffix';
+    $_SERVER['APP_ENV'] ??= 'production';
+    $_SERVER['COUNTER']++;
+    --$_SERVER['COUNTER'];
+    $reference = &$_SERVER['APP_ENV'];
+    foreach ($list as $_SERVER['APP_ENV']) {
+    }
+    [$_SERVER['APP_ENV']] = ['production'];
+    sort($_SERVER['LIST']);
+    preg_match('/env/', 'env', $_SERVER['MATCHES']);
+    $_SERVER['nested']['key'] = $value;
+}
+
+?>

--- a/tests/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector/Fixture/skip_interpolated_string.php.inc
+++ b/tests/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector/Fixture/skip_interpolated_string.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\SessionVariableToSessionFacadeRector\Fixture;
+
+echo "user {$_SESSION['user']}";
+echo "user $_SESSION[user]";
+
+?>

--- a/tests/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector/Fixture/skip_write_contexts.php.inc
+++ b/tests/Rector/ArrayDimFetch/SessionVariableToSessionFacadeRector/Fixture/skip_write_contexts.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\ArrayDimFetch\SessionVariableToSessionFacadeRector\Fixture;
+
+function skipWriteContexts($value, array $list)
+{
+    $_SESSION['key'] .= 'suffix';
+    $_SESSION['key'] ??= 'value';
+    $_SESSION['counter']++;
+    --$_SESSION['counter'];
+    $reference = &$_SESSION['key'];
+    foreach ($list as $_SESSION['key']) {
+    }
+    [$_SESSION['key']] = ['value'];
+    sort($_SESSION['list']);
+    preg_match('/key/', 'key', $_SESSION['matches']);
+    $_SESSION['nested']['key'] = $value;
+}
+
+?>


### PR DESCRIPTION
Fixes #419.

## The bug

The `ArrayDimFetch` rules only guarded against a direct `=` assignment (`AttributeKey::IS_BEING_ASSIGNED`, or `IS_IN_SUPERGLOBAL_ASSIGN`). Every other context where PHP requires a variable rather than an expression was still rewritten into a static call, producing code that does not run:

```php
unset($_ENV[$key]);        // -> unset(Env::get($key));                 Can't use method return value in write context
$_ENV['KEY'] .= 'x';       // -> Env::get('KEY') .= 'x';
$_ENV['COUNT']++;          // -> Env::get('COUNT')++;
$r = &$_ENV['KEY'];        // -> $r = &Env::get('KEY');
isset($_ENV['KEY']);       // -> isset(Env::get('KEY'));                Cannot use isset() on the result of an expression
echo "app {$_ENV['KEY']}"; // -> echo "app {\Illuminate\Support\Env::get('KEY')}";
sort($_SERVER['LIST']);    // -> sort(Request::server('LIST'));         by-reference argument
$_SESSION['a']['b'] = $v;  // -> Session::get('a')['b'] = $v;
```

`foreach ($list as $array['key'])` did worse than emit bad code — it aborted the whole Rector run from `ArrayToArrGetRector` with `System error: "Scope not available on "PhpParser\Node\Expr\Variable" node."`.

The issue was reported against `EnvVariableToEnvHelperRector`, but reproducing each context across the directory showed the same hole in all five rules. The `= ` case from the original report was already fixed in #516; the two follow-up comments (an assignment in a Pest `beforeAll`, and `unset()`) were not.

| context | Env | Server | Request | Session | Arr |
| --- | --- | --- | --- | --- | --- |
| `.=` / `??=` | ✗ | ✗ | ✗ | ✗ | ok |
| `++` / `--` | ✗ | ✗ | ✗ | ✗ | ✗ |
| `$r = &$x['k']` | ✗ | ✗ | ✗ | ✗ | ok |
| `foreach (… as $x['k'])` | ✗ | ✗ | ✗ | ✗ | crash |
| `[$x['k']] = […]` | ok | ✗ | ✗ | ✗ | ok |
| by-ref arg (`sort()`) | ✗ | ✗ | ✗ | ✗ | ✗ |
| `unset()` | ✗ | ok | ok | ok¹ | ok |
| `isset()` | ✗ | ok | ok¹ | ok¹ | ok |
| `"{$x['k']}"` | ✗ | ok | ok | ✗ | n/a |
| `$x['a']['b'] = …` | ✗ | ✗ | ✗ | ✗ | ok |

¹ deliberately converted to `has()` / `forget()`, left as is.

## The fix

`ArrayDimFetchContextNodeVisitor` gains two attributes, so the knowledge lives in one place rather than being re-derived per rule:

- **`IS_IN_WRITE_CONTEXT`** — the variable chain of anything PHP accepts only as a variable: `Assign` / `AssignOp` targets, both sides of `AssignRef`, increment and decrement, `foreach` key and value targets, `isset()` / `unset()` operands, destructuring targets inside `List_` / `Array_`, and by-reference arguments of named function calls, resolved through `ReflectionProvider` (named and variadic-by-ref parameters included). It walks `$_ENV['a']['b']` → `$_ENV['a']` → `$_ENV`, and deliberately leaves the dimension expressions unmarked — those stay reads, so `$_ENV[$_ENV['KEY']] = $v` still converts its inner read.
- **`IS_IN_INTERPOLATED_STRING`** — for `"{$_ENV['KEY']}"`, where a call is a syntax error.

All five rules then consult them. The change is purely additive: the existing `IS_BEING_ASSIGNED` and `IS_IN_SUPERGLOBAL_ASSIGN` checks are untouched, and no existing conversion moves. In particular the `isset()` / `unset()` rewrites into `Session::has()` / `Session::forget()` and `Request::exists()` still run, because those are handled on the `Isset_` / `Unset_` node itself, which is never marked — only its operands are. For the same reason `$_SESSION['key'] = $v` still becomes `Session::put()` via the `Assign` handler, while `$_SESSION['a']['b'] = $v` is now correctly left alone instead of becoming `Session::get('a')['b'] = $v`.

`empty()` is not treated as a write context — it accepts an arbitrary expression, so `empty(Env::get('KEY'))` is valid and that conversion is kept.

## Known gap

By-reference detection covers plain named function calls only. `$obj->method($_ENV['k'])` and `Cls::method($_ENV['k'])` with a by-ref parameter cannot be resolved from a decorating node visitor, which runs before PHPStan scope is attached. Rare for superglobals, but worth naming.

## Tests

Seven new fixtures — `skip_write_contexts.php.inc` for each of the five rules, plus `skip_interpolated_string.php.inc` for Env and Session. Reverting `src/` alone turns them into 6 failures and 1 error, so they are load-bearing.

Full suite green on PHP 8.3 and 8.5 (664 → 671 tests), plus `phpstan`, `duster lint` and `structarmed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
