### PR TITLE
Fix/query builder union type reflection

### DIFF
--- a/src/NodeAnalyzer/QueryBuilderAnalyzer.php
+++ b/src/NodeAnalyzer/QueryBuilderAnalyzer.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Rector\Exception\ShouldNotHappenException;
@@ -24,17 +23,17 @@ final readonly class QueryBuilderAnalyzer
 
     protected static function modelType(): ObjectType
     {
-        return new ObjectType('Illuminate\Database\Eloquent\Model');
+        return new ObjectType('Illuminate\\Database\\Eloquent\\Model');
     }
 
     protected static function queryBuilderType(): ObjectType
     {
-        return new ObjectType('Illuminate\Contracts\Database\Query\Builder');
+        return new ObjectType('Illuminate\\Contracts\\Database\\Query\\Builder');
     }
 
     protected static function eloquentQueryBuilderType(): ObjectType
     {
-        return new ObjectType('Illuminate\Database\Eloquent\Builder');
+        return new ObjectType('Illuminate\\Database\\Eloquent\\Builder');
     }
 
     /**
@@ -77,15 +76,12 @@ final readonly class QueryBuilderAnalyzer
             return false;
         }
 
-        /** @phpstan-ignore method.notFound */
-        $reflectionClass = $classType->getClassReflection();
-
-        /** @phpstan-ignore phpstanApi.instanceofAssumption */
-        if (! $reflectionClass instanceof ClassReflection) {
+        $classReflections = $classType->getObjectClassReflections();
+        if (count($classReflections) !== 1) {
             return false;
         }
 
-        return ! $reflectionClass->hasNativeMethod($methodName);
+        return ! $classReflections[0]->hasNativeMethod($methodName);
     }
 
     /**

--- a/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Fixture/skip_parent_native_static_call.php.inc
+++ b/tests/Rector/MethodCall/DateWhereClauseToShorthandRector/Fixture/skip_parent_native_static_call.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace RectorLaravel\Tests\Rector\MethodCall\DateWhereClauseToShorthandRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+final class SkipParentNativeStaticCall extends Model
+{
+    protected function casts(): array
+    {
+        return [
+            ...parent::casts(),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a crash in `QueryBuilderAnalyzer::isProxyCall()` when PHPStan resolves a model static call to a compound type such as `UnionType`.

The issue can be triggered by native model calls such as:

```php
protected function casts(): array
{
    return [
        ...parent::casts(),
    ];
}
```

With `DateWhereClauseToShorthandRector` enabled, Rector may fail with:

```text
Call to undefined method PHPStan\Type\UnionType::getClassReflection()
```

## Cause

`QueryBuilderAnalyzer` assumed that any type for which `isObject()` does not return `no` supports:

```php
$classType->getClassReflection();
```

That is not true for compound PHPStan types such as `UnionType`.

## Fix

Use PHPStan's common `Type::getObjectClassReflections()` API instead.

The analyzer now proceeds only when exactly one class reflection can be resolved; otherwise it safely returns `false`.

## Tests

Added a regression fixture using `parent::casts()` to ensure native parent model calls no longer cause Rector to crash.
