### PR TITLE
Skip static contexts in CarbonSetTestNowToTravelToRector

### DIFF
--- a/src/Rector/StaticCall/CarbonSetTestNowToTravelToRector.php
+++ b/src/Rector/StaticCall/CarbonSetTestNowToTravelToRector.php
@@ -105,6 +105,12 @@ CODE_SAMPLE
 
     private function isInLaravelTestCaseScope(Scope $scope): bool
     {
+        // Static methods (e.g. data providers) and static closures have no `$this` to call
+        // `travelTo()` on, so rewriting there would produce a fatal error.
+        if (! $scope->hasVariableType('this')->yes()) {
+            return false;
+        }
+
         if ($scope->isInClass()) {
             return $scope->getClassReflection()->is(self::TEST_CASE_CLASS);
         }

--- a/tests/Rector/StaticCall/CarbonSetTestNowToTravelToRector/Fixture/skip_in_static_closure.php.inc
+++ b/tests/Rector/StaticCall/CarbonSetTestNowToTravelToRector/Fixture/skip_in_static_closure.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\CarbonSetTestNowToTravelToRector\Fixture;
+
+use Illuminate\Foundation\Testing\TestCase;
+use Carbon\Carbon;
+
+class SkipInStaticClosureTest extends TestCase
+{
+    public function test()
+    {
+        $callback = static function () {
+            Carbon::setTestNow('2025-10-14');
+        };
+
+        $callback();
+    }
+}
+
+?>

--- a/tests/Rector/StaticCall/CarbonSetTestNowToTravelToRector/Fixture/skip_in_static_method.php.inc
+++ b/tests/Rector/StaticCall/CarbonSetTestNowToTravelToRector/Fixture/skip_in_static_method.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\StaticCall\CarbonSetTestNowToTravelToRector\Fixture;
+
+use Illuminate\Foundation\Testing\TestCase;
+use Carbon\Carbon;
+
+class SkipInStaticMethodTest extends TestCase
+{
+    public static function validationDataProvider(): array
+    {
+        Carbon::setTestNow('2025-10-14');
+
+        return [];
+    }
+}
+
+?>


### PR DESCRIPTION
Fixes #408

`CarbonSetTestNowToTravelToRector` decided it was safe to emit `$this->travelTo()` based only on the enclosing class being a Laravel `TestCase`, never on whether `$this` is actually bound at the call site. So it also rewrote calls inside static methods — the reported case is a PHPUnit data provider, which must be static — producing code that fatals with *Using $this when not in object context*:

```php
public static function validationDataProvider(): array
{
-    Carbon::setTestNow('2025-10-14');
+    $this->travelTo('2025-10-14'); // Error: Using $this when not in object context
}
```

The same happens inside a `static function () {}` closure in an ordinary test method, so the guard is on static contexts generally rather than on static methods alone.

## The change

`isInLaravelTestCaseScope()` now bails out when `$this` is not bound, before the existing checks:

```php
if (! $scope->hasVariableType('this')->yes()) {
    return false;
}
```

`hasVariableType('this')` resolves to `No` in both a static method and a static closure, and to `Yes` in a normal method, so it is the narrow check for exactly this condition.

I first tried collapsing the class-reflection branch and the Pest branch into the single `getType(new Variable('this'))` check, since in principle it covers both. That broke four existing fixtures: every fixture in that directory declares `SomeTest` in the same namespace, and `in_non_laravel_testcase_class.php.inc` — alphabetically first — declares a `SomeTest` extending PHPUnit's `TestCase`, so the cached reflection for that name makes `$this` resolve to a non-Laravel type in the later fixtures. `$scope->getClassReflection()` reads the actual class node and is unaffected, so that branch is kept deliberately.

## Fixtures

Two no-change fixtures, both of which fail without the guard:

- `skip_in_static_method.php.inc` — the data provider from the issue
- `skip_in_static_closure.php.inc` — `static function () {}` inside a test method

## Checks

- Rule tests: 9/9 pass
- `composer phpstan`: no errors; `composer lint`: clean
- `composer test`: the 1 error / 14 failures are pre-existing on `main` (unrelated rules, e.g. `ReplaceFakerInstanceWithHelperRector`); the count is identical with and without this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)