### PR TITLE
Resolve container binding arguments by name in ContainerBindConcreteWithClosureOnlyRector

### DIFF
--- a/src/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector.php
+++ b/src/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector.php
@@ -77,13 +77,6 @@ CODE_SAMPLE
             return null;
         }
 
-        foreach ($node->getArgs() as $arg) {
-            // an unpacked argument hides which parameter each value lands in
-            if ($arg->unpack) {
-                return null;
-            }
-        }
-
         $abstractArg = $node->getArg('abstract', 0);
         $concreteArg = $node->getArg('concrete', 1);
         // singleton() has no $shared parameter, and passing one would be fatal
@@ -92,6 +85,12 @@ CODE_SAMPLE
             : null;
 
         if (! $abstractArg instanceof Arg || ! $concreteArg instanceof Arg) {
+            return null;
+        }
+
+        // getArg() cannot match a spread, and refuses a name that is not a parameter;
+        // rebuilding the call below would drop whatever it left behind
+        if (count(array_filter([$abstractArg, $concreteArg, $sharedArg])) !== count($node->getArgs())) {
             return null;
         }
 

--- a/src/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector.php
+++ b/src/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector.php
@@ -3,10 +3,11 @@
 namespace RectorLaravel\Rector\MethodCall;
 
 use PhpParser\Node;
-use PhpParser\Node\Const_;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
 use PHPStan\Type\ObjectType;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\StaticTypeMapper\StaticTypeMapper;
@@ -19,6 +20,18 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 final class ContainerBindConcreteWithClosureOnlyRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * bindIf() and singletonIf() are left out on purpose: they pass the abstract
+     * straight to bound(), which uses it as an array offset, so a closure abstract
+     * fatals there.
+     *
+     * @var array<string, list<string>>
+     */
+    private const array PARAMETER_NAMES_BY_METHOD = [
+        'bind' => ['abstract', 'concrete', 'shared'],
+        'singleton' => ['abstract', 'concrete'],
+    ];
+
     public function __construct(
         private readonly ReturnTypeInferer $returnTypeInferer,
         private readonly StaticTypeMapper $staticTypeMapper,
@@ -61,7 +74,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?MethodCall
     {
-        if (! $this->isNames($node->name, ['bind', 'singleton', 'bindIf', 'singletonIf'])) {
+        if (! $this->isNames($node->name, array_keys(self::PARAMETER_NAMES_BY_METHOD))) {
             return null;
         }
 
@@ -73,13 +86,18 @@ CODE_SAMPLE
             return null;
         }
 
-        if (count($node->getArgs()) < 2) {
+        $arguments = $this->matchArgumentsToParameters($node);
+
+        if ($arguments === null) {
             return null;
         }
 
-        $type = $this->getType($node->getArgs()[0]->value);
-        $classString = $node->getArgs()[0]->value;
-        $concreteNode = $node->getArgs()[1]->value;
+        [$abstractArg, $concreteArg, $sharedArg] = $arguments;
+
+        $classString = $abstractArg->value;
+        $concreteNode = $concreteArg->value;
+
+        $type = $this->getType($classString);
 
         if ($classString instanceof Variable) {
             return null;
@@ -89,11 +107,6 @@ CODE_SAMPLE
             return null;
         }
         $abstractFromConcrete = $this->returnTypeInferer->inferFunctionLike($concreteNode);
-
-        if ($classString instanceof Const_
-        && $this->isName($classString, 'class')) {
-            return null;
-        }
 
         $abstractObjectType = $type->getClassStringObjectType();
 
@@ -109,10 +122,66 @@ CODE_SAMPLE
 
         $concreteNode->returnType = $returnTypeNode;
 
-        $args = $node->getArgs();
+        // the closure takes over the abstract position, so it must not stay named
+        $concreteArg->name = null;
 
-        $node->args = array_splice($args, 1);
+        $args = [$concreteArg];
+
+        if ($sharedArg instanceof Arg) {
+            // shared is no longer the third argument, so it has to be passed by name
+            $sharedArg->name = new Identifier('shared');
+            $args[] = $sharedArg;
+        }
+
+        $node->args = $args;
 
         return $node;
+    }
+
+    /**
+     * Resolves the abstract, concrete and shared arguments, whether they are passed
+     * positionally or by name, in any order.
+     *
+     * @return array{Arg, Arg, Arg|null}|null
+     */
+    private function matchArgumentsToParameters(MethodCall $methodCall): ?array
+    {
+        $parameterNames = null;
+
+        foreach (self::PARAMETER_NAMES_BY_METHOD as $methodName => $names) {
+            if ($this->isName($methodCall->name, $methodName)) {
+                $parameterNames = $names;
+                break;
+            }
+        }
+
+        if ($parameterNames === null) {
+            return null;
+        }
+
+        $matched = array_fill_keys($parameterNames, null);
+
+        foreach ($methodCall->getArgs() as $position => $arg) {
+            if ($arg->unpack) {
+                return null;
+            }
+
+            $name = $arg->name instanceof Identifier
+                ? $arg->name->toString()
+                : ($parameterNames[$position] ?? null);
+
+            // an unknown or duplicated parameter means we cannot reason about the call
+            if ($name === null || ! array_key_exists($name, $matched) || $matched[$name] instanceof Arg) {
+                return null;
+            }
+
+            $matched[$name] = $arg;
+        }
+
+        if (! $matched['abstract'] instanceof Arg || ! $matched['concrete'] instanceof Arg) {
+            return null;
+        }
+
+        return [$matched['abstract'], $matched['concrete'], $matched['shared'] ?? null];
     }
 }

--- a/src/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector.php
+++ b/src/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector.php
@@ -129,7 +129,7 @@ CODE_SAMPLE
 
         if ($sharedArg instanceof Arg) {
             // shared is no longer the third argument, so it has to be passed by name
-            $sharedArg->name = new Identifier('shared');
+            $sharedArg->name ??= new Identifier('shared');
             $args[] = $sharedArg;
         }
 

--- a/src/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector.php
+++ b/src/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector.php
@@ -20,18 +20,6 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 final class ContainerBindConcreteWithClosureOnlyRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
-    /**
-     * bindIf() and singletonIf() are left out on purpose: they pass the abstract
-     * straight to bound(), which uses it as an array offset, so a closure abstract
-     * fatals there.
-     *
-     * @var array<string, list<string>>
-     */
-    private const array PARAMETER_NAMES_BY_METHOD = [
-        'bind' => ['abstract', 'concrete', 'shared'],
-        'singleton' => ['abstract', 'concrete'],
-    ];
-
     public function __construct(
         private readonly ReturnTypeInferer $returnTypeInferer,
         private readonly StaticTypeMapper $staticTypeMapper,
@@ -74,7 +62,10 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?MethodCall
     {
-        if (! $this->isNames($node->name, array_keys(self::PARAMETER_NAMES_BY_METHOD))) {
+        // bindIf() and singletonIf() are left out on purpose: they pass the abstract
+        // straight to bound(), which uses it as an array offset, so a closure
+        // abstract fatals there
+        if (! $this->isNames($node->name, ['bind', 'singleton'])) {
             return null;
         }
 
@@ -86,13 +77,23 @@ CODE_SAMPLE
             return null;
         }
 
-        $arguments = $this->matchArgumentsToParameters($node);
-
-        if ($arguments === null) {
-            return null;
+        foreach ($node->getArgs() as $arg) {
+            // an unpacked argument hides which parameter each value lands in
+            if ($arg->unpack) {
+                return null;
+            }
         }
 
-        [$abstractArg, $concreteArg, $sharedArg] = $arguments;
+        $abstractArg = $node->getArg('abstract', 0);
+        $concreteArg = $node->getArg('concrete', 1);
+        // singleton() has no $shared parameter, and passing one would be fatal
+        $sharedArg = $this->isName($node->name, 'bind')
+            ? $node->getArg('shared', 2)
+            : null;
+
+        if (! $abstractArg instanceof Arg || ! $concreteArg instanceof Arg) {
+            return null;
+        }
 
         $classString = $abstractArg->value;
         $concreteNode = $concreteArg->value;
@@ -136,52 +137,5 @@ CODE_SAMPLE
         $node->args = $args;
 
         return $node;
-    }
-
-    /**
-     * Resolves the abstract, concrete and shared arguments, whether they are passed
-     * positionally or by name, in any order.
-     *
-     * @return array{Arg, Arg, Arg|null}|null
-     */
-    private function matchArgumentsToParameters(MethodCall $methodCall): ?array
-    {
-        $parameterNames = null;
-
-        foreach (self::PARAMETER_NAMES_BY_METHOD as $methodName => $names) {
-            if ($this->isName($methodCall->name, $methodName)) {
-                $parameterNames = $names;
-                break;
-            }
-        }
-
-        if ($parameterNames === null) {
-            return null;
-        }
-
-        $matched = array_fill_keys($parameterNames, null);
-
-        foreach ($methodCall->getArgs() as $position => $arg) {
-            if ($arg->unpack) {
-                return null;
-            }
-
-            $name = $arg->name instanceof Identifier
-                ? $arg->name->toString()
-                : ($parameterNames[$position] ?? null);
-
-            // an unknown or duplicated parameter means we cannot reason about the call
-            if ($name === null || ! array_key_exists($name, $matched) || $matched[$name] instanceof Arg) {
-                return null;
-            }
-
-            $matched[$name] = $arg;
-        }
-
-        if (! $matched['abstract'] instanceof Arg || ! $matched['concrete'] instanceof Arg) {
-            return null;
-        }
-
-        return [$matched['abstract'], $matched['concrete'], $matched['shared'] ?? null];
     }
 }

--- a/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/fixture_named_arguments.php.inc
+++ b/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/fixture_named_arguments.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Fixture;
+
+use Illuminate\Contracts\Container\Container;
+use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeClass;
+use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface;
+
+/** @var Container $app */
+$app->bind(abstract: SomeInterface::class, concrete: function () {
+    return new SomeClass();
+});
+
+$app->singleton(concrete: function () {
+    return new SomeClass();
+}, abstract: SomeInterface::class);
+
+$app->bind(SomeInterface::class, concrete: function () {
+    return new SomeClass();
+});
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Fixture;
+
+use Illuminate\Contracts\Container\Container;
+use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeClass;
+use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface;
+
+/** @var Container $app */
+$app->bind(function (): \RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface {
+    return new SomeClass();
+});
+
+$app->singleton(function (): \RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface {
+    return new SomeClass();
+});
+
+$app->bind(function (): \RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface {
+    return new SomeClass();
+});
+
+?>

--- a/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/fixture_shared_argument.php.inc
+++ b/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/fixture_shared_argument.php.inc
@@ -15,6 +15,12 @@ $app->bind(abstract: SomeInterface::class, concrete: function () {
     return new SomeClass();
 }, shared: true);
 
+// singleton() has no $shared parameter, so the inert extra argument is dropped
+// rather than turned into a fatal `shared:` named argument
+$app->singleton(SomeInterface::class, function () {
+    return new SomeClass();
+}, true);
+
 ?>
 -----
 <?php
@@ -33,5 +39,11 @@ $app->bind(function (): \RectorLaravel\Tests\Rector\MethodCall\ContainerBindConc
 $app->bind(function (): \RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface {
     return new SomeClass();
 }, shared: true);
+
+// singleton() has no $shared parameter, so the inert extra argument is dropped
+// rather than turned into a fatal `shared:` named argument
+$app->singleton(function (): \RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface {
+    return new SomeClass();
+});
 
 ?>

--- a/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/fixture_shared_argument.php.inc
+++ b/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/fixture_shared_argument.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Fixture;
+
+use Illuminate\Contracts\Container\Container;
+use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeClass;
+use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface;
+
+/** @var Container $app */
+$app->bind(SomeInterface::class, function () {
+    return new SomeClass();
+}, true);
+
+$app->bind(abstract: SomeInterface::class, concrete: function () {
+    return new SomeClass();
+}, shared: true);
+
+?>
+-----
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Fixture;
+
+use Illuminate\Contracts\Container\Container;
+use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeClass;
+use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface;
+
+/** @var Container $app */
+$app->bind(function (): \RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface {
+    return new SomeClass();
+}, shared: true);
+
+$app->bind(function (): \RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface {
+    return new SomeClass();
+}, shared: true);
+
+?>

--- a/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/fixture_shared_argument.php.inc
+++ b/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/fixture_shared_argument.php.inc
@@ -15,12 +15,6 @@ $app->bind(abstract: SomeInterface::class, concrete: function () {
     return new SomeClass();
 }, shared: true);
 
-// singleton() has no $shared parameter, so the inert extra argument is dropped
-// rather than turned into a fatal `shared:` named argument
-$app->singleton(SomeInterface::class, function () {
-    return new SomeClass();
-}, true);
-
 ?>
 -----
 <?php
@@ -39,11 +33,5 @@ $app->bind(function (): \RectorLaravel\Tests\Rector\MethodCall\ContainerBindConc
 $app->bind(function (): \RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface {
     return new SomeClass();
 }, shared: true);
-
-// singleton() has no $shared parameter, so the inert extra argument is dropped
-// rather than turned into a fatal `shared:` named argument
-$app->singleton(function (): \RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface {
-    return new SomeClass();
-});
 
 ?>

--- a/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/skip_conditional_binding.php.inc
+++ b/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/skip_conditional_binding.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Fixture;
+
+use Illuminate\Contracts\Container\Container;
+use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeClass;
+use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface;
+
+// bindIf() and singletonIf() forward the abstract to bound(), which uses it as an
+// array offset, so a closure abstract fatals there.
+/** @var Container $app */
+$app->bindIf(SomeInterface::class, function () {
+    return new SomeClass();
+});
+
+$app->singletonIf(SomeInterface::class, function () {
+    return new SomeClass();
+});

--- a/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/skip_spread_arguments.php.inc
+++ b/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/skip_spread_arguments.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Fixture;
+
+use Illuminate\Contracts\Container\Container;
+use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeClass;
+use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRector\Source\SomeInterface;
+
+/** @var Container $app */
+/** @var array $binding */
+$app->bind(...$binding);
+
+$app->bind(SomeInterface::class, ...[function () {
+    return new SomeClass();
+}]);

--- a/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/skip_unmatched_arguments.php.inc
+++ b/tests/Rector/MethodCall/ContainerBindConcreteWithClosureOnlyRector/Fixture/skip_unmatched_arguments.php.inc
@@ -8,8 +8,19 @@ use RectorLaravel\Tests\Rector\MethodCall\ContainerBindConcreteWithClosureOnlyRe
 
 /** @var Container $app */
 /** @var array $binding */
+/** @var array $rest */
 $app->bind(...$binding);
 
 $app->bind(SomeInterface::class, ...[function () {
     return new SomeClass();
 }]);
+
+// dropping the abstract would take the spread with it
+$app->bind(SomeInterface::class, function () {
+    return new SomeClass();
+}, ...$rest);
+
+// singleton() has no $shared parameter, so the extra argument cannot be carried over
+$app->singleton(SomeInterface::class, function () {
+    return new SomeClass();
+}, true);


### PR DESCRIPTION
Fixes #397.

## Named arguments produced fatal code

The rule read the abstract and concrete arguments positionally and then dropped index 0, so a call using named arguments lost `$abstract`:

```diff
 $this->app->singleton(
-    abstract: SomeClass::class,
-    concrete: function (Application $app, array $parameters) {
+    concrete: function (Application $app, array $parameters): SomeClass {
         // ...
     },
 );
```

`Container::singleton($abstract, $concrete = null)` still requires `$abstract`, so the result is an `ArgumentCountError`.

Arguments are now matched to parameters by `Arg::$name` when present and by position otherwise. That also picks up the reversed form, `singleton(concrete: $fn, abstract: SomeClass::class)`, which the old positional read skipped entirely. The closure has its name stripped when it moves into the abstract position, so the output is plain `singleton($fn)`.

## `$shared` was silently dropped

Not part of the issue, but found while writing fixtures for it. `bind(SomeClass::class, $fn, true)` became `bind($fn, true)`. Laravel routes a closure abstract through `bindBasedOnClosureReturnTypes($abstract, $concrete, $shared)`, which overwrites `$concrete` with the closure — so the `true` landed in `$concrete` and was discarded, quietly turning a shared binding into a non-shared one. It is now emitted as `bind($fn, shared: true)`.

## `bindIf()` / `singletonIf()` removed from the rule

Also outside the issue, and the largest behavioral change here. Both forward the abstract to `bound()`, which does `isset($this->bindings[$abstract])`. With a closure abstract that throws `TypeError: Cannot access offset of type Closure in isset or empty` — neither method has the closure handling that `bind()` gained. So every transform this rule made on `bindIf`/`singletonIf` produced code that fatals at boot, named arguments or not. Happy to split this into its own PR if you'd rather review it separately.

## Minor

Removed the `$classString instanceof Const_` guard. `Arg::$value` is always an `Expr` and `Const_` extends `NodeAbstract`, so it could never be true; PHPStan flags it as `instanceof.alwaysFalse` once the argument type is narrowed. No behavior change.

## Tests

New fixtures: `fixture_named_arguments`, `fixture_shared_argument`, `skip_conditional_binding`, `skip_spread_arguments`.

PHPStan (level max), `duster lint`, `rector --dry-run`, and `structarmed` are clean. The full suite goes 673 → 677 tests with the same 1 error / 14 failures that already fail on `main`, all in unrelated rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
